### PR TITLE
Fix header formatting and dangling link

### DIFF
--- a/language-reference-guide/docs/symbols/dot.md
+++ b/language-reference-guide/docs/symbols/dot.md
@@ -5,13 +5,13 @@
 <h1 class="heading"><span class="name">Dot</span> <span class="command">.</span></h1>
 
 
-## Dot can be used as a Dyadic operator with Dyadic
-      operands
+## Dot can be used as a Dyadic operator with Dyadic operands
 
 ## Operator Dot means
 
 
 [Inner Product](../primitive-operators/inner-product.md)
+
 ```apl
       1 2 3 +.× 4 5 6
 32
@@ -25,8 +25,7 @@
 15 22
 ```
 
-## Used with Jot in place of the left operand Jot
-      Dot means
+## Used with Jot in place of the left operand Jot Dot means
 
 
 [Outer Product](../primitive-operators/outer-product.md)
@@ -40,9 +39,10 @@
 ```
 
 
-N.B. Dot is also used as a decimal point and as a name separator in namespace reference syntax.
+!!!note
+    Dot is also used as a decimal point and as a name separator in namespace reference syntax.
 
 
-[Language Elements](./language-elements.md)
+[Language Elements](language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/language-elements.md
+++ b/language-reference-guide/docs/symbols/language-elements.md
@@ -211,7 +211,7 @@
 - [Special Syntax](../special-symbols)
 - [Variables](../../../programming-reference-guide/introduction/arrays/arrays)
 - [Namespaces](../../../programming-reference-guide/introduction/namespaces/namespaces)
-- [Defined Fns & Ops](../defined-functions-and-operators/defined-functions-and-operators)
+- [Defined Fns & Ops](../../../programming-reference-guide/defined-functions-and-operators/introduction)
 - [Dynamic Fns & Ops](../../../programming-reference-guide/defined-functions-and-operators/dfns-and-dops/dynamic-functions-and-operators)
 - [MultiThreading](../../../programming-reference-guide/threads/multithreading-overview)
 - [Object Oriented Programming](../../../programming-reference-guide/object-oriented-programming/introducing-classes/introducing-classes)


### PR DESCRIPTION
- Header formatting for the 'dot' disambiguation page.
- Dangling link on Language Elements page.