### PR TITLE
The ToC entry for "Restrictions and Limitations" lacked an "and".

### DIFF
--- a/interface-guide/docs/dde/restrictions-limitations.md
+++ b/interface-guide/docs/dde/restrictions-limitations.md
@@ -1,4 +1,4 @@
-<h1 class="heading"><span class="name">Restrictions & Limitations</span></h1>
+<h1 class="heading"><span class="name">Restrictions and Limitations</span></h1>
 
 Although shared variables have been implemented as closely to the APL standard as is possible, certain restrictions are imposed by the nature of DDE itself.
 

--- a/interface-guide/mkdocs.yml
+++ b/interface-guide/mkdocs.yml
@@ -162,4 +162,4 @@ nav:
       - Excel as the Server: dde/example-excel-as-the-server.md
       - Excel as the Client: dde/example-excel-as-the-client.md
       - APL as Compute Server for Excel: dde/example-apl-as-compute-server-for-excel.md
-      - Restrictions Limitations: dde/restrictions-limitations.md
+      - Restrictions and Limitations: dde/restrictions-limitations.md


### PR DESCRIPTION
The heading for "Restrictions and Limitations" used an ampersand; bad habit. Changed to "and", and mirrored in the ToC.