### PR TITLE
macOS, not OS X

### DIFF
--- a/windows-installation-and-configuration-guide/docs/configuration-parameters/cfext.md
+++ b/windows-installation-and-configuration-guide/docs/configuration-parameters/cfext.md
@@ -4,7 +4,7 @@ This parameter specifies component file filename extensions.
 
 CFEXT is a string that specifies a colon-separated list of one or more extensions, including any period (".") which separates the extension from its basename.
 
-If undefined, CFEXT defaults to `.dcf:` on Windows and OS X, and `.dcf:.DCF:` on all other platforms.
+If undefined, CFEXT defaults to `.dcf:` on Windows and macOS, and `.dcf:.DCF:` on all other platforms.
 
 In the Windows case, this means that `'myfile'⎕FTIE 0` will search first for a file named `myfile.dcf` , and then for a file named `myfile` (with no extension). As file names are not case-sensitive under Windows, this will find `myfile.DCF` or `MyFile.Dcf` and so forth. If none are found with this extension, it will load `myfile` , `MyFile` , `MYFILE` etc.
 

--- a/windows-installation-and-configuration-guide/docs/configuration-parameters/wsext.md
+++ b/windows-installation-and-configuration-guide/docs/configuration-parameters/wsext.md
@@ -4,7 +4,7 @@ This parameter specifies workspace filename extensions. It complements the **WSP
 
 WSEXT is a string that specifies a colon-separated list of one or more extensions, including any period (".") which separates the extension from its basename.
 
-If undefined, WSEXT defaults to `.dws:` on Windows and OS X, and `:.dws:.DWS` on all other platforms.
+If undefined, WSEXT defaults to `.dws:` on Windows and macOS, and `:.dws:.DWS` on all other platforms.
 
 In the Windows case, this means that `)LOAD myws` will search first for a file named `myws.dws` , and then for a file named `myws` (with no extension). As file names are not case-sensitive under Windows, this will find `myws.DWS` or `MyWs.Dws` and so forth. If none are found with this extension, it will load `myws` , `MyWs` , `MYWS` etc.
 


### PR DESCRIPTION
Fix lingering instances of "OS X"

```
grep -rlE "OS ?X" --include="*.md" .

windows-installation-and-configuration-guide/docs/configuration-parameters/cfext.md
windows-installation-and-configuration-guide/docs/configuration-parameters/wsext.md
```