### PR TITLE
Link resolution as a post-conversion process 

### DIFF
--- a/tools/mkdocs2chm/assets/main.css
+++ b/tools/mkdocs2chm/assets/main.css
@@ -74,7 +74,12 @@ th, td {
     font-family: APL;
 }
 
-/* Compress lists a bit vertcially */
+.right {
+    text-align: right;
+    color: black;
+}
+
+/* Compress lists a bit vertically */
 li {
     margin-bottom: 0px !important;
 }


### PR DESCRIPTION
Problem: Previously, links were resolved in the Markdown before conversion to HTML. This misses any link written using HTML syntax. 

Solution: resolve links in the HTML post-conversion.