### PR TITLE
Remove bad chars in link anchors

### DIFF
--- a/language-reference-guide/docs/system-commands/save.md
+++ b/language-reference-guide/docs/system-commands/save.md
@@ -7,7 +7,7 @@
 
 
 
-This command compacts (see ["Workspace Available: "](../system-functions/wa.md) for details) and saves the active workspace.
+This command compacts (see [Workspace Available](../system-functions/wa.md) for details) and saves the active workspace.
 
 
 If specified, `ws` is a full or relative path name to the file in which the workspace will be written. If `ws` is omitted, it defaults to `⎕WSID`. Unless the path specified by `ws` or `⎕WSID` is a full pathname, it is taken to be relative to the current working directory which may be obtained by the expression: `⊃1 ⎕NPARTS ''`.

--- a/language-reference-guide/docs/system-commands/sh.md
+++ b/language-reference-guide/docs/system-commands/sh.md
@@ -7,7 +7,7 @@
 
 
 
-This command allows WINDOWS or UNIX shell commands to be given from APL.  `)SH` is a synonym of `)CMD`. Either command may be given in either environment (Windows or UNIX) with exactly the same effect.  `)SH` is probably more natural for the UNIX user. This section describes the behaviour of `)SH` and `)CMD` under UNIX. See ["Windows Command Processor: "](cmd.md) for a discussion of their behaviour under Windows.
+This command allows WINDOWS or UNIX shell commands to be given from APL.  `)SH` is a synonym of `)CMD`. Either command may be given in either environment (Windows or UNIX) with exactly the same effect.  `)SH` is probably more natural for the UNIX user. This section describes the behaviour of `)SH` and `)CMD` under UNIX. See [Windows Command Processor](cmd.md) for a discussion of their behaviour under Windows.
 
 
 

--- a/language-reference-guide/docs/system-functions/execute-unix-command.md
+++ b/language-reference-guide/docs/system-functions/execute-unix-command.md
@@ -7,7 +7,7 @@
 
 
 
-`⎕SH` executes a UNIX shell or a Windows Command Processor.  `⎕SH` is a synonym of `⎕CMD`.  Either function may be used in either environment (UNIX or Windows) with exactly the same effect.  `⎕SH` is probably more natural for the UNIX user.  This section describes the behaviour of `⎕SH` and `⎕CMD` under UNIX.  See ["Execute Windows Command: "](execute-windows-command.md) for a discussion of the behaviour of these system functions under Windows.
+`⎕SH` executes a UNIX shell or a Windows Command Processor.  `⎕SH` is a synonym of `⎕CMD`.  Either function may be used in either environment (UNIX or Windows) with exactly the same effect.  `⎕SH` is probably more natural for the UNIX user.  This section describes the behaviour of `⎕SH` and `⎕CMD` under UNIX.  See [Execute Windows Command](execute-windows-command.md) for a discussion of the behaviour of these system functions under Windows.
 
 
 The system commands [`)SH`](../system-commands/sh.md) and [`)CMD`](../system-commands/cmd.md) provide similar facilities. For further information, see [Execute (UNIX) Command: ](../system-commands/sh.md) and [Example](../system-commands/cmd.md).

--- a/language-reference-guide/docs/system-functions/execute-windows-command.md
+++ b/language-reference-guide/docs/system-functions/execute-windows-command.md
@@ -7,7 +7,7 @@
 
 
 
-`⎕CMD` executes the Windows Command Processor or UNIX shell or starts another Windows application program.  `⎕CMD` is a synonym of `⎕SH`.  Either system function may be used in either environment (Windows or UNIX) with exactly the same effect.  `⎕CMD` is probably more natural for the Windows user.  This section describes the behaviour of `⎕CMD` and `⎕SH` under Windows. See ["Execute (UNIX) Command: "](execute-unix-command.md) for a discussion of the behaviour of these system functions under UNIX.
+`⎕CMD` executes the Windows Command Processor or UNIX shell or starts another Windows application program.  `⎕CMD` is a synonym of `⎕SH`.  Either system function may be used in either environment (Windows or UNIX) with exactly the same effect.  `⎕CMD` is probably more natural for the Windows user.  This section describes the behaviour of `⎕CMD` and `⎕SH` under Windows. See [Execute (UNIX) Command](execute-unix-command.md) for a discussion of the behaviour of these system functions under UNIX.
 
 
 The system commands [`)SH`](../system-commands/sh.md) and [`)CMD`](../system-commands/cmd.md) provide similar facilities. For further information, see [Execute (UNIX) Command: ](../system-commands/sh.md) and [Example](../system-commands/cmd.md).

--- a/language-reference-guide/docs/system-functions/nq.md
+++ b/language-reference-guide/docs/system-functions/nq.md
@@ -20,7 +20,7 @@ While APL is executing, events occur "naturally" as a result of user action or o
 If the left argument `X` is omitted or is 0, `⎕NQ` adds the event specified by `Y` to the bottom of the event queue. The event will subsequently be processed by `⎕DQ` when it reaches the top of the queue.
 
 
-If `X` is 1, the event is actioned **immediately** by `⎕NQ` itself and is processed in exactly the same way as it would be processed by `⎕DQ`.  For example, if the event has a callback function attached, `⎕NQ` will invoke it directly. See ["Dequeue Events: "](dq.md) for further details. If the event generates any subsidiary events (for example, a KeyPress might generate a GotFocus), the subsidiary events are added to the event queue rather than being executed immediately.
+If `X` is 1, the event is actioned **immediately** by `⎕NQ` itself and is processed in exactly the same way as it would be processed by `⎕DQ`.  For example, if the event has a callback function attached, `⎕NQ` will invoke it directly. See [Dequeue Events](dq.md) for further details. If the event generates any subsidiary events (for example, a KeyPress might generate a GotFocus), the subsidiary events are added to the event queue rather than being executed immediately.
 
 
 Note that it is not possible for one thread to use `1 ⎕NQ` to send an event to another thread.

--- a/language-reference-guide/docs/system-functions/start-unix-auxiliary-processor.md
+++ b/language-reference-guide/docs/system-functions/start-unix-auxiliary-processor.md
@@ -7,7 +7,7 @@
 
 
 
-Used dyadically, `⎕SH` starts an Auxiliary Processor. The effect, as far as the APL user is concerned, is identical under both Windows and UNIX although there are differences in the method of implementation. `⎕SH` is a synonym of `⎕CMD` Either function may be used in either environment (UNIX or Windows) with exactly the same effect. This section describes the behaviour of `⎕SH` and `⎕CMD` under UNIX. See ["Start Windows Auxiliary Processor: "](start-windows-auxiliary-processor.md) for a discussion of the behaviour of these system functions under Windows.
+Used dyadically, `⎕SH` starts an Auxiliary Processor. The effect, as far as the APL user is concerned, is identical under both Windows and UNIX although there are differences in the method of implementation. `⎕SH` is a synonym of `⎕CMD` Either function may be used in either environment (UNIX or Windows) with exactly the same effect. This section describes the behaviour of `⎕SH` and `⎕CMD` under UNIX. See [Start Windows Auxiliary Processor](start-windows-auxiliary-processor.md) for a discussion of the behaviour of these system functions under Windows.
 
 
 Although it is still possible for users to create their own APs, Dyalog strongly recommends creating shared libraries/DLLs instead.

--- a/language-reference-guide/docs/system-functions/system-functions-categorised/component-files/fchk.md
+++ b/language-reference-guide/docs/system-functions/system-functions-categorised/component-files/fchk.md
@@ -122,7 +122,7 @@ Following a *repair* of the file, the result indicates those components that cou
 
 
 
-Repair can recover only check-summed components from the file, that is, only those components that were written with the checksum option enabled (see ["File Properties: "](fprops.md)).
+Repair can recover only check-summed components from the file, that is, only those components that were written with the checksum option enabled (see [File Properties](fprops.md)).
 
 
 Following an operating system crash, repair may result in one or more individual components being rolled back to a previous version or not recovered at all, unless Journaling levels 2 or 3 were also set when these components were written.

--- a/language-reference-guide/docs/system-functions/system-functions-categorised/component-files/freplace.md
+++ b/language-reference-guide/docs/system-functions/system-functions-categorised/component-files/freplace.md
@@ -12,7 +12,7 @@
 `Y` must be a simple 2 or 3 element integer vector containing the file tie number, the component number, and an optional passnumber.  If the passnumber is omitted it is assumed to be zero.  The component number specified must lie within the file's component number limits.
 
 
-`X` is any array (including, for example, the `⎕OR` of a namespace), and overwrites the value of the specified component.  The component information (see ["File Read Component Information: "](frdci.md)) is also updated.
+`X` is any array (including, for example, the `⎕OR` of a namespace), and overwrites the value of the specified component.  The component information (see [File Read Component Information](frdci.md)) is also updated.
 
 
 The shy result of `⎕FREPLACE` is the file index (component number of replaced record).

--- a/language-reference-guide/docs/system-functions/system-functions-categorised/gui-and-com-support/nq.md
+++ b/language-reference-guide/docs/system-functions/system-functions-categorised/gui-and-com-support/nq.md
@@ -20,7 +20,7 @@ While APL is executing, events occur "naturally" as a result of user action or o
 If the left argument `X` is omitted or is 0, `⎕NQ` adds the event specified by `Y` to the bottom of the event queue. The event will subsequently be processed by `⎕DQ` when it reaches the top of the queue.
 
 
-If `X` is 1, the event is actioned **immediately** by `⎕NQ` itself and is processed in exactly the same way as it would be processed by `⎕DQ`.  For example, if the event has a callback function attached, `⎕NQ` will invoke it directly. See ["Dequeue Events: "](dq.md) for further details. If the event generates any subsidiary events (for example, a KeyPress might generate a GotFocus), the subsidiary events are added to the event queue rather than being executed immediately.
+If `X` is 1, the event is actioned **immediately** by `⎕NQ` itself and is processed in exactly the same way as it would be processed by `⎕DQ`.  For example, if the event has a callback function attached, `⎕NQ` will invoke it directly. See [Dequeue Events](dq.md) for further details. If the event generates any subsidiary events (for example, a KeyPress might generate a GotFocus), the subsidiary events are added to the event queue rather than being executed immediately.
 
 
 Note that it is not possible for one thread to use `1 ⎕NQ` to send an event to another thread.

--- a/language-reference-guide/docs/system-functions/system-functions-categorised/manipulating-functions-and-operators/refs.md
+++ b/language-reference-guide/docs/system-functions/system-functions-categorised/manipulating-functions-and-operators/refs.md
@@ -7,7 +7,7 @@
 
 
 
-`Y` must be a simple character scalar or vector, identifying the name of a function or operator, or the object representation form of a function or operator (see ["Object Representation: "](or.md)).  `R` is a simple character matrix, with one name per row, of identified names in the function or operator in `Y` excluding distinguished names of system constants, variables or functions.
+`Y` must be a simple character scalar or vector, identifying the name of a function or operator, or the object representation form of a function or operator (see [Object Representation](or.md)).  `R` is a simple character matrix, with one name per row, of identified names in the function or operator in `Y` excluding distinguished names of system constants, variables or functions.
 
 
 <h2 class="example">Example</h2>

--- a/language-reference-guide/docs/system-functions/system-functions-categorised/manipulating-functions-and-operators/set-monitor.md
+++ b/language-reference-guide/docs/system-functions/system-functions-categorised/manipulating-functions-and-operators/set-monitor.md
@@ -22,7 +22,7 @@ Note that `⎕MONITOR` does not apply to  dfns or dops.
 `R` is a vector of numbers on which a monitor has been placed in ascending order.  The result is suppressed unless it is explicitly used or assigned. `R` will be empty for dfns and dops.
 
 
-The effect of `⎕MONITOR` is to accumulate timing statistics for the lines for which the monitor has been set.  See ["Query Monitor: "](query-monitor.md) for details.
+The effect of `⎕MONITOR` is to accumulate timing statistics for the lines for which the monitor has been set.  See [Query Monitor](query-monitor.md) for details.
 
 
 

--- a/language-reference-guide/docs/system-functions/system-functions-categorised/manipulating-functions-and-operators/set-stop.md
+++ b/language-reference-guide/docs/system-functions/system-functions-categorised/manipulating-functions-and-operators/set-stop.md
@@ -45,7 +45,7 @@ Attempts to set stop controls in a locked function or operator are ignored.
 ```
 
 
-The effect of `⎕STOP` when a function or operator is invoked is to suspend execution at the beginning of any line in the function or operator on which a stop control is placed immediately before that line is executed, and immediately before exiting from the function or operator if a stop control of 0 is set.  Execution may be resumed by a branch expression.  A stop control interrupt (1001) may also be trapped - see ["Trap Event: "](trap.md).
+The effect of `⎕STOP` when a function or operator is invoked is to suspend execution at the beginning of any line in the function or operator on which a stop control is placed immediately before that line is executed, and immediately before exiting from the function or operator if a stop control of 0 is set.  Execution may be resumed by a branch expression.  A stop control interrupt (1001) may also be trapped - see [Trap Event](trap.md).
 
 <h2 class="example">Example</h2>
 ```apl

--- a/language-reference-guide/docs/system-functions/system-functions-categorised/native-files/nreplace.md
+++ b/language-reference-guide/docs/system-functions/system-functions-categorised/native-files/nreplace.md
@@ -23,7 +23,7 @@
 
 
 
-See ["Native File Read: "](nread.md) for a list of valid conversion codes.
+See [Native File Read](nread.md) for a list of valid conversion codes.
 
 
 The shy result is the location of the internal file pointer which will be pointing to the end of the newly written data. Used, for example, in:

--- a/language-reference-guide/docs/system-functions/system-functions-categorised/native-files/nuntie.md
+++ b/language-reference-guide/docs/system-functions/system-functions-categorised/native-files/nuntie.md
@@ -7,7 +7,7 @@
 
 
 
-This closes one or more native files.  `Y` is a scalar or vector of negative integer tie numbers.  The files associated with elements of `Y` are closed.  Native file untie with a zero length argument (`⎕NUNTIE ⍬`) flushes all file buffers to disk - see ["File Untie: "](funtie.md) for more explanation.
+This closes one or more native files.  `Y` is a scalar or vector of negative integer tie numbers.  The files associated with elements of `Y` are closed.  Native file untie with a zero length argument (`⎕NUNTIE ⍬`) flushes all file buffers to disk - see [File Untie](funtie.md) for more explanation.
 
 
 The shy result of `⎕NUNTIE` is a vector of tie numbers of the files **actually untied**.

--- a/language-reference-guide/docs/system-functions/system-functions-categorised/shared-variables/svr.md
+++ b/language-reference-guide/docs/system-functions/system-functions-categorised/shared-variables/svr.md
@@ -16,7 +16,7 @@ This system function terminates communication via one or more shared variables, 
 The result `R` is vector whose length corresponds to the number of names specified by Y, indicating the level of sharing of each variable after retraction.
 
 
-See ["Shared Variable State: "](svs.md) for further information on the possible states of a shared variable.
+See [Shared Variable State](svs.md) for further information on the possible states of a shared variable.
 
 
 

--- a/language-reference-guide/docs/system-functions/system-functions-categorised/stack-and-workspace/stack-and-workspace-information/nl.md
+++ b/language-reference-guide/docs/system-functions/system-functions-categorised/stack-and-workspace/stack-and-workspace-information/nl.md
@@ -6,7 +6,7 @@
 
 
 
-`Y` must be a simple numeric scalar or vector containing one or more of the values for name-class.  See also ["Name Classification: "](nc.md).
+`Y` must be a simple numeric scalar or vector containing one or more of the values for name-class.  See also [Name Classification](nc.md).
 
 
 `X` is optional. If present, it must be a simple character scalar or vector. `R` is a list of the names of active objects whose name-class is included in `Y` in standard sorted order.

--- a/language-reference-guide/docs/system-functions/system-functions-categorised/stack-and-workspace/stack-and-workspace-information/si.md
+++ b/language-reference-guide/docs/system-functions/system-functions-categorised/stack-and-workspace/stack-and-workspace-information/si.md
@@ -57,6 +57,6 @@ To check if the function `∆N` is pendent:
 ```
 
 
-See also ["Extended State Indicator: "](xsi.md).
+See also [Extended State Indicator](xsi.md).
 
 

--- a/language-reference-guide/docs/system-functions/system-functions-categorised/stack-and-workspace/stack-and-workspace-information/xsi.md
+++ b/language-reference-guide/docs/system-functions/system-functions-categorised/stack-and-workspace/stack-and-workspace-information/xsi.md
@@ -34,7 +34,7 @@ x.foo[1]
 This can be used for example, to edit all functions in the stack, irrespective of the current namespace by typing:    `⎕ed ⎕xsi`
 
 
-See also ["State Indicator: "](si.md).
+See also [State Indicator](si.md).
 
 
 

--- a/language-reference-guide/docs/system-functions/system-functions-categorised/system-settings/state-settings/dct.md
+++ b/language-reference-guide/docs/system-functions/system-functions-categorised/system-settings/state-settings/dct.md
@@ -17,7 +17,7 @@ The value of `⎕DCT` determines the precision with which two numbers are judged
 `⎕CT` and `⎕DCT` are implicit arguments of the monadic primitive functions Ceiling (`⌈`), Floor (`⌊`) and Unique (`∪`), and of the dyadic functions Equal (`=`), Excluding (`~`), Find (`⍷`), Greater (`>`), Greater or Equal (`≥`), Greatest Common Divisor (`∨`), Index of (`⍳`), Intersection (`∩`), Less (`<`), Less or Equal (`≤`), Lowest Common Multiple (`∧`), Match (`≡`), Membership (`∊`), Not Match (`≢`), Not Equal (`≠`), Residue (`|`) and Union (`∪`), as well as `⎕FMT` O-format.
 
 
-For further information, see ["Comparison Tolerance: "](ct.md).
+For further information, see [Comparison Tolerance](ct.md).
 
 <h2 class="example">Examples</h2>
 ```apl

--- a/language-reference-guide/docs/system-functions/system-functions-categorised/tools-and-access-to-external-facilities/tools-and-access-to-external-utilities/execute-unix-command.md
+++ b/language-reference-guide/docs/system-functions/system-functions-categorised/tools-and-access-to-external-facilities/tools-and-access-to-external-utilities/execute-unix-command.md
@@ -7,7 +7,7 @@
 
 
 
-`⎕SH` executes a UNIX shell or a Windows Command Processor.  `⎕SH` is a synonym of `⎕CMD`.  Either function may be used in either environment (UNIX or Windows) with exactly the same effect.  `⎕SH` is probably more natural for the UNIX user.  This section describes the behaviour of `⎕SH` and `⎕CMD` under UNIX.  See ["Execute Windows Command: "](execute-windows-command.md) for a discussion of the behaviour of these system functions under Windows.
+`⎕SH` executes a UNIX shell or a Windows Command Processor.  `⎕SH` is a synonym of `⎕CMD`.  Either function may be used in either environment (UNIX or Windows) with exactly the same effect.  `⎕SH` is probably more natural for the UNIX user.  This section describes the behaviour of `⎕SH` and `⎕CMD` under UNIX.  See [Execute Windows Command](execute-windows-command.md) for a discussion of the behaviour of these system functions under Windows.
 
 
 The system commands [`)SH`](../../../../system-commands/sh.md) and [`)CMD`](../../../../system-commands/cmd.md) provide similar facilities. For further information, see [Execute (UNIX) Command: ](../../../../system-commands/sh.md) and [Example](../../../../system-commands/cmd.md).

--- a/language-reference-guide/docs/system-functions/system-functions-categorised/tools-and-access-to-external-facilities/tools-and-access-to-external-utilities/execute-windows-command.md
+++ b/language-reference-guide/docs/system-functions/system-functions-categorised/tools-and-access-to-external-facilities/tools-and-access-to-external-utilities/execute-windows-command.md
@@ -7,7 +7,7 @@
 
 
 
-`⎕CMD` executes the Windows Command Processor or UNIX shell or starts another Windows application program.  `⎕CMD` is a synonym of `⎕SH`.  Either system function may be used in either environment (Windows or UNIX) with exactly the same effect.  `⎕CMD` is probably more natural for the Windows user.  This section describes the behaviour of `⎕CMD` and `⎕SH` under Windows. See ["Execute (UNIX) Command: "](execute-unix-command.md) for a discussion of the behaviour of these system functions under UNIX.
+`⎕CMD` executes the Windows Command Processor or UNIX shell or starts another Windows application program.  `⎕CMD` is a synonym of `⎕SH`.  Either system function may be used in either environment (Windows or UNIX) with exactly the same effect.  `⎕CMD` is probably more natural for the Windows user.  This section describes the behaviour of `⎕CMD` and `⎕SH` under Windows. See [Execute (UNIX) Command](execute-unix-command.md) for a discussion of the behaviour of these system functions under UNIX.
 
 
 The system commands [`)SH`](../../../../system-commands/sh.md) and [`)CMD`](../../../../system-commands/cmd.md) provide similar facilities. For further information, see [Execute (UNIX) Command: ](../../../../system-commands/sh.md) and [Example](../../../../system-commands/cmd.md).

--- a/language-reference-guide/docs/system-functions/system-functions-categorised/tools-and-access-to-external-facilities/tools-and-access-to-external-utilities/start-unix-auxiliary-processor.md
+++ b/language-reference-guide/docs/system-functions/system-functions-categorised/tools-and-access-to-external-facilities/tools-and-access-to-external-utilities/start-unix-auxiliary-processor.md
@@ -7,7 +7,7 @@
 
 
 
-Used dyadically, `⎕SH` starts an Auxiliary Processor. The effect, as far as the APL user is concerned, is identical under both Windows and UNIX although there are differences in the method of implementation. `⎕SH` is a synonym of `⎕CMD` Either function may be used in either environment (UNIX or Windows) with exactly the same effect. This section describes the behaviour of `⎕SH` and `⎕CMD` under UNIX. See ["Start Windows Auxiliary Processor: "](start-windows-auxiliary-processor.md) for a discussion of the behaviour of these system functions under Windows.
+Used dyadically, `⎕SH` starts an Auxiliary Processor. The effect, as far as the APL user is concerned, is identical under both Windows and UNIX although there are differences in the method of implementation. `⎕SH` is a synonym of `⎕CMD` Either function may be used in either environment (UNIX or Windows) with exactly the same effect. This section describes the behaviour of `⎕SH` and `⎕CMD` under UNIX. See [Start Windows Auxiliary Processor](start-windows-auxiliary-processor.md) for a discussion of the behaviour of these system functions under Windows.
 
 
 Although it is still possible for users to create their own APs, Dyalog strongly recommends creating shared libraries/DLLs instead.


### PR DESCRIPTION
A handful of link anchors were double-quoted and had a lingering colon-space at the end.

References #71 