### PR TITLE
JSON error message has been changed

### DIFF
--- a/language-reference-guide/docs/system-functions/json.md
+++ b/language-reference-guide/docs/system-functions/json.md
@@ -295,7 +295,7 @@ See also: [JSON_Name_Mangling](json-name-manglling.md).
     └─┴──────┴───┴─┘
 
           1 (⎕JSON⍠ 'Format' 'M')M
-    DOMAIN ERROR: Value does not match the specified type in row 3
+    DOMAIN ERROR: JSON export: value does not match the specified type in row 3 (⎕IO=1)
           1(⎕JSON⍠'Format' 'M')M
             ∧
     ```


### PR DESCRIPTION
Fix error example in JSON export section to show new-format error msg.

References #90 Mantis 21010