### PR TITLE
Underscores, not dashes in PDF asset names

### DIFF
--- a/pdf/config.json
+++ b/pdf/config.json
@@ -3,47 +3,47 @@
         "language-reference-guide": {
             "title": "Dyalog APL Language",
             "subtitle": "Reference Guide",
-            "filename": "Dyalog-APL-Language-Reference-Guide.pdf"
+            "filename": "Dyalog_APL_Language_Reference_Guide.pdf"
         },
         "dotnet-interface": {
             "title": "Dyalog for Microsoft Windows",
             "subtitle": ".NET Framework Interface Guide",
-            "filename": "Dyalog-for-Microsoft-Windows-.NET-Framework-Interface-Guide.pdf"
+            "filename": "Dyalog_for_Microsoft_Windows_.NET_Framework_Interface_Guide.pdf"
         },
         "interface-guide": {
             "title": "Dyalog for Microsoft Windows",
             "subtitle": "Interfaces Guide",
-            "filename": "Dyalog-for-Microsoft-Windows-Interface-Guide.pdf"
+            "filename": "Dyalog_for_Microsoft_Windows_Interface_Guide.pdf"
         },
         "object-reference": {
             "title": "Dyalog for Microsoft Windows",
             "subtitle": "Object Reference Guide",
-            "filename": "Dyalog-for-Microsoft-Windows-Object-Reference-Guide.pdf"
+            "filename": "Dyalog_for_Microsoft_Windows_Object_Reference_Guide.pdf"
         },
         "programming-reference-guide": {
             "title": "Dyalog Programming",
             "subtitle": "Reference Guide",
-            "filename": "Dyalog-Programming-Reference-Guide.pdf"
+            "filename": "Dyalog_Programming_Reference_Guide.pdf"
         },
         "unix-installation-and-configuration-guide": {
             "title": "Dyalog for UNIX",
             "subtitle": "Installation and Configuration Guide",
-            "filename": "Dyalog-for-UNIX-Installation-and-Configuration-Guide.pdf"
+            "filename": "Dyalog_for_UNIX_Installation_and_Configuration_Guide.pdf"
         },
         "unix-user-guide": {
             "title": "Dyalog for UNIX",
             "subtitle": "UI Guide",
-            "filename": "Dyalog-for-UNIX-UI-Guide.pdf"
+            "filename": "Dyalog_for_UNIX_UI_Guide.pdf"
         },
         "windows-installation-and-configuration-guide": {
             "title": "Dyalog for Microsoft Windows",
             "subtitle": "Installation and Configuration Guide",
-            "filename": "Dyalog-for-Microsoft-Windows-Installation-and-Configuration-Guide.pdf"
+            "filename": "Dyalog_for_Microsoft_Windows_Installation_and_Configuration_Guide.pdf"
         },
         "windows-ui-guide": {
             "title": "Dyalog for Microsoft Windows",
             "subtitle": "UI Guide",
-            "filename": "Dyalog-for-Microsoft-Windows-UI-Guide.pdf"
+            "filename": "Dyalog_for_Microsoft_Windows_UI_Guide.pdf"
         }
     },
     "settings": {


### PR DESCRIPTION
References #139