### PR TITLE
Change PDF TOC logic to treat top-level files as chapters

### DIFF
--- a/language-reference-guide/docs/pcre-specifications/pcre-regular-expression-details.md
+++ b/language-reference-guide/docs/pcre-specifications/pcre-regular-expression-details.md
@@ -1,6 +1,6 @@
 <h1 class="heading"><span class="name">PCRE Regular Expression Details</span></h1>
 
-```other
+<pre class="manpage">
 PCREPATTERN(3)             Library Functions Manual             PCREPATTERN(3)
 
 NAME
@@ -2897,4 +2897,4 @@ REVISION
 
        Last updated: 08 January 2014
        Copyright (c) 1997-2014 University of Cambridge.
-```
+</pre>

--- a/language-reference-guide/docs/pcre-specifications/pcre-regular-expression-syntax-summary.md
+++ b/language-reference-guide/docs/pcre-specifications/pcre-regular-expression-syntax-summary.md
@@ -1,7 +1,8 @@
 <h1 class="heading"><span class="name">PCRE Regular Expression Syntax Summary</span></h1>
 
 The following is a summary of search pattern syntax.
-```other
+
+<pre class="manpage">
 PCRESYNTAX(3)              Library Functions Manual              PCRESYNTAX(3)
 
 NAME
@@ -377,4 +378,4 @@ REVISION
 
        Last updated: 08 January 2014
        Copyright (c) 1997-2014 University of Cambridge.
-```
+</pre>

--- a/pdf/assets/styles/codeblocks.css
+++ b/pdf/assets/styles/codeblocks.css
@@ -1,7 +1,8 @@
 /*------- Fences and code highlights -------*/
 code {
-	word-break: normal !important;
+    word-break: normal !important;
     overflow-wrap: break-word !important;
+    font-size: 9pt;
 }
 
 .text {
@@ -12,79 +13,378 @@ code {
     font-family: APL !important;
     /*line-height: 1.2em !important;*/
     color: #9400d3;
-    font-size: 10pt;
+    font-size: 9pt;
 }
 
-code, .command {
+code,
+.command {
     font-family: APL;
 }
 
+pre.manpage {
+    font-family: monospace;
+    font-size: 8pt;
+    line-height: 1.15;
+    white-space: pre-wrap;
+    padding: 0.5em;
+    margin: 0.5em 0;
+    max-width: 100%;
+    overflow-x: visible;
+    tab-size: 4;
+}
+
 /* Code highlighter: https://raw.githubusercontent.com/richleland/pygments-css/master/default.css */
-.highlight .hll { background-color: #ffffcc }
-.highlight  { background: #f8f8f8; }
-.highlight .c { color: #408080; font-style: italic } /* Comment */
-.highlight .k { color: #008000; font-weight: bold } /* Keyword */
-.highlight .o { color: #666666 } /* Operator */
-.highlight .ch { color: #408080; font-style: italic } /* Comment.Hashbang */
-.highlight .cm { color: #408080; font-style: italic } /* Comment.Multiline */
-.highlight .cp { color: #BC7A00 } /* Comment.Preproc */
-.highlight .cpf { color: #408080; font-style: italic } /* Comment.PreprocFile */
-.highlight .c1 { color: #408080; font-style: italic } /* Comment.Single */
-.highlight .cs { color: #408080; font-style: italic } /* Comment.Special */
-.highlight .gd { color: #A00000 } /* Generic.Deleted */
-.highlight .ge { font-style: italic } /* Generic.Emph */
-.highlight .gr { color: #FF0000 } /* Generic.Error */
-.highlight .gh { color: #000080; font-weight: bold } /* Generic.Heading */
-.highlight .gi { color: #00A000 } /* Generic.Inserted */
-.highlight .go { color: #888888 } /* Generic.Output */
-.highlight .gp { color: #000080; font-weight: bold } /* Generic.Prompt */
-.highlight .gs { font-weight: bold } /* Generic.Strong */
-.highlight .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
-.highlight .gt { color: #0044DD } /* Generic.Traceback */
-.highlight .kc { color: #008000; font-weight: bold } /* Keyword.Constant */
+.highlight .hll {
+    background-color: #ffffcc
+}
+
+.highlight {
+    background: #f8f8f8;
+}
+
+.highlight .c {
+    color: #408080;
+    font-style: italic
+}
+
+/* Comment */
+.highlight .k {
+    color: #008000;
+    font-weight: bold
+}
+
+/* Keyword */
+.highlight .o {
+    color: #666666
+}
+
+/* Operator */
+.highlight .ch {
+    color: #408080;
+    font-style: italic
+}
+
+/* Comment.Hashbang */
+.highlight .cm {
+    color: #408080;
+    font-style: italic
+}
+
+/* Comment.Multiline */
+.highlight .cp {
+    color: #BC7A00
+}
+
+/* Comment.Preproc */
+.highlight .cpf {
+    color: #408080;
+    font-style: italic
+}
+
+/* Comment.PreprocFile */
+.highlight .c1 {
+    color: #408080;
+    font-style: italic
+}
+
+/* Comment.Single */
+.highlight .cs {
+    color: #408080;
+    font-style: italic
+}
+
+/* Comment.Special */
+.highlight .gd {
+    color: #A00000
+}
+
+/* Generic.Deleted */
+.highlight .ge {
+    font-style: italic
+}
+
+/* Generic.Emph */
+.highlight .gr {
+    color: #FF0000
+}
+
+/* Generic.Error */
+.highlight .gh {
+    color: #000080;
+    font-weight: bold
+}
+
+/* Generic.Heading */
+.highlight .gi {
+    color: #00A000
+}
+
+/* Generic.Inserted */
+.highlight .go {
+    color: #888888
+}
+
+/* Generic.Output */
+.highlight .gp {
+    color: #000080;
+    font-weight: bold
+}
+
+/* Generic.Prompt */
+.highlight .gs {
+    font-weight: bold
+}
+
+/* Generic.Strong */
+.highlight .gu {
+    color: #800080;
+    font-weight: bold
+}
+
+/* Generic.Subheading */
+.highlight .gt {
+    color: #0044DD
+}
+
+/* Generic.Traceback */
+.highlight .kc {
+    color: #008000;
+    font-weight: bold
+}
+
+/* Keyword.Constant */
 /* .highlight .kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
-.highlight .kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
-.highlight .kp { color: #008000 } /* Keyword.Pseudo */
-.highlight .kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
-.highlight .kt { color: #B00040 } /* Keyword.Type */
-.highlight .m { color: #666666 } /* Literal.Number */
-.highlight .s { color: #BA2121 } /* Literal.String */
-.highlight .na { color: #7D9029 } /* Name.Attribute */
-.highlight .nb { color: #008000 } /* Name.Builtin */
-.highlight .nc { color: #0000FF; font-weight: bold } /* Name.Class */
-.highlight .no { color: #880000 } /* Name.Constant */
-.highlight .nd { color: #AA22FF } /* Name.Decorator */
-.highlight .ni { color: #999999; font-weight: bold } /* Name.Entity */
-.highlight .ne { color: #D2413A; font-weight: bold } /* Name.Exception */
-.highlight .nf { color: #0000FF } /* Name.Function */
-.highlight .nl { color: #A0A000 } /* Name.Label */
-.highlight .nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
-.highlight .nt { color: #008000; font-weight: bold } /* Name.Tag */
-.highlight .nv { color: #19177C } /* Name.Variable */
-.highlight .ow { color: #AA22FF; font-weight: bold } /* Operator.Word */
-.highlight .w { color: #bbbbbb } /* Text.Whitespace */
-.highlight .mb { color: #666666 } /* Literal.Number.Bin */
-.highlight .mf { color: #666666 } /* Literal.Number.Float */
-.highlight .mh { color: #666666 } /* Literal.Number.Hex */
-.highlight .mi { color: #666666 } /* Literal.Number.Integer */
-.highlight .mo { color: #666666 } /* Literal.Number.Oct */
-.highlight .sa { color: #BA2121 } /* Literal.String.Affix */
-.highlight .sb { color: #BA2121 } /* Literal.String.Backtick */
-.highlight .sc { color: #BA2121 } /* Literal.String.Char */
-.highlight .dl { color: #BA2121 } /* Literal.String.Delimiter */
-.highlight .sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
-.highlight .s2 { color: #BA2121 } /* Literal.String.Double */
-.highlight .se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
-.highlight .sh { color: #BA2121 } /* Literal.String.Heredoc */
-.highlight .si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
-.highlight .sx { color: #008000 } /* Literal.String.Other */
-.highlight .sr { color: #BB6688 } /* Literal.String.Regex */
-.highlight .s1 { color: #BA2121 } /* Literal.String.Single */
-.highlight .ss { color: #19177C } /* Literal.String.Symbol */
-.highlight .bp { color: #008000 } /* Name.Builtin.Pseudo */
-.highlight .fm { color: #0000FF } /* Name.Function.Magic */
-.highlight .vc { color: #19177C } /* Name.Variable.Class */
-.highlight .vg { color: #19177C } /* Name.Variable.Global */
-.highlight .vi { color: #19177C } /* Name.Variable.Instance */
-.highlight .vm { color: #19177C } /* Name.Variable.Magic */
-.highlight .il { color: #666666 } /* Literal.Number.Integer.Long */
+.highlight .kn {
+    color: #008000;
+    font-weight: bold
+}
+
+/* Keyword.Namespace */
+.highlight .kp {
+    color: #008000
+}
+
+/* Keyword.Pseudo */
+.highlight .kr {
+    color: #008000;
+    font-weight: bold
+}
+
+/* Keyword.Reserved */
+.highlight .kt {
+    color: #B00040
+}
+
+/* Keyword.Type */
+.highlight .m {
+    color: #666666
+}
+
+/* Literal.Number */
+.highlight .s {
+    color: #BA2121
+}
+
+/* Literal.String */
+.highlight .na {
+    color: #7D9029
+}
+
+/* Name.Attribute */
+.highlight .nb {
+    color: #008000
+}
+
+/* Name.Builtin */
+.highlight .nc {
+    color: #0000FF;
+    font-weight: bold
+}
+
+/* Name.Class */
+.highlight .no {
+    color: #880000
+}
+
+/* Name.Constant */
+.highlight .nd {
+    color: #AA22FF
+}
+
+/* Name.Decorator */
+.highlight .ni {
+    color: #999999;
+    font-weight: bold
+}
+
+/* Name.Entity */
+.highlight .ne {
+    color: #D2413A;
+    font-weight: bold
+}
+
+/* Name.Exception */
+.highlight .nf {
+    color: #0000FF
+}
+
+/* Name.Function */
+.highlight .nl {
+    color: #A0A000
+}
+
+/* Name.Label */
+.highlight .nn {
+    color: #0000FF;
+    font-weight: bold
+}
+
+/* Name.Namespace */
+.highlight .nt {
+    color: #008000;
+    font-weight: bold
+}
+
+/* Name.Tag */
+.highlight .nv {
+    color: #19177C
+}
+
+/* Name.Variable */
+.highlight .ow {
+    color: #AA22FF;
+    font-weight: bold
+}
+
+/* Operator.Word */
+.highlight .w {
+    color: #bbbbbb
+}
+
+/* Text.Whitespace */
+.highlight .mb {
+    color: #666666
+}
+
+/* Literal.Number.Bin */
+.highlight .mf {
+    color: #666666
+}
+
+/* Literal.Number.Float */
+.highlight .mh {
+    color: #666666
+}
+
+/* Literal.Number.Hex */
+.highlight .mi {
+    color: #666666
+}
+
+/* Literal.Number.Integer */
+.highlight .mo {
+    color: #666666
+}
+
+/* Literal.Number.Oct */
+.highlight .sa {
+    color: #BA2121
+}
+
+/* Literal.String.Affix */
+.highlight .sb {
+    color: #BA2121
+}
+
+/* Literal.String.Backtick */
+.highlight .sc {
+    color: #BA2121
+}
+
+/* Literal.String.Char */
+.highlight .dl {
+    color: #BA2121
+}
+
+/* Literal.String.Delimiter */
+.highlight .sd {
+    color: #BA2121;
+    font-style: italic
+}
+
+/* Literal.String.Doc */
+.highlight .s2 {
+    color: #BA2121
+}
+
+/* Literal.String.Double */
+.highlight .se {
+    color: #BB6622;
+    font-weight: bold
+}
+
+/* Literal.String.Escape */
+.highlight .sh {
+    color: #BA2121
+}
+
+/* Literal.String.Heredoc */
+.highlight .si {
+    color: #BB6688;
+    font-weight: bold
+}
+
+/* Literal.String.Interpol */
+.highlight .sx {
+    color: #008000
+}
+
+/* Literal.String.Other */
+.highlight .sr {
+    color: #BB6688
+}
+
+/* Literal.String.Regex */
+.highlight .s1 {
+    color: #BA2121
+}
+
+/* Literal.String.Single */
+.highlight .ss {
+    color: #19177C
+}
+
+/* Literal.String.Symbol */
+.highlight .bp {
+    color: #008000
+}
+
+/* Name.Builtin.Pseudo */
+.highlight .fm {
+    color: #0000FF
+}
+
+/* Name.Function.Magic */
+.highlight .vc {
+    color: #19177C
+}
+
+/* Name.Variable.Class */
+.highlight .vg {
+    color: #19177C
+}
+
+/* Name.Variable.Global */
+.highlight .vi {
+    color: #19177C
+}
+
+/* Name.Variable.Instance */
+.highlight .vm {
+    color: #19177C
+}
+
+/* Name.Variable.Magic */
+.highlight .il {
+    color: #666666
+}

--- a/pdf/assets/styles/pdf.css
+++ b/pdf/assets/styles/pdf.css
@@ -313,3 +313,19 @@ hr {
     height: 1px;
     background-color: #dcdcdc;
 }
+
+img {
+    display: block;
+    /* Makes images behave as block elements */
+    margin: 1em auto;
+    /* Centers images with auto margins */
+    max-width: 95%;
+    /* Prevents images from overflowing their containers */
+    height: auto;
+    /* Maintains aspect ratio */
+}
+
+figure {
+    text-align: center;
+    margin: 1em auto;
+}

--- a/unix-installation-and-configuration-guide/docs/configuration-parameters/environment-variables.md
+++ b/unix-installation-and-configuration-guide/docs/configuration-parameters/environment-variables.md
@@ -3,7 +3,7 @@
 Environment variables are used to configure various aspects of Dyalog APL. The complete list appears in the *Dyalog for Microsoft Windows Installation and Configuration Guide: Configuration Parameters*; this section discusses those variables which are of particular importance to the Non-GUI versions of Dyalog APL, and lists those that have meaning to the UNIX versions. Additionally there some non-GUI-specific variables which are described below and some which either do not apply, or may not work as the user might at first expect.
 
 Under UNIX, all environment variables should appear in UPPER CASE. For example, to set the default value of `⎕ml` to 3, then
-```apl
+```
 $ export DEFAULT_ML=3
 ```
 
@@ -22,22 +22,22 @@ The environment variables are broken down into several tables:
 - [](#E7): RIDE-related environment variables
 - [](#E8): SALT and User Command-related environment variables
 
-Table: Commonly used Variables { #E1 }
+Table: Commonly used Variables {: #E1 }
 
 |Variable|Notes|
 |---|---|
 |TERM<br/>APLK<br/>APLK0<br/>APLT<br/>APLTn|Define the input and output translate tables used by Dyalog APL. The values of APLK0 and APLTn override the values of APLK and APLT if set, and they in turn override the value of (Unicode) *default*, or (Classic) TERM if set.<p/><p/>APLK is for input translation, APLT for output translation.<p/><p/>These are used in conjunction with ..|
-|APLKEYS APLTTRANS|Define the search path for the input and output translate tables respectively. If unset, the interpreter will default to $DYALOG; if $DYALOG too is not set, will default to /usr/dyalog.|
-|APLNID|This variable is ignored by the UNIX versions of Dyalog APL: `⎕ai` and `⎕an` pick up their values from the user's uid and /etc/passwd.|
-|APLSTATUSFD|If set, this defines the stream number on which all messages for the Status Window appear. It is then possible to redirect this output when APL is started.<p/><p/>If unset, the output will appear in the same terminal window as the APL session, although it is not part of the session; such output can be removed by hitting SR (Screen Redraw - often defined to be Ctrl-L).|
-|DYALOG_NETCORE|This parameter is a Boolean value with a default value of 1. If set to 0, it disables the .NET interface.|
-|DYALOG_SERIAL|This parameter contains your Dyalog serial number. This must be set to the serial number issued to you. If not set, then the software is unregistered. For the full licence terms and conditions, see [https://www.dyalog.com/uploads/documents/Terms_and_Conditions.pdf](https://www.dyalog.com/uploads/documents/Terms_and_Conditions.pdf) .|
-|DYALOG_SERIALFILE|This parameter specifies the full path to the text file containing your Dyalog serial number.|
-|ENABLE_CEF|This parameter is a Boolean value with a default value of 1. If set to 0, it disables the [Chromium Embedded Framework (CEF).](https://en.wikipedia.org/wiki/Chromium_Embedded_Framework) and at attempt to create an [HTMLRenderer](../../../object-reference/objects/htmlrenderer) object will fail with an error meessage. See Note (below).|
-|ERRORONEXTERNALEXCEPTION|By default, any error when calling `⎕NA` will result in APL terminating; if `ERRORONEXTERNALEXCEPTION` is set to 1, then APL will instead generate an event 91: `EXTERNAL DLL EXCEPTION` . Be aware however that the workspace may become corrupted. This is best used when developing `⎕NA` code rather than in production.|
-|LIBPATH|A suitable entry for the Conga libraries needs to be added to the LIBPATH variable if Conga is to be used. For more information see the Conga Guide.|
-|MAXWS|Defines the size of the workspace that will be presented to the user when Dyalog APL is started. A simple integer value will be treated as being in KB. K, M and G can be appended to the value to indicate KiB, MiB and GiB (binary) respectively. If unset, the default value is 256M.|
-|WSPATH|Defines the search path for both workspaces and Auxiliary processors.<p/><p/>If unset, there is no default value. Workspaces and APs that are not on the WSPATH can be accessed using absolute or relative pathnames.|
+|`APLKEYS` `APLTTRANS`|Define the search path for the input and output translate tables respectively. If unset, the interpreter will default to `$DYALOG`; if `$DYALOG` too is not set, will default to `/usr/dyalog`.|
+|`APLNID`|This variable is ignored by the UNIX versions of Dyalog APL: `⎕AI` and `⎕AN` pick up their values from the user's uid and `/etc/passwd`.|
+|`APLSTATUSFD`|If set, this defines the stream number on which all messages for the Status Window appear. It is then possible to redirect this output when APL is started.<p/><p/>If unset, the output will appear in the same terminal window as the APL session, although it is not part of the session; such output can be removed by hitting SR (Screen Redraw - often defined to be Ctrl-L).|
+|`DYALOG_NETCORE`|This parameter is a Boolean value with a default value of 1. If set to 0, it disables the .NET interface.|
+|`DYALOG_SERIAL`|This parameter contains your Dyalog serial number. This must be set to the serial number issued to you. If not set, then the software is unregistered. For the full licence terms and conditions, see [https://www.dyalog.com/uploads/documents/Terms_and_Conditions.pdf](https://www.dyalog.com/uploads/documents/Terms_and_Conditions.pdf) .|
+|`DYALOG_SERIALFILE`|This parameter specifies the full path to the text file containing your Dyalog serial number.|
+|`ENABLE_CEF`|This parameter is a Boolean value with a default value of 1. If set to 0, it disables the [Chromium Embedded Framework (CEF)](https://en.wikipedia.org/wiki/Chromium_Embedded_Framework) and at attempt to create an HTMLRenderer object (see [HTMLRenderer](../../../object-reference/objects/htmlrenderer)) will fail with an error message. See Note (below).|
+|`ERRORONEXTERNALEXCEPTION`|By default, any error when calling `⎕NA` will result in APL terminating; if `ERRORONEXTERNALEXCEPTION` is set to 1, then APL will instead generate an event 91: `EXTERNAL DLL EXCEPTION` . Be aware however that the workspace may become corrupted. This is best used when developing `⎕NA` code rather than in production.|
+|`LIBPATH`|A suitable entry for the Conga libraries needs to be added to the `LIBPATH` variable if Conga is to be used. For more information see the *Conga Guide*.|
+|`MAXWS`|Defines the size of the workspace that will be presented to the user when Dyalog APL is started. A simple integer value will be treated as being in KB. K, M and G can be appended to the value to indicate KiB, MiB and GiB (binary) respectively. If unset, the default value is 256M.|
+|`WSPATH`|Defines the search path for both workspaces and Auxiliary processors.<p/><p/>If unset, there is no default value. Workspaces and APs that are not on the `WSPATH` can be accessed using absolute or relative pathnames.|
 
 ## Note
 
@@ -48,35 +48,35 @@ is used.
 
 Under macOS and Linux, if the configuration parameter **ENABLE_CEF** is 1, Auxiliary Processors cannot be used (they hang on error). The default value is 1 unless you are not running under a desktop (for example, you are running Dyalog in a PuTTY session when the default is 0).
 
-Table: Default workspace values { #E2 }
+Table: Default workspace values {: #E2 }
 
 |Variable|Notes|
 |---|---|
-|DEFAULT_DIV|Default value for `⎕div` in a clear workspace.|
-|DEFAULT_IO|Default value for `⎕io` in a clear workspace.|
-|DEFAULT_ML|Default value for `⎕ml` in a clear workspace.|
-|DEFAULT_PP|Default value for `⎕pp` in a clear workspace.|
-|AUTO_PW DEFAULT_PW|`⎕pw` is set by the interpreter when it starts, or when the session window is resized. Under UNIX if the terminal window is resized, the session will be resized when the interpreter next checks for input.|
-|DEFAULT_RTL|Default value for `⎕rtl` in a clear workspace.|
-|DEFAULT_WX|Default value for `⎕wx` in a clear workspace. Note that although the UNIX versions of Dyalog APL do not have GUI objects, `⎕se` is present, and the value of `⎕wx` will affect the programmer's ability to run expressions such as `⎕se.PropList`.|
+|`DEFAULT_DIV`|Default value for `⎕DIV` in a clear workspace.|
+|`DEFAULT_IO`|Default value for `⎕IO` in a clear workspace.|
+|`DEFAULT_ML`|Default value for `⎕ML` in a clear workspace.|
+|`DEFAULT_PP`|Default value for `⎕PP` in a clear workspace.|
+|`AUTO_PW` `DEFAULT_PW`|`⎕PW` is set by the interpreter when it starts, or when the session window is resized. Under UNIX if the terminal window is resized, the session will be resized when the interpreter next checks for input.|
+|`DEFAULT_RTL`|Default value for `⎕RTL` in a clear workspace.|
+|`DEFAULT_WX`|Default value for `⎕WX` in a clear workspace. Note that although the UNIX versions of Dyalog APL do not have GUI objects, `⎕SE` is present, and the value of `⎕WX` will affect the programmer's ability to run expressions such as `⎕SE.PropList`.|
 
 For numeric values, the interpreter takes the value of the environment variable, and prepends a "0" to that string. It then parses the string, accepting characters until the first non-digit character is reached.
 
 This string, now of digits only, is converted into an integer. If the resulting value is valid, then that is the value that will be used in the workspace. If the resulting value is invalid, then the default value will be used instead.
 
-Table: Variables used to configure the Session  { #E3 }
+Table: Variables used to configure the Session {: #E3 }
 
 |Variable|Notes|
 |---|---|
-|DYALOGLINK|Specifies the directory for Link|
-|DYALOGSTARTUPSE|Specifies one or more *Session initialisation* directories that contain APL code to be installed in `⎕SE`|
-|DYALOGSTART_X|Specifies whether the `Run` function is executed during 					Session startup|
-|DYALOG_GUTTER_ENABLE|Enable or disable Session Gutter|
-|HISTORY_SIZE|The size of the prior line buffer|
-|INPUT_SIZE|The size of the buffer used to store lines marked for execution|
-|LOG_FILE LOG_FILE_INUSE LOG_SIZE|These three variables determine the name of the session log file (default ~/.dyalog/session_log_<DyalogMajor><DyalogMinor><U|C><bits>_*.dlf, for example, ~/.dyalog/session_log_190U64_*.dlf), whether a log file is created or not, and the size of the log file in KB. Be aware: the session log file is not interchangeable between the different editions and widths of APL; in a mixed environment it is strongly recommended to use a different log file for each version.|
-|PFKEY_SIZE|The size of the buffer used to hold `⎕pfkey` definitions: if this is too small, an attempt to add a new definition will result in a LIMIT ERROR.|
-|SESSION_FILE|Defines the location of your session file; session file support was added in Dyalog 13.1. The default value is $DYALOG/default.dse|
+|`DYALOGLINK`|Specifies the directory for Link|
+|`DYALOGSTARTUPSE`|Specifies one or more *Session initialisation* directories that contain APL code to be installed in `⎕SE`|
+|`DYALOGSTART_X`|Specifies whether the `Run` function is executed during Session startup|
+|`DYALOG_GUTTER_ENABLE`|Enable or disable Session Gutter|
+|`HISTORY_SIZE`|The size of the prior line buffer|
+|`INPUT_SIZE`|The size of the buffer used to store lines marked for execution|
+|`LOG_FILE` `LOG_FILE_INUSE` `LOG_SIZE`|These three variables determine the name of the session log file (default `~/.dyalog/session_log_<DyalogMajor><DyalogMinor><U|C><bits>_*.dlf`, for example, `~/.dyalog/session_log_190U64_*.dlf`), whether a log file is created or not, and the size of the log file in KB. Be aware: the session log file is not interchangeable between the different editions and widths of APL; in a mixed environment it is strongly recommended to use a different log file for each version.|
+|`PFKEY_SIZE`|The size of the buffer used to hold `PFKEY` definitions: if this is too small, an attempt to add a new definition will result in a `LIMIT ERROR`.|
+|`SESSION_FILE`|Defines the location of your session file; session file support was added in Dyalog 13.1. The default value is `$DYALOG/default.dse`|
 
 To set values, use K to indicate KB. Note that the buffers will contain other information, so the buffer size will not be exact. Note also that multibyte Unicode characters will take up more space than single byte characters, and that 32 and 64 bit versions of Dyalog APL can require different amounts of space for holding the same information.
 
@@ -85,42 +85,42 @@ Example:
 HISTORY_SIZE=4K my_apl_startup_script
 ```
 
-Table: Miscellaneous Variables used by non-GUI Dyalog APL  { #E4 }
+Table: Miscellaneous Variables used by non-GUI Dyalog APL {: #E4 }
 
 |---|---|
 |Variable|Notes|
-|APL_TEXTINAPLCORE|If set with the value 1 the "Interesting Information" section is included in an aplcore file. Otherwise this section is omitted. By default the interpreter has this set to 0; it is the default APL script which sets it to 1.|
-|AUTOFORMAT TABSTOPS|If AUTOFORMAT is 1, then control structures will be shown with indents, set at TABSTOPS spaces; the changes are reflected in the editor window when the RD (ReDraw) command key is hit.|
-|AUTOINDENT|If AUTOINDENT is set to 1, then if a line is added it is indented the same as the previous line.|
-|AUTO_PW|Introduced in 13.0. With `AUTO_PW=0, ⎕pw` remains fixed at the size of the terminal window when APL was started. When set to 1, or unset, `⎕pw` alters each time the terminal window is resized.|
-|DYALOG|This variable is defined in the supplied mapl startup script, and is used to form the default values for APLKEYS, APLTRANS, WSPATH etc. If it is necessary to identify the location of the Dyalog executable, then a more reliable method is to determine the full path name from the appropriate file in the /proc/<process_id_of_APL_session>/ subdirectory or from the output of ps.|
+|`APL_TEXTINAPLCORE`|If set with the value 1 the "Interesting Information" section is included in an aplcore file. Otherwise this section is omitted. By default the interpreter has this set to 0; it is the default APL script which sets it to 1.|
+|`AUTOFORMAT` `TABSTOPS`|If `AUTOFORMAT` is 1, then control structures will be shown with indents, set at `TABSTOPS` spaces; the changes are reflected in the editor window when the `RD` (ReDraw) command key is hit.|
+|`AUTOINDENT`|If `AUTOINDENT` is set to 1, then if a line is added it is indented the same as the previous line.|
+|`AUTO_PW`|Introduced in 13.0. With `AUTO_PW=0` `⎕PW` remains fixed at the size of the terminal window when APL was started. When set to 1, or unset, `⎕PW` alters each time the terminal window is resized.|
+|`DYALOG`|This variable is defined in the supplied `mapl` startup script, and is used to form the default values for `APLKEYS`, `APLTRANS`, `WSPATH` etc. If it is necessary to identify the location of the Dyalog executable, then a more reliable method is to determine the full path name from the appropriate file in the `/proc/<process_id_of_APL_session>/` subdirectory or from the output of `ps`.|
 
 These are the remaining variables listed in the *Dyalog for Microsoft Windows Installation and Configuration Guide* which are effective in the non-GUI UNIX versions of Dyalog APL
 
-Table: Editor-related environment variables { #E5 }
+Table: Editor-related environment variables {: #E5 }
 
 |---|---|
 |Variable|Notes|
-|EDITOR_COLUMNS_*|See [Configuring the Editor](configuring-the-editor.md). Can be one of EDITOR_COLUMNS_CHARACTER_ARRAY EDITOR_COLUMNS_CLASS EDITOR_COLUMNS_FUNCTION EDITOR_COLUMNS_NAMESPACE EDITOR_COLUMNS_NUMERIC_ARRAY|
-|DYALOG_DISCARD_FN_SOURCE|Specifies whether source code is retained in the workspace|
+|`EDITOR_COLUMNS_*`|See [Configuring the Editor](configuring-the-editor.md). Can be one of `EDITOR_COLUMNS_CHARACTER_ARRAY EDITOR_COLUMNS_CLASS EDITOR_COLUMNS_FUNCTION EDITOR_COLUMNS_NAMESPACE EDITOR_COLUMNS_NUMERIC_ARRAY`|
+|`DYALOG_DISCARD_FN_SOURCE`|Specifies whether source code is retained in the workspace|
 
-Table: Tracer-related environment variables { #E6 }
+Table: Tracer-related environment variables {: #E6 }
 
 |--------------|--------------------------------------------------------------------------------------|
 |Variable      |Notes                                                                                 |
-|TRACE_ON_ERROR|With this is set to 1 (the default) the tracer is opened if an untrapped error occurs.|
+|`TRACE_ON_ERROR`|With this is set to 1 (the default) the tracer is opened if an untrapped error occurs.|
 
-Table: Ride-related environment variables { #E7 }
+Table: Ride-related environment variables {: #E7 }
 
 |---------|----------------------------------------------------------------------------|
 |Variable |Notes                                                                       |
-|RIDE_INIT|Enables and configures Ride; see the [Ride User Guide](https://dyalog.github.io/ride) for more information.|
+|`RIDE_INIT`|Enables and configures Ride; see the [Ride User Guide](https://dyalog.github.io/ride) for more information.|
 
-Table: SALT and user commands related environment variables { #E8 }
+Table: SALT and user commands related environment variables {: #E8 }
 
 |---|---|
 |Variable|Notes|
-|SESSION_FILE|Specifies the location of the file containing `⎕SE` . The default value is $DYALOG/default.dse|
-|UCMDCACHEFILE|Specifies the location of the user command cache file. Defaults to `"UserCommand{UcmdMajor}{UcmdMinor}.{DyalogMajor}{DyalogMinor}{U|C}{bits}.cache"` , for example, `UserCommand25.182U64.cache` in the `dyalog` directory.|
+|`SESSION_FILE`|Specifies the location of the file containing `⎕SE` . The default value is `$DYALOG/default.dse`|
+|`UCMDCACHEFILE`|Specifies the location of the user command cache file. Defaults to `"UserCommand{UcmdMajor}{UcmdMinor}.{DyalogMajor}{DyalogMinor}{U|C}{bits}.cache"` , for example, `UserCommand25.182U64.cache` in the `dyalog` directory.|
 
 Further information about SALT and user commands appear in the *User Commands User Guide* and the *SALT User Guide*.

--- a/unix-installation-and-configuration-guide/print_mkdocs.yml
+++ b/unix-installation-and-configuration-guide/print_mkdocs.yml
@@ -1,0 +1,68 @@
+site_name: UNIX Installation and Configuration Guide
+theme:
+  favicon: img/favicon-32.png
+  logo: img/dyalog-logo-2025_white.svg
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.path
+    - navigation.indexes
+  name: material
+  font:
+    text: Be Vietnam Pro
+extra_css:
+  - style/main.css
+  - style/extra.css
+  - style/admonition-ucmdhelp.css
+extra_javascript:
+  - javascripts/mathjax.js
+  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
+plugins:
+  - privacy
+  - search
+  - macros
+  - site-urls
+  - caption:
+      table:
+        enable: true
+        start_index: 1
+        increment_index: 1
+        position: bottom
+extra:
+  version_maj: 20
+  version_majmin: 20.0
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.keys
+  - pymdownx.superfences
+  - pymdownx.arithmatex:
+      generic: true
+  - attr_list
+  - abbr
+  - footnotes
+  - md_in_html
+  - markdown_tables_extended
+  - toc:
+      title: On this page
+nav:
+  - Installation:
+    - introduction.md
+    - installation.md
+  - Dyalog Serial Number: dyalog-serial-number.md
+  - Konsole: linux-console-config.md
+  - APL VNC RDP: apl-vnc-rdp.md
+  - PuTTY: putty.md
+  - Configuration Parameters:
+      - Introduction: configuration-parameters/configuration-parameters.md
+      - Configuration Files: configuration-parameters/configuration-files.md
+      - Environment Variables: configuration-parameters/environment-variables.md
+  - Configuring the Editor: configuring-the-editor.md
+  - Starting from scripts: starting-apl-from-scripts.md
+  - Magic: magic.md
+  - SE and SALT: se-and-user-commands.md
+  - HOME dyalog directory: home-dyalog-directory.md
+  - QuadNA and UNIX: quadna.md
+  - Miscellaneous: miscellaneous.md
+  - BuildID: buildid.md

--- a/unix-user-guide/print_mkdocs.yml
+++ b/unix-user-guide/print_mkdocs.yml
@@ -1,0 +1,66 @@
+site_name: UNIX User Guide
+theme:
+  favicon: img/favicon-32.png
+  logo: img/dyalog-logo-2025_white.svg
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.path
+    - navigation.indexes
+  name: material
+  font:
+    text: Be Vietnam Pro
+extra_css:
+  - style/main.css
+  - style/extra.css
+  - style/admonition-ucmdhelp.css
+extra_javascript:
+  - javascripts/mathjax.js
+  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
+plugins:
+  - privacy
+  - search
+  - macros
+  - site-urls
+  - caption:
+      table:
+        enable: true
+        start_index: 1
+        increment_index: 1
+        position: bottom
+extra:
+  version_maj: 20
+  version_majmin: 20.0
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.keys
+  - pymdownx.superfences
+  - pymdownx.arithmatex:
+      generic: true
+  - attr_list
+  - abbr
+  - footnotes
+  - md_in_html
+  - markdown_tables_extended
+  - toc:
+      title: On this page
+nav:
+  - Introduction:
+    - Overview: overview.md
+    - Entering Characters: entering-characters.md
+    - Entering Nest and Stencil Characters: entering-the-stencil-character.md
+    - Entering Commands: entering-commands.md
+  - Input Windows: the-different-input-windows.md
+  - Driving the tty version: driving-tty-dyalog-apl.md
+  - Starting APL: starting-apl.md
+  - Configuring the Editor: configuring-the-editor.md
+  - File Permissions and FSTAC: file-permissions-and-fstac.md
+  - Calling UNIX Commands: calling-unix-commands.md
+  - Signals and Trap: signals-and-trap.md
+  - BuildID: buildid.md
+  - Core and APLCore Files: core-and-aplcore-files.md
+  - Appendix A: appendix-a-table-of-keycodes-te.md
+  - Appendix B: appendix-b-table-of-keycodes-putty.md
+  - Appendix C: appendix-c-unused-keycodes.md

--- a/windows-installation-and-configuration-guide/print_mkdocs.yml
+++ b/windows-installation-and-configuration-guide/print_mkdocs.yml
@@ -1,0 +1,248 @@
+site_name: Windows Installation and Configuration Guide
+theme:
+  favicon: img/favicon-32.png
+  logo: img/dyalog-logo-2025_white.svg
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.path
+    - navigation.indexes
+  name: material
+  font:
+    text: Be Vietnam Pro
+extra_css:
+  - style/main.css
+  - style/extra.css
+  - style/admonition-ucmdhelp.css
+extra_javascript:
+  - javascripts/mathjax.js
+  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
+plugins:
+  - privacy
+  - search
+  - macros
+  - site-urls
+  - caption:
+      table:
+        enable: true
+        start_index: 1
+        increment_index: 1
+        position: bottom
+extra:
+  version_maj: 20
+  version_majmin: 20.0
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.keys
+  - pymdownx.superfences
+  - pymdownx.arithmatex:
+      generic: true
+  - attr_list
+  - abbr
+  - footnotes
+  - md_in_html
+  - markdown_tables_extended
+  - toc:
+      title: On this page
+nav:
+  - Installation and Configuration:
+    - Documentation: documentation.md
+    - Files and Directories: files-and-directories.md
+    - File Extensions: file-associations.md
+    - APL Fonts: apl-fonts.md
+    - Interoperability and Compatibility: interoperability.md
+    - The APL Command Line: apl-command-line.md
+    - APL Exit Codes: apl-exit-codes.md
+    - Dyalog Serial Number: dyalog-serial-number.md
+    - Configuration Parameters:
+        - Introduction: configuration-parameters/configuration-parameters.md
+        - AddClassHeaders: configuration-parameters/addclassheaders.md
+        - AplCoreName: configuration-parameters/aplcorename.md
+        - aplk: configuration-parameters/aplk.md
+        - aplkeys: configuration-parameters/aplkeys.md
+        - aplnid: configuration-parameters/aplnid.md
+        - aplt: configuration-parameters/aplt.md
+        - apltrans: configuration-parameters/apltrans.md
+        - APL_CODE_E_MAGNITUDE: configuration-parameters/apl-code-e-magnitude.md
+        - APL_COMPLEX_AS_V12: configuration-parameters/apl-complex-as-v12.md
+        - APL_FCREATE_PROPS_C: configuration-parameters/apl-fcreate-props-c.md
+        - APL_FCREATE_PROPS_J: configuration-parameters/apl-fcreate-props-j.md
+        - APL_FAST_FCHK: configuration-parameters/apl-fast-fchk.md
+        - APL_MAX_THREADS: configuration-parameters/apl-max-threads.md
+        - APL_TextInAplCore: configuration-parameters/apl-textinaplcore.md
+        - AutoDPI: configuration-parameters/autodpi.md
+        - AutoComplete:
+            - CancelKey1: configuration-parameters/autocomplete/cancelkey1.md
+            - CancelKey2: configuration-parameters/autocomplete/cancelkey2.md
+            - Cols: configuration-parameters/autocomplete/cols.md
+            - CommonKey1: configuration-parameters/autocomplete/commonkey1.md
+            - CompleteKey1: configuration-parameters/autocomplete/completekey1.md
+            - CompleteKey2: configuration-parameters/autocomplete/completekey2.md
+            - Enabled: configuration-parameters/autocomplete/enabled.md
+            - History: configuration-parameters/autocomplete/history.md
+            - HistorySize: configuration-parameters/autocomplete/historysize.md
+            - PrefixSize: configuration-parameters/autocomplete/prefixsize.md
+            - Rows: configuration-parameters/autocomplete/rows.md
+            - ShowFiles: configuration-parameters/autocomplete/showfiles.md
+        - AutoFormat: configuration-parameters/autoformat.md
+        - AutoIndent: configuration-parameters/autoindent.md
+        - auto_pw: configuration-parameters/auto-pw.md
+        - CFEXT: configuration-parameters/cfext.md
+        - ClassicMode: configuration-parameters/classicmode.md
+        - ClassicModeSavePosition: configuration-parameters/classicmodesaveposition.md
+        - CMD_PREFIX and CMD_POSTFIX: configuration-parameters/cmd-prefix-and-cmd-postfix.md
+        - ConfigFile: configuration-parameters/configfile.md
+        - confirm_abort: configuration-parameters/confirm-abort.md
+        - confirm_close: configuration-parameters/confirm-close.md
+        - confirm_fix: configuration-parameters/confirm-fix.md
+        - confirm_session_delete: configuration-parameters/confirm-session-delete.md
+        - default_div: configuration-parameters/default-div.md
+        - default_io: configuration-parameters/default-io.md
+        - default_ml: configuration-parameters/default-ml.md
+        - default_pp: configuration-parameters/default-pp.md
+        - default_pw: configuration-parameters/default-pw.md
+        - default_rtl: configuration-parameters/default-rtl.md
+        - default_wx: configuration-parameters/default-wx.md
+        - DMXOUTPUTONERROR: configuration-parameters/dmxoutputonerror.md
+        - DockableEditWindows: configuration-parameters/dockableeditwindows.md
+        - DoubleClickEdit: configuration-parameters/doubleclickedit.md
+        - dyalog: configuration-parameters/dyalog.md
+        - DyalogEmailAddress: configuration-parameters/dyalogemailaddress.md
+        - DyalogHelpDir: configuration-parameters/dyaloghelpdir.md
+        - DyalogInstallDir: configuration-parameters/dyaloginstalldir.md
+        - DyalogLink: configuration-parameters/dyaloglink.md
+        - DyalogStartup: configuration-parameters/dyalogstartup.md
+        - DyalogStartupSE: configuration-parameters/dyalogstartupse.md
+        - DyalogStartup_X: configuration-parameters/dyalogstartup-x.md
+        - DyalogWebSite: configuration-parameters/dyalogwebsite.md
+        - DYALOG_DISCARD_FN_SOURCE: configuration-parameters/dyalog-discard-fn-source.md
+        - DYALOG_EVENTLOGGINGLEVEL: configuration-parameters/dyalog-eventlogginglevel.md
+        - DYALOG_EVENTLOGNAME: configuration-parameters/dyalog-eventlogname.md
+        - DYALOG_GUTTER_ENABLE: configuration-parameters/dyalog-gutter-enable.md
+        - Dyalog_LineEditor_Mode: configuration-parameters/dyalog-lineeditor-mode.md
+        - Dyalog_NETCore: configuration-parameters/dyalog-netcore.md
+        - DYALOG_NOPOPUPS: configuration-parameters/dyalog-nopopups.md
+        - DYALOG_PIXEL_TYPE: configuration-parameters/dyalog-pixel-type.md
+        - DYALOG_SERIAL: configuration-parameters/dyalog-serial.md
+        - EditorState: configuration-parameters/editorstate.md
+        - Edit_Cols: configuration-parameters/edit-cols.md
+        - Edit_First_X: configuration-parameters/edit-first-x.md
+        - Edit_First_Y: configuration-parameters/edit-first-y.md
+        - Edit_Offset_X: configuration-parameters/edit-offset-x.md
+        - Edit_Offset_Y: configuration-parameters/edit-offset-y.md
+        - Edit_Rows: configuration-parameters/edit-rows.md
+        - ENABLE_CEF: configuration-parameters/enable-cef.md
+        - ErrorOnExternalException: configuration-parameters/erroronexternalexception.md
+        - ExternalHelpURL: configuration-parameters/externalhelpurl.md
+        - File_Stack_Size: configuration-parameters/file-stack-size.md
+        - greet_bitmap: configuration-parameters/greet-bitmap.md
+        - history_size: configuration-parameters/history-size.md
+        - inifile: configuration-parameters/inifile.md
+        - InitFullScriptNormal: configuration-parameters/initfullscriptnormal.md
+        - InitFullScriptSusp: configuration-parameters/initfullscriptsusp.md
+        - InitialKeyboardLayout: configuration-parameters/initialkeyboardlayout.md
+        - InitialKeyboardLayoutInUse: configuration-parameters/initialkeyboardlayoutinuse.md
+        - InitialKeyboardLayoutShowAll: configuration-parameters/initialkeyboardlayoutshowall.md
+        - input_size: configuration-parameters/input-size.md
+        - KeyboardInputDelay: configuration-parameters/keyboardinputdelay.md
+        - Load: configuration-parameters/load.md
+        - localdyalogdir: configuration-parameters/localdyalogdir.md
+        - log_file: configuration-parameters/log-file.md
+        - log_file_inuse: configuration-parameters/log-file-inuse.md
+        - log_size: configuration-parameters/log-size.md
+        - LX: configuration-parameters/lx.md
+        - mapchars: configuration-parameters/mapchars.md
+        - MaxAplCores: configuration-parameters/maxaplcores.md
+        - maxws: configuration-parameters/maxws.md
+        - OverstrikesPopup: configuration-parameters/overstrikespopup.md
+        - PassExceptionsToOpSys: configuration-parameters/passexceptionstoopsys.md
+        - pfkey_size: configuration-parameters/pfkey-size.md
+        - ProgramFolder: configuration-parameters/programfolder.md
+        - PropertyExposeRoot: configuration-parameters/propertyexposeroot.md
+        - PropertyExposeSE: configuration-parameters/propertyexposese.md
+        - qcmd_timeout: configuration-parameters/qcmd-timeout.md
+        - ResolveOverstrikes: configuration-parameters/resolveoverstrikes.md
+        - RIDE_Init: configuration-parameters/ride-init.md
+        - RIDE_Spawned: configuration-parameters/ride-spawned.md
+        - RunAsService: configuration-parameters/runasservice.md
+        - SaveContinueOnExit: configuration-parameters/savecontinueonexit.md
+        - SaveLogOnExit: configuration-parameters/savelogonexit.md
+        - SaveSessionOnExit: configuration-parameters/savesessiononexit.md
+        - Serial: configuration-parameters/serial.md
+        - SessionOnTop: configuration-parameters/sessionontop.md
+        - session_file: configuration-parameters/session-file.md
+        - ShowStatusOnError: configuration-parameters/showstatusonerror.md
+        - SingleTrace: configuration-parameters/singletrace.md
+        - SkipLines: configuration-parameters/skiplines.md
+        - SM_Cols: configuration-parameters/sm-cols.md
+        - SM_Rows: configuration-parameters/sm-rows.md
+        - StatusOnEdit: configuration-parameters/statusonedit.md
+        - TabStops: configuration-parameters/tabstops.md
+        - ToolBarsOnEdit: configuration-parameters/toolbarsonedit.md
+        - TraceStopMonitor: configuration-parameters/tracestopmonitor.md
+        - Trace_First_X: configuration-parameters/trace-first-x.md
+        - Trace_First_Y: configuration-parameters/trace-first-y.md
+        - Trace_level_warn: configuration-parameters/trace-level-warn.md
+        - Trace_Offset_X: configuration-parameters/trace-offset-x.md
+        - Trace_Offset_Y: configuration-parameters/trace-offset-y.md
+        - Trace_On_Error: configuration-parameters/trace-on-error.md
+        - UCMDCacheFile: configuration-parameters/ucmdcachefile.md
+        - UnicodeToClipboard: configuration-parameters/unicodetoclipboard.md
+        - URLHighlight: configuration-parameters/urlhighlight.md
+        - UseExternalHelpURL: configuration-parameters/useexternalhelpurl.md
+        - UserConfigFile: configuration-parameters/userconfigfile.md
+        - UseXCV: configuration-parameters/usexcv.md
+        - ValueTips:
+            - ValueTips/ColourScheme: configuration-parameters/valuetips/colourscheme.md
+            - ValueTips/Delay: configuration-parameters/valuetips/delay.md
+            - ValueTips/Enabled: configuration-parameters/valuetips/enabled.md
+        - WantsSpecialKeys: configuration-parameters/wantsspecialkeys.md
+        - WrapSearch: configuration-parameters/wrapsearch.md
+        - WrapSearchMsgBox: configuration-parameters/wrapsearchmsgbox.md
+        - WSEXT: configuration-parameters/wsext.md
+        - WSPATH: configuration-parameters/wspath.md
+        - XPLookAndFeel: configuration-parameters/xplookandfeel.md
+        - yy_window: configuration-parameters/yy-window.md
+    - Registry SubFolders: registry-subfolders.md
+    - Configuration Files: configuration-files.md
+    - Window Captions: window-captions.md
+    - Workspace Management: workspace-management.md
+    - Interface with Windows: interface-with-windows.md
+    - Auxiliary Processors: auxiliary-processors.md
+    - Access Control for External Variables: access-control-for-external-variables.md
+    - Shell Scripts: shell-scripts.md
+    - Creating Executables: creating-executables.md
+    - Run-Time Applications and Components: runtime-applications-and-components.md
+    - Run-Time Applications Additonal Considerations: runtime-applications-addional.md
+    - COM Objects and the Dyalog APL DLL: com-objects-and-the-dyalog-dll.md
+    - APL Application as a Service: apl-application-as-a-service.md
+    - APLService Logging Events: aplservice-logging-events.md
+  - Configuring the IDE:
+      - Configuration Dialog:
+          - General Tab: configuring-the-ide/configuration-dialog/configuration-dialog-general-tab.md
+          - Unicode Input Tab: 
+              configuring-the-ide/configuration-dialog/configuration-dialog-unicode-input-tab-unicode-edition-only.md
+          - Input Tab (Classic Edition): 
+              configuring-the-ide/configuration-dialog/configuration-dialog-input-tab-classic-edition-only.md
+          - Output Tab (Classic Edition): 
+              configuring-the-ide/configuration-dialog/configuration-dialog-output-tab-classic-edition-only.md
+          - Keyboard Shortcuts Tab: 
+              configuring-the-ide/configuration-dialog/configuration-dialog-keyboard-shortcuts-tab.md
+          - Workspace Tab: configuring-the-ide/configuration-dialog/configuration-dialog-workspace-tab.md
+          - Help/DMX Tab: configuring-the-ide/configuration-dialog/configuration-dialog-help-dmx-tab.md
+          - Windows Tab: configuring-the-ide/configuration-dialog/configuration-dialog-windows-tab.md
+          - Session Tab: configuring-the-ide/configuration-dialog/configuration-dialog-session-tab.md
+          - Trace/Edit Tab: configuring-the-ide/configuration-dialog/configuration-dialog-trace-edit-tab.md
+          - Auto Complete Tab: 
+              configuring-the-ide/configuration-dialog/configuration-dialog-auto-complete-tab.md
+          - SALT Tab: configuring-the-ide/configuration-dialog/configuration-dialog-salt-tab.md
+          - User Commands Tab: 
+              configuring-the-ide/configuration-dialog/configuration-dialog-user-commands-tab.md
+          - Object Syntax Tab: 
+              configuring-the-ide/configuration-dialog/configuration-dialog-object-syntax-tab.md
+          - Saved ResponsesTab: 
+              configuring-the-ide/configuration-dialog/configuration-dialog-saved-responsestab.md
+      - Colour Selection Dialog: configuring-the-ide/colour-selection-dialog.md
+      - Print Configuration Dialog: configuring-the-ide/print-configuration.md

--- a/windows-ui-guide/docs/session-colour-scheme.md
+++ b/windows-ui-guide/docs/session-colour-scheme.md
@@ -10,7 +10,7 @@ In the Classic Edition, colours may alternatively be defined in the Output Trans
 
 The first table below shows the colours used for different session components. The second table shows how different colours are used to identify different types of data in edit windows.
 
-Table: Default Colour Scheme - Session { #default-colour-scheme-session }
+Table: Default Colour Scheme - Session {: #default-colour-scheme-session }
 
 |Colour|Used for                   |Default            |
 |------|---------------------------|-------------------|
@@ -20,7 +20,7 @@ Table: Default Colour Scheme - Session { #default-colour-scheme-session }
 |253   |Tracer : Pendent Function  |Yellow on Dark Grey|
 |245   |Tracer : Current Line      |White on Red       |
 
-Table: Default Colour Scheme Edit windows { #default-colour-scheme-edit-windows }
+Table: Default Colour Scheme Edit windows {: #default-colour-scheme-edit-windows }
 
 |Colour|Array Type                 |Editable|Default         |
 |------|---------------------------|--------|----------------|

--- a/windows-ui-guide/docs/session-menubar.md
+++ b/windows-ui-guide/docs/session-menubar.md
@@ -6,7 +6,7 @@ The Session MenuBar  (`⎕SE.mb`) contains a set of menus as follows. Note that,
 
 The *File* menu (`⎕SE.mb.file`) provides a means to execute those APL System Commands that are concerned with the active and saved workspaces. The contents of a typical File menu and the operations they perform are illustrated below.
 
-Table: File Menu Operations { #file-menu-operations }
+Table: File Menu Operations {: #file-menu-operations }
 
 |Item|Action|Description|
 |---|---|---|
@@ -29,7 +29,7 @@ Table: File Menu Operations { #file-menu-operations }
 
 The *Edit* menu (`⎕SE.mb.edit`) provides a means to recall previously entered input lines for re-execution and for copying text to and from the clipboard.
 
-Table: Edit menu operations { #edit-menu-operations }
+Table: Edit menu operations {: #edit-menu-operations }
 
 |Item             |Action          |Description                                                                               |
 |-----------------|----------------|------------------------------------------------------------------------------------------|
@@ -47,7 +47,7 @@ Table: Edit menu operations { #edit-menu-operations }
 
 The *View* menu (`⎕SE.mb.view`) toggles the visibility of the Session Toolbar, StatusBar, and Language Bar.
 
-Table: View menu operations { #view-menu-operations }
+Table: View menu operations {: #view-menu-operations }
 
 |Item       |Action|Description                    |
 |-----------|------|-------------------------------|
@@ -59,7 +59,7 @@ Table: View menu operations { #view-menu-operations }
 
 This contains a single action (`⎕SE.mb.windows`) which is to close all of the Edit and Trace windows and the Status window.
 
-Table: Window menu operations { #window-menu-operations }
+Table: Window menu operations {: #window-menu-operations }
 
 |Item             |Action      |Description                      |
 |-----------------|------------|---------------------------------|
@@ -73,7 +73,7 @@ In addition, the *Window* menu will contain options to switch the focus to any s
 
 The *Session* menu (`⎕SE.mb.session`) provides access to the system operations that allow you to load a session (`⎕SE`) from a session file and to save your current session (`⎕SE`) to a session file. If you use these facilities rarely, you may wish to move them to (say) the *Options* menu or even dispense with them entirely.
 
-Table: Session menu operations { #session-menu-operations }
+Table: Session menu operations {: #session-menu-operations }
 
 |Item|Action|Description|
 |---|---|---|
@@ -85,7 +85,7 @@ Table: Session menu operations { #session-menu-operations }
 
 The *Log* menu (`⎕SE.mb.log`) provides access to the system operations that manipulate Session log files.
 
-Table: Log menu operations { #log-menu-operations }
+Table: Log menu operations {: #log-menu-operations }
 
 |Item   |Action       |Description                                                                                 |
 |-------|-------------|--------------------------------------------------------------------------------------------|
@@ -99,7 +99,7 @@ Table: Log menu operations { #log-menu-operations }
 
 The *Action* menu (`⎕SE.mb.action`) may be used to perform a variety of operations on the *current object* or the *current line*. The current object is the object whose name contains the cursor. The current line is that line that contains the cursor. The *Edit*, *Copy Object*, *Paste Object* and *Print Object* items operate on the current object. For example, if the name `SALES` appears in the session and the cursor is placed somewhere within it, `SALES` is the current object and will be copied to the clipboard by selecting *Copy object* or opened up for editing by selecting *Edit*.
 
-Table: Action menu operations { #actions-menu-operations }
+Table: Action menu operations {: #actions-menu-operations }
 
 |Item        |Action       |Description                                                                                                                           |
 |------------|-------------|--------------------------------------------------------------------------------------------------------------------------------------|
@@ -117,7 +117,7 @@ Table: Action menu operations { #actions-menu-operations }
 
 The *Options* menu (`⎕SE.mb.options`) provides configuration options.
 
-Table: Options menu operations { #options-menu-operations }
+Table: Options menu operations {: #options-menu-operations }
 
 |Item                     |Action                      |Description                                                                                                      |
 |-------------------------|----------------------------|-----------------------------------------------------------------------------------------------------------------|
@@ -137,7 +137,7 @@ The default values of these items are defined by the parameters **default_wx**, 
 
 The *Tools* menu (`⎕SE.mb.tools`) provides access to various session tools and dialog boxes.
 
-Table: Tools Menu Operations { #tools-menu-operations }
+Table: Tools Menu Operations {: #tools-menu-operations }
 
 |Item        |Action         |Description                                                                                          |
 |------------|---------------|-----------------------------------------------------------------------------------------------------|
@@ -152,7 +152,7 @@ Table: Tools Menu Operations { #tools-menu-operations }
 
 The *Threads* menu (`⎕SE.mb.threads`) provides access to various session tools and dialog boxes.
 
-Table: Threads Menu Operations { #threads-menu-operations }
+Table: Threads Menu Operations {: #threads-menu-operations }
 
 |Item               |Action                 |Description                                        |
 |-------------------|-----------------------|---------------------------------------------------|
@@ -169,7 +169,7 @@ Table: Threads Menu Operations { #threads-menu-operations }
 
 The *Debugger* menu (`⎕SE.mb.layout`) provides layout options for the Debugger.
 
-Table: Debugger Menu Operations { #debugger-layout-menu-operations }
+Table: Debugger Menu Operations {: #debugger-layout-menu-operations }
 
 |Item           |Action             |Description                                        |
 |---------------|-------------------|---------------------------------------------------|
@@ -181,7 +181,7 @@ Table: Debugger Menu Operations { #debugger-layout-menu-operations }
 
 The *Help* menu (`⎕SE.mb.help`) provides access to the help system which is packaged as a single *Microsoft HTML Help* compiled help file named `help\dyalog.chm.`
 
-Table: Help menu operations { #help-menu-operations }
+Table: Help menu operations {: #help-menu-operations }
 
 |Label|Action|Description|
 |---|---|---|

--- a/windows-ui-guide/docs/tracer/trace-primitives.md
+++ b/windows-ui-guide/docs/tracer/trace-primitives.md
@@ -69,8 +69,8 @@ When tracing primitives, there are several more aspects of an expression that ca
 The relationship between these panes can be illustrated as
 
 ```other
-Left Argument  ┐     ┌─  Axis Specification
-               │ ┌─┐ │  ┌──────┬─  Right Argument / Previous Result
+     Left Arg  ┐     ┌─  Axis Specification
+               │ ┌─┐ │  ┌──────┬─  Right Arg / Prev Result
                a │B│[1] c D[2] e
                  └┬┘    │ │ │  └  Previous Right
 Current Function  ┘     │ │ └  Previous Axis

--- a/windows-ui-guide/print_mkdocs.yml
+++ b/windows-ui-guide/print_mkdocs.yml
@@ -1,0 +1,99 @@
+site_name: Windows UI Guide
+theme:
+  favicon: img/favicon-32.png
+  logo: img/dyalog-logo-2025_white.svg
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.path
+    - navigation.indexes
+  name: material
+  font:
+    text: Be Vietnam Pro
+extra_css:
+  - style/main.css
+  - style/extra.css
+  - style/admonition-ucmdhelp.css
+extra_javascript:
+  - javascripts/mathjax.js
+  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
+plugins:
+  - privacy
+  - search
+  - macros
+  - caption:
+      table:
+        enable: true
+        start_index: 1
+        increment_index: 1
+        position: bottom
+extra:
+  version_maj: 20
+  version_majmin: 20.0
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.keys
+  - pymdownx.superfences
+  - pymdownx.arithmatex:
+      generic: true
+  - attr_list
+  - abbr
+  - footnotes
+  - md_in_html
+  - markdown_tables_extended
+  - toc:
+      title: On this page
+nav:
+  - Introduction: introduction.md
+  - APL Keyboards: apl-keyboards.md
+  - Session Manager: session-manager.md
+  - Session Gutter: session-gutter.md
+  - Multi-line Session Input: multiline-session-input.md
+  - Unicode Edition Keyboard: unicode-edition-keyboard.md
+  - IME Configuration: ime-configuration.md
+  - Classic Edition Keyboard: classic-edition-keyboard.md
+  - Keyboard Shortcuts: keyboard-shortcuts.md
+  - Session Colour Scheme: session-colour-scheme.md
+  - The Session Window: the-session-window.md
+  - Language Bar: language-bar.md
+  - Entering and Executing Expressions: entering-and-executing-expressions.md
+  - Value Tips: value-tips.md
+  - Value Tips for External Functions: value-tips-external.md
+  - Configuring Value Tips: value-tips-configuring.md
+  - Array Editor: array-editor.md
+  - Session GUI: session-gui.md
+  - Session MenuBar: session-menubar.md
+  - Session Popup Menu: session-popup-menu.md
+  - The Session Toolbars: session-toolbars.md
+  - Session StatusBar: session-statusbar.md
+  - Status Window: status-window.md
+  - Workspace Explorer: workspace-explorer.md
+  - Browsing Classes: browsing-classes.md
+  - Browsing Type Libraries: browsing-type-libraries.md
+  - Browsing .Net Classes: browsing-net-classes.md
+  - Find Objects Tool: find-objects-tool.md
+  - Object Properties Dialog: object-properties-dialog.md
+  - Editor: editor.md
+  - Find and Replace Dialogs: find-and-replace-dialogs.md
+  - Editing Scripts and Text Files: editing-scripts-and-text-files.md
+  - Source as Typed: source-as-typed.md
+  - The Tracer: 
+      - tracer/index.md
+      - Trace Primitives: tracer/trace-primitives.md
+  - The Threads Tool: threads-tool.md
+  - Debugging Threads: debugging-threads.md
+  - The Event Viewer: event-viewer.md
+  - The Session Object:
+      - Introduction: the-session-object/session-object.md
+      - AfterFix: the-session-object/afterfix.md
+      - Fix: the-session-object/fix.md
+      - Format: the-session-object/format.md
+      - SessionPrint Event: the-session-object/sessionprint.md
+      - SessionTrace: the-session-object/sessiontrace.md
+      - WorkspaceLoaded Event: the-session-object/workspaceloaded.md
+      - Configuring the Session: the-session-object/configuring-the-session.md
+      - Session Initialisation: the-session-object/session-initialisation.md
+  - User Commands: user-commands.md
+  - File Explorer Integration: file-explorer-integration.md


### PR DESCRIPTION
The table of contents logic in the pdf maker does not treat top-level files as chapters:

```yml
nav:
  - Not a chapter but should be: chapter1.md
  - Is a chapter and should be:
     - Intro: intro/chapter2.md
```

References #161 