### PR TITLE
Inject build date and git details into site footer

### DIFF
--- a/.github/workflows/mkdocs-publish.yml
+++ b/.github/workflows/mkdocs-publish.yml
@@ -48,7 +48,28 @@ jobs:
           mkdocs-site-urls \
           mkdocs-caption \
           markdown-tables-extended
-    
+
+    - name: Get Git Info
+      id: git-info
+      run: |
+        BRANCH=$(git rev-parse --abbrev-ref HEAD)
+        HASH=$(git rev-parse --short HEAD)
+        echo "GIT_INFO=${BRANCH}:${HASH}" >> $GITHUB_OUTPUT
+        echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+    - name: Substitute env variables in mkdocs.yml
+      env:
+        GIT_INFO: ${{ steps.git-info.outputs.GIT_INFO }}
+        BUILD_DATE: ${{ steps.git-info.outputs.DATE }}
+      run: |
+        # Create backup
+        cp mkdocs.yml mkdocs.yml.bak
+        # Substitute variables
+        envsubst '$BUILD_DATE $GIT_INFO' < mkdocs.yml.bak > mkdocs.yml
+        # Display substituted content for debugging
+        echo "--- Checking substituted content ---"
+        cat mkdocs.yml | grep -A5 copyright
+
     - name: Deploy documentation
       run: |
         if [ "${{ inputs.update_latest }}" = "true" ]; then

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: Documentation
 repo_url: https://github.com/dyalog/documentation
+copyright: Made with <a href="https://squidfunk.github.io/mkdocs-material/" target="_blank" rel="noopener"><strong>Material for MkDocs</strong></a><br/>Copyright &copy; 2015-2024 <strong><a href="https://dyalog.com" target="_blank" rel="noopener">Dyalog, LTD</a></strong> ($BUILD_DATE $GIT_INFO)
 
 theme:
   favicon: 'img/favicon-32.png'
@@ -40,6 +41,7 @@ extra:
   version_majmin: 20.0
   version:
     provider: mike
+  generator: false
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
Add date and commitish to the footer.


<img width="892" alt="Screenshot 2025-02-26 at 16 47 50" src="https://github.com/user-attachments/assets/1eee0a21-5293-4474-87e6-94d3fd3d44d0" />
