### PR TITLE
Allow for top-level file elements in the monorepo nav

### DIFF
--- a/pdf/mkdocs2pdf.py
+++ b/pdf/mkdocs2pdf.py
@@ -821,14 +821,23 @@ def toc_friendly_headings(soup: BeautifulSoup) -> None:
             # Replace the old heading with the new structure
             heading.replace_with(heading_container)
 
-
 def toplevel_docs(nav: List[Dict[str, str]]) -> Dict[str, str]:
     result = {}
     for entry in nav:
         for doc_name, include_path in entry.items():
-            path = include_path.split(' ')[1]
-            first_component = path.split('/')[1]
-            result[first_component] = doc_name
+            if "!include" in include_path:
+                # This is a directory include
+                path = include_path.split(' ')[1]
+                first_component = path.split('/')[1]
+                result[first_component] = doc_name
+            else:
+                # This is a direct file reference
+                path_parts = include_path.split('/')
+                # Use the filename without extension as the key
+                if len(path_parts) > 0:
+                    filename = path_parts[-1]
+                    file_base = os.path.splitext(filename)[0]
+                    result[file_base] = doc_name
     return result
 
 def process_document(document_path):


### PR DESCRIPTION
The PDF and CHM conversion tools assumed that every element in the nav would be an !include -- this is not the case:

```yml
nav:
  - Release Notes V19.0: "!include ./release-notes-v19-0/mkdocs.yml"
  - Windows Installation: "!include ./windows-installation-and-configuration-guide/mkdocs.yml"
  - UNIX Installation: "!include ./unix-installation-and-configuration-guide/mkdocs.yml"
  - Programmer's Guide: "!include ./programming-reference-guide/mkdocs.yml"
  - Language Reference: "!include ./language-reference-guide/mkdocs.yml"
  - Object Reference: "!include ./object-reference/mkdocs.yml"
  - Windows UI Guide: "!include ./windows-ui-guide/mkdocs.yml"
  - Interface Guide: "!include ./interface-guide/mkdocs.yml"
  - .NET Interface: "!include ./dotnet-interface/mkdocs.yml"
  - UNIX User Guide: "!include ./unix-user-guide/mkdocs.yml"
  - Licences for third-party components: licences-overview.md
  - Trademarks: trademarks.md
```

This fix addresses that.