### PR TITLE
52 set file attributes

### DIFF
--- a/language-reference-guide/docs/system-functions/native-files.md
+++ b/language-reference-guide/docs/system-functions/native-files.md
@@ -10,7 +10,7 @@
 |[`⎕NERASE`](nerase.md)  |Erase a File                                                 |
 |[`⎕NEXISTS`](nexists.md) |Discover whether or not a file or directory exists           |
 |[`⎕NGET`](nget.md)    |Read Text File                                               |
-|[`⎕NINFO`](ninfo.md)   |Obtain information about one or more files and/or directories|
+|[`⎕NINFO`](ninfo.md)   |Query or set information about one or more files and/or directories|
 |[`⎕NLOCK`](nlock.md)   |Lock a region of a file                                      |
 |[`⎕NMOVE`](nmove.md)   |Move files and directories                                   |
 |[`⎕NNAMES`](nnames.md)  |Names of tied Files                                          |

--- a/language-reference-guide/docs/system-functions/ninfo.md
+++ b/language-reference-guide/docs/system-functions/ninfo.md
@@ -1,6 +1,6 @@
 <h1 class="heading"><span class="name">Native File Information</span> <span class="command">R←{X}⎕NINFO Y</span></h1>
 
-This function returns information about one or more files or directories. `Y` may  be:
+This function queries or sets information about one or more files or directories. `Y` may be:
 
 - a numeric scalar containing the tie number of a native file
 - a character vector or scalar containing a file or directory name that conforms to the naming rules of the host Operating System.
@@ -8,7 +8,7 @@ This function returns information about one or more files or directories. `Y` ma
 
 ## Variant Options
 
-`⎕NINFO` may be applied using the Variant operator with the options  Wildcard (the Principal option), Recurse and Follow.
+`⎕NINFO` may be applied using the Variant operator with the options Wildcard (the Principal option), Recurse and Follow.
 
 ## Wildcard Option (Boolean)
 
@@ -30,36 +30,44 @@ This function returns information about one or more files or directories. `Y` ma
 |`0`|the properties reported are those of the symbolic link itself                           |
 |1 { .shaded } |the properties reported for a symbolic link are those of the target of the symbolic link|
 
-The optional left argument `X` is a simple numeric array containing values shown in the following table.
+The properties to be queried or set are specified in the optional left argument `X`, which may be an array of any shape.
 
-|`X`|Property|Default|
-|---|---|---|
-|`0`|Name of the file or directory, as a character vector. If `Y` is a tie number then this is the name which the file was tied.|&nbsp;|
-|`1`|Type, as a numeric scalar: 0=Not known 1=Directory 2=Regular file 3=Character device 4=Symbolic link (only when Follow is 0) 5=Block device 6=FIFO (not Windows) 7=Socket (not Windows)|`0`|
-|`2`|Size in bytes, as a numeric scalar|`0`|
-|`3`|Last modification time, as a timestamp in `⎕TS` format|`7⍴0`|
-|`4`|Owner user id, as a character vector – on Windows a SID, on other platforms a numeric userid converted to character format|`''`|
-|`5`|Owner name, as a character vector|`''`|
-|`6`|Whether the file or directory is hidden (1) or not (0), as a numeric scalar. On Windows, file properties include a "hidden" attribute; on non-Windows platforms a file or directory is implicitly considered to be hidden if its name begins with a "."|`¯1`|
-|`7`|Target of symbolic link (when Type is 4)|`''`|
-|`8`|Current position in the file. Always 0 if `Y` is a file name.|`0`|
-|`9`|Last access time  in `⎕TS` format, when available|`7⍴0`|
-|`10`|Creation time if available, otherwise the time of the last file status change in `⎕TS` format|`7⍴0`|
-|`11`|Whether the file or directory can (1) or cannot (0) be read ( `¯1` if unknown)|`¯1`|
-|`12`|Whether the file or directory can (1) or cannot (0) be written  ( `¯1` if unknown or for a directory under Windows)|`¯1`|
-|`13`|Last modification time, as a UTC  Dyalog Date  Number.|`0`|
-|`14`|Last access time  as a UTC Dyalog Date  Number, when available.|`0`|
-|`15`|Creation time if available, otherwise the time of the last file status change  as a UTC Dyalog Date  Number.|`0`|
+When `X` is a simple numeric array consisting of values as specified in the following table, properties are queried. If the property is unobtainable the Default value shown in the table is provided.
 
-Note that the current file position identifies where `⎕NREAD` will next read from or `⎕NAPPEND` will next write to and is only pertinent when the corresponding value in `Y` is a tie number rather than a name. It will be reported as 0 for named files.
+When some or all of the elements in `X` are nested vectors consisting of a numeric value as specified in the following table and an appropriate corresponding value, properties are set. Not all file properties are settable.
 
-Each value in `X` identifies a property of the file(s) or directory(ies) identified by `Y` whose value is to be returned in the result `R`. If omitted, the default value of `X` is 0. Values in `X` may be specified in any order and duplicates are allowed. A value in `X` which is not defined in the table above will not generate an error but results in a `⍬` (Zilde) in the corresponding element of `R`.
+|`X`|Property|Default|Settable|
+|---|---|---|---|
+|`0`|Name of the file or directory, as a character vector. If `Y` is a tie number then this is the name which the file was tied.|&nbsp;|No|
+|`1`|Type, as a numeric scalar: 0=Not known 1=Directory 2=Regular file 3=Character device 4=Symbolic link (only when Follow is 0) 5=Block device 6=FIFO (not Windows) 7=Socket (not Windows)|`0`|No|
+|`2`|Size in bytes, as a numeric scalar|`0`|Yes|
+|`3`|Last modification time, as a timestamp in `⎕TS` format|`7⍴0`|No|
+|`4`|Owner user id, as a character vector – on Windows a SID, on other platforms a numeric userid converted to character format|`''`|No|
+|`5`|Owner name, as a character vector|`''`|No|
+|`6`|Whether the file or directory is hidden (1) or not (0), as a numeric scalar. On Windows, file properties include a "hidden" attribute; on non-Windows platforms a file or directory is implicitly considered to be hidden if its name begins with a "."|`¯1`|Windows only|
+|`7`|Target of symbolic link (when Type is 4)|`''`|No|
+|`8`|Current position in the file|`0`|Yes|
+|`9`|Last access time  in `⎕TS` format, when available|`7⍴0`|No|
+|`10`|Creation time if available, otherwise the time of the last file status change in `⎕TS` format|`7⍴0`|No|
+|`11`|Whether the file or directory can (1) or cannot (0) be read ( `¯1` if unknown)|`¯1`|No|
+|`12`|Whether the file or directory can (1) or cannot (0) be written  ( `¯1` if unknown or for a directory under Windows)|`¯1`|No|
+|`13`|Last modification time, as a UTC  Dyalog Date Number.|`0`|Yes|
+|`14`|Last access time, as a UTC Dyalog Date Number, when available.|`0`|Yes|
+|`15`|Creation time if available, otherwise the time of the last file status change  as a UTC Dyalog Date  Number.|`0`|Windows only|
+
+The current file position property (`8`) identifies where `⎕NREAD` would next read from or `⎕NAPPEND` would next write to and is only pertinent when the corresponding value in `Y` is a tie number. It is reported as 0 for named files and directories.
+
+When querying file properties: each simple value in `X` identifies a property of the file(s) or directory(ies) identified by `Y` whose value is to be returned in the result `R`. If the value in `X` is not defined in the table above, `⍬` (Zilde) is returned in the corresponding element of `R`.
+
+When setting file properties: each nested vector in `X` identifies a property of the file(s) or directory(ies) identified by `Y` and a value to which the property is to be set. The new value is returned in the result `R`. If the value in `X` does not specify a settable property, or is not defined in the table above, or if the property cannot be set, an error will be signalled.
+
+If omitted, the default value of `X` is 0. Values in `X` may be specified in any order and duplicates are allowed.
 
 `R` is the same shape as `X` and each element contains value(s) determined by the property specified in the corresponding element in `X`. The depth of `R` depends upon whether or not the Wildcard option is enabled. If, for any reason, the function is unable to obtain a property value, (for example, if the file is in use exclusively by another process) the default value shown in the last column is returned instead.
 
-If the Wildcard option is not enabled (the default) then `Y` specifies exactly one file or directory and must exist.  In this case each element in `R` is a single property value for that file. If the name in `Y` does not exist, the function signals an error. On non-Windows platforms "*" and "?" are treated as normal characters. On Windows an error will be signalled since neither "*" nor "?" are valid characters for file or directory names.
+If the Wildcard option is not enabled (the default) then `Y` specifies exactly one file or directory and must exist. In this case each element in `R` is a single property value for that file. If the name in `Y` does not exist, the function signals an error. On non-Windows platforms "*" and "?" are treated as normal characters. On Windows an error will be signalled since neither are valid characters for file or directory names.
 
-If the Wildcard option is enabled,  zero or more files and/or directories may match the  pattern in `Y`. In this case each element in `R` is a vector of property values for each of the files. Note that  no error will be signalled if no files match the pattern.
+If the Wildcard option is enabled, zero or more files and/or directories may match the pattern in `Y`. In this case each element in `R` is a vector of property values for each of the files. Note that no error will be signalled if no files match the pattern.
 
 When using the Wildcard option, matching of names is done case insensitively on Windows and macOS, and case sensitively on other platforms. The names '.' and '..' are excluded from any matches. The order in which the names match is not defined.
 
@@ -157,9 +165,17 @@ The next set of examples, illustrate the use of the Recurse variant option to li
 4223
 ```
 
-The following expression will return all Word document (`.docx` and `.doc`) in the current directory, searching recursively through any sub-directories:
+The following expression will return all Word documents (`.docx` and `.doc`) in the current directory, searching recursively through any sub-directories:
 ```apl
      (⎕NINFO⍠('Recurse' 1)('Wildcard' 1))'*.docx' '*.doc'
+```
+
+The following expression "touches" files - that is, it sets their last modification time to the current UTC time:
+```apl
+      (⊂13(1 ⎕DT'Z'))(⎕NINFO⍠1)'*.txt'
+┌───────────────────────┐
+│45719.53226 45719.53226│
+└───────────────────────┘
 ```
 
 !!! note

--- a/language-reference-guide/docs/system-functions/ninfo.md
+++ b/language-reference-guide/docs/system-functions/ninfo.md
@@ -57,11 +57,13 @@ When some or all of the elements in `X` are nested vectors consisting of a numer
 
 The current file position property (`8`) identifies where `⎕NREAD` would next read from or `⎕NAPPEND` would next write to and is only pertinent when the corresponding value in `Y` is a tie number. It is reported as 0 for named files and directories.
 
+The values in `X` are processed in the order given, in ravel order. Duplicates are allowed.
+
 When querying file properties: each simple value in `X` identifies a property of the file(s) or directory(ies) identified by `Y` whose value is to be returned in the result `R`. If the value in `X` is not defined in the table above, `⍬` (Zilde) is returned in the corresponding element of `R`.
 
 When setting file properties: each nested vector in `X` identifies a property of the file(s) or directory(ies) identified by `Y` and a value to which the property is to be set. The new value is returned in the result `R`. If the value in `X` does not specify a settable property, or is not defined in the table above, or if the property cannot be set, an error will be signalled.
 
-If omitted, the default value of `X` is 0. Values in `X` may be specified in any order and duplicates are allowed.
+If omitted, the default value of `X` is 0.
 
 `R` is the same shape as `X` and each element contains value(s) determined by the property specified in the corresponding element in `X`. The depth of `R` depends upon whether or not the Wildcard option is enabled. If, for any reason, the function is unable to obtain a property value, (for example, if the file is in use exclusively by another process) the default value shown in the last column is returned instead.
 

--- a/language-reference-guide/docs/system-functions/ninfo.md
+++ b/language-reference-guide/docs/system-functions/ninfo.md
@@ -30,11 +30,12 @@ This function queries or sets information about one or more files or directories
 |`0`|the properties reported are those of the symbolic link itself                           |
 |1 { .shaded } |the properties reported for a symbolic link are those of the target of the symbolic link|
 
-The properties to be queried or set are specified in the optional left argument `X`, which may be an array of any shape.
+Optionally, `X` specifies properties of the files/directories identifed in `Y`. `X` can be an array of any shape; the shape determines whether the specified properties are queried or set:
 
-When `X` is a simple numeric array consisting of values as specified in the following table, properties are queried. If the property is unobtainable the Default value shown in the table is provided.
+- If `X` is a simple numeric array, the properties are queried. In this case, the values of `X` correspond to properties of the file/directory specified in `Y` that are to be queried, as defined in the following table.
+- If some or all of the elements in `X` are nested vectors, the properties are set. In this case, the values of `X` correspond to properties of the file/directory specified in `Y` that are to be set, as defined in the following table, with appropriate corresponding values to which those properties should be set. Not all file properties are settable. 
 
-When some or all of the elements in `X` are nested vectors consisting of a numeric value as specified in the following table and an appropriate corresponding value, properties are set. Not all file properties are settable.
+If `X` is not defined, it is assumed to be `0`.
 
 |`X`|Property|Default|Settable|
 |---|---|---|---|
@@ -46,7 +47,8 @@ When some or all of the elements in `X` are nested vectors consisting of a numer
 |`5`|Owner name, as a character vector|`''`|No|
 |`6`|Whether the file or directory is hidden (1) or not (0), as a numeric scalar. On Windows, file properties include a "hidden" attribute; on non-Windows platforms a file or directory is implicitly considered to be hidden if its name begins with a "."|`¯1`|Windows only|
 |`7`|Target of symbolic link (when Type is 4)|`''`|No|
-|`8`|Current position in the file|`0`|Yes|
+|`8`|Current position in the file. This identifies where `⎕NREAD` would next read from or `⎕NAPPEND` would next write to, and is only pertinent when the corresponding value in `Y` is a tie number. It is reported as `0` for named files and directories.|`0`|Yes|
+
 |`9`|Last access time  in `⎕TS` format, when available|`7⍴0`|No|
 |`10`|Creation time if available, otherwise the time of the last file status change in `⎕TS` format|`7⍴0`|No|
 |`11`|Whether the file or directory can (1) or cannot (0) be read ( `¯1` if unknown)|`¯1`|No|
@@ -55,19 +57,22 @@ When some or all of the elements in `X` are nested vectors consisting of a numer
 |`14`|Last access time, as a UTC Dyalog Date Number, when available.|`0`|Yes|
 |`15`|Creation time if available, otherwise the time of the last file status change  as a UTC Dyalog Date  Number.|`0`|Windows only|
 
-The current file position property (`8`) identifies where `⎕NREAD` would next read from or `⎕NAPPEND` would next write to and is only pertinent when the corresponding value in `Y` is a tie number. It is reported as 0 for named files and directories.
+The values in `X` are processed in ravel order. Duplicates are allowed.
 
-The values in `X` are processed in the order given, in ravel order. Duplicates are allowed.
+The returned value `R` has the same shape as `X` (if the **Wildcard** variant option has been specified, the depth will change – see below). The content of `R` depends on whether properties were queried or set:
 
-When querying file properties: each simple value in `X` identifies a property of the file(s) or directory(ies) identified by `Y` whose value is to be returned in the result `R`. If the value in `X` is not defined in the table above, `⍬` (Zilde) is returned in the corresponding element of `R`.
+- If properties were queried:
+    - each element of `R` is the value of the property identified by the corresponding value of `X`.
+    - if a value in `X` is not defined in the table above, the corresponding `R` value is `⍬` (Zilde).
+    - if more than one file/directory is specified in `Y`, the element of `R` corresponding to each element of `X` contains the property values for each of the files/directories specified in `Y`.
+- If properties were set:
+    - each element of `R` is the new value of the property identified by the corresponding value of `X`.
+    - if the value in `X` does not specify a property that is defined in the table above and settable, or if the new value specified for the property is not valid, an error will be signalled.
+    - if more than one file/directory is specified in `Y`, the element of `R` corresponding to each element of `X` contains the new property values for each of the files/directories specified in `Y`.
 
-When setting file properties: each nested vector in `X` identifies a property of the file(s) or directory(ies) identified by `Y` and a value to which the property is to be set. The new value is returned in the result `R`. If the value in `X` does not specify a settable property, or is not defined in the table above, or if the property cannot be set, an error will be signalled.
+If a property value cannot be obtained, the default value (shown in the table above) is returned for that property.
 
-If omitted, the default value of `X` is 0.
-
-`R` is the same shape as `X` and each element contains value(s) determined by the property specified in the corresponding element in `X`. The depth of `R` depends upon whether or not the Wildcard option is enabled. If, for any reason, the function is unable to obtain a property value, (for example, if the file is in use exclusively by another process) the default value shown in the last column is returned instead.
-
-If the Wildcard option is not enabled (the default) then `Y` specifies exactly one file or directory and must exist. In this case each element in `R` is a single property value for that file. If the name in `Y` does not exist, the function signals an error. On non-Windows platforms "*" and "?" are treated as normal characters. On Windows an error will be signalled since neither are valid characters for file or directory names.
+If the Wildcard option is not enabled (the default) then `Y` specifies exactly one file or directory and must exist. In this case each element in `R` is a single property value for that file. If the name in `Y` does not exist, the function signals an error. On non-Windows platforms "*" and "?" are treated as normal characters. On Microsoft Windows an error will be signalled since neither are valid characters for file or directory names.
 
 If the Wildcard option is enabled, zero or more files and/or directories may match the pattern in `Y`. In this case each element in `R` is a vector of property values for each of the files. Note that no error will be signalled if no files match the pattern.
 
@@ -167,12 +172,13 @@ The next set of examples, illustrate the use of the Recurse variant option to li
 4223
 ```
 
-The following expression will return all Word documents (`.docx` and `.doc`) in the current directory, searching recursively through any sub-directories:
+The following expression will return all Microsoft Word documents (`.docx` and `.doc`) in the current directory, searching recursively through any sub-directories:
 ```apl
      (⎕NINFO⍠('Recurse' 1)('Wildcard' 1))'*.docx' '*.doc'
 ```
 
-The following expression "touches" files - that is, it sets their last modification time to the current UTC time:
+The following expression "touches" files, that is, it sets their last modification time to the current UTC time:
+
 ```apl
       (⊂13(1 ⎕DT'Z'))(⎕NINFO⍠1)'*.txt'
 ┌───────────────────────┐
@@ -182,5 +188,3 @@ The following expression "touches" files - that is, it sets their last modificat
 
 !!! note
     Of the file timestamps which are reported by the operating system, only the last modification time should be considered reliable and portable. Neither the access time or creation time are well supported across all platforms. Furthermore, they may not accurately reflect the actual time that the operation occurred.
-
-

--- a/language-reference-guide/docs/system-functions/system-functions-categorised.md
+++ b/language-reference-guide/docs/system-functions/system-functions-categorised.md
@@ -173,7 +173,7 @@ NOTE: Tolerant comparisons depend on `⎕FR` to select which of `⎕CT` and `⎕
 |[`⎕NERASE`](nerase.md)  |Erase a File                                                 |
 |[`⎕NEXISTS`](nexists.md) |Discover whether or not a file or directory exists           |
 |[`⎕NGET`](nget.md)    |Read Text File                                               |
-|[`⎕NINFO`](ninfo.md)   |Obtain information about one or more files and/or directories|
+|[`⎕NINFO`](ninfo.md)   |Query or set information about one or more files and/or directories|
 |[`⎕NLOCK`](nlock.md)   |Lock a region of a file                                      |
 |[`⎕NMOVE`](nmove.md)   |Move files and directories                                   |
 |[`⎕NNAMES`](nnames.md)  |Names of tied Files                                          |


### PR DESCRIPTION
There are some duplicate files related to ⎕NINFO; I have assumed that we have some old files still in the sources which are now defunct, and have only updated what I think are the current ones. Specifically, I have updated:

language-reference-guide/docs/system-functions/system-functions-categorised/native-files/ninfo.md
language-reference-guide/docs/system-functions/system-functions-categorised/system-functions-categorised.md

but not:

language-reference-guide/docs/system-functions/ninfo.md
language-reference-guide/docs/system-functions/system-functions-categorised.md

If this assumption is not correct, please let me know!

-- Update--

These are now updated as well:

language-reference-guide/docs/system-functions/ninfo.md
language-reference-guide/docs/system-functions/system-functions-categorised.md

Indeed, the updates to 

language-reference-guide/docs/system-functions/system-functions-categorised/native-files/ninfo.md
language-reference-guide/docs/system-functions/system-functions-categorised/system-functions-categorised.md

can be ignored.