### PR TITLE
Add search keywords to the i-beam pages

### DIFF
--- a/language-reference-guide/docs/the-i-beam-operator/called-monadically.md
+++ b/language-reference-guide/docs/the-i-beam-operator/called-monadically.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  900⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/canonical-representation.md
+++ b/language-reference-guide/docs/the-i-beam-operator/canonical-representation.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  180⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/case-convert.md
+++ b/language-reference-guide/docs/the-i-beam-operator/case-convert.md
@@ -1,3 +1,9 @@
+
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  819⌶
+</div>
+
 <h1 class="heading"><span class="name">Case Convert</span> <span class="command">R←{X}(819⌶)Y</span></h1>
 
 !!! note

--- a/language-reference-guide/docs/the-i-beam-operator/change-user.md
+++ b/language-reference-guide/docs/the-i-beam-operator/change-user.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  4001⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/close-all-windows.md
+++ b/language-reference-guide/docs/the-i-beam-operator/close-all-windows.md
@@ -1,3 +1,9 @@
+
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  2023⌶
+</div>
+
 <h1 class="heading"><span class="name">Close All Windows</span> <span class="command">R←2023⌶Y</span></h1>
 
 Under Windows the option, *Windows -> Close All Windows* allows the user to close all open Editor and Tracer Windows, but does not reset the *state indicator*.

--- a/language-reference-guide/docs/the-i-beam-operator/close-net-appdomain.md
+++ b/language-reference-guide/docs/the-i-beam-operator/close-net-appdomain.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  2101⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/compiler-control.md
+++ b/language-reference-guide/docs/the-i-beam-operator/compiler-control.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  400⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/compress-vector-of-short-integers.md
+++ b/language-reference-guide/docs/the-i-beam-operator/compress-vector-of-short-integers.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  219⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/connected-to-the-ride.md
+++ b/language-reference-guide/docs/the-i-beam-operator/connected-to-the-ride.md
@@ -1,3 +1,9 @@
+
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  3501⌶
+</div>
+
 <h1 class="heading"><span class="name">Connected to Ride</span> <span class="command">R←(3501⌶)Y</span></h1>
 
 `Y` can be any value and is ignored.

--- a/language-reference-guide/docs/the-i-beam-operator/continue-autosave.md
+++ b/language-reference-guide/docs/the-i-beam-operator/continue-autosave.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  2704⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/create-data-binding-source.md
+++ b/language-reference-guide/docs/the-i-beam-operator/create-data-binding-source.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  2015⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/create-net-delegate.md
+++ b/language-reference-guide/docs/the-i-beam-operator/create-net-delegate.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  2016⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/disable-component-checksum-validation.md
+++ b/language-reference-guide/docs/the-i-beam-operator/disable-component-checksum-validation.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  3002⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/disable-global-triggers.md
+++ b/language-reference-guide/docs/the-i-beam-operator/disable-global-triggers.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  2007⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/discard-parked-threads.md
+++ b/language-reference-guide/docs/the-i-beam-operator/discard-parked-threads.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  2502⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/discard-source-code.md
+++ b/language-reference-guide/docs/the-i-beam-operator/discard-source-code.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  5172⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/discard-source-information.md
+++ b/language-reference-guide/docs/the-i-beam-operator/discard-source-information.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  5171⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/discard-thread-on-exit.md
+++ b/language-reference-guide/docs/the-i-beam-operator/discard-thread-on-exit.md
@@ -1,3 +1,9 @@
+
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  2501⌶
+</div>
+
 <h1 class="heading"><span class="name">Discard Thread on Exit</span> <span class="command">R←2501⌶Y</span></h1>
 
 APL threads that Dyalog creates to serve incoming .NET requests are not terminated when their work is done. They persist so that if another call comes in on the same .NET thread the same APL thread can handle it. In effect the thread is *parked* until it is needed again. If the thread is not required, there is a small performance cost in maintaining it in this state.

--- a/language-reference-guide/docs/the-i-beam-operator/enable-compression-of-large-components.md
+++ b/language-reference-guide/docs/the-i-beam-operator/enable-compression-of-large-components.md
@@ -1,3 +1,9 @@
+
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  3012⌶
+</div>
+
 <h1 class="heading"><span class="name">Enable Compression of Large Components</span> <span class="command">{R}←3012⌶Y</span></h1>
 
 Specifies whether large components (>2GB) may be compressed.

--- a/language-reference-guide/docs/the-i-beam-operator/execute-expression.md
+++ b/language-reference-guide/docs/the-i-beam-operator/execute-expression.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  85⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/export-to-memory.md
+++ b/language-reference-guide/docs/the-i-beam-operator/export-to-memory.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  2100⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/expose-root-properties.md
+++ b/language-reference-guide/docs/the-i-beam-operator/expose-root-properties.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  2401⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/flush-session-caption.md
+++ b/language-reference-guide/docs/the-i-beam-operator/flush-session-caption.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  2022⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/fork-new-task.md
+++ b/language-reference-guide/docs/the-i-beam-operator/fork-new-task.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  4000⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/format-datetime.md
+++ b/language-reference-guide/docs/the-i-beam-operator/format-datetime.md
@@ -1,3 +1,8 @@
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  1200⌶
+</div>
+
 <h1 class="heading"><span class="name">Format Date-time</span><span class="command">R←X(1200⌶)Y</span></h1>
 
 `Y` is a numeric array of any shape, where every element contains a Dyalog Date Number that represents a date between 1

--- a/language-reference-guide/docs/the-i-beam-operator/hash-array.md
+++ b/language-reference-guide/docs/the-i-beam-operator/hash-array.md
@@ -1,10 +1,11 @@
 
-
-
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  1500⌶
+</div>
 
 
 <h1 class="heading"><span class="name">Hash Array</span> <span class="command">R←{X}1500⌶Y</span></h1>
-
 
 
 This function creates a hashed array, returns an unhashed copy of an array or reports the state of hashing of an array.

--- a/language-reference-guide/docs/the-i-beam-operator/hash-table-size.md
+++ b/language-reference-guide/docs/the-i-beam-operator/hash-table-size.md
@@ -1,3 +1,9 @@
+
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  8468⌶
+</div>
+
 <h1 class="heading"><span class="name">Hash Table Size</span> <span class="command">{R}←8468⌶Y</span></h1>
 
 Increases the amount of workspace allocated to internal hash tables. These tables are created when a set primitive is executed or by the Hash Array function (`1500⌶`).

--- a/language-reference-guide/docs/the-i-beam-operator/identify-net-type.md
+++ b/language-reference-guide/docs/the-i-beam-operator/identify-net-type.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  2017⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/inverted-table-index-of.md
+++ b/language-reference-guide/docs/the-i-beam-operator/inverted-table-index-of.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  8⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/json-translate-name.md
+++ b/language-reference-guide/docs/the-i-beam-operator/json-translate-name.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  7162⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/line-count.md
+++ b/language-reference-guide/docs/the-i-beam-operator/line-count.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  50100⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/list-loaded-file-objects.md
+++ b/language-reference-guide/docs/the-i-beam-operator/list-loaded-file-objects.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  5177⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/list-loaded-files.md
+++ b/language-reference-guide/docs/the-i-beam-operator/list-loaded-files.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  5176⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/loaded-file-object-info.md
+++ b/language-reference-guide/docs/the-i-beam-operator/loaded-file-object-info.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  5179⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/loaded-libraries.md
+++ b/language-reference-guide/docs/the-i-beam-operator/loaded-libraries.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  950⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/lookup-table-size.md
+++ b/language-reference-guide/docs/the-i-beam-operator/lookup-table-size.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  8469⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/manage-ride-connections.md
+++ b/language-reference-guide/docs/the-i-beam-operator/manage-ride-connections.md
@@ -1,3 +1,9 @@
+
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  3502⌶
+</div>
+
 <h1 class="heading"><span class="name">Manage Ride Connections</span> <span class="command">R←3502⌶Y</span></h1>
 
 `3502⌶` gives control over Ride connections to the interpreter. More details about Ride can be found in the [Ride User Guide](https://dyalog.github.io/ride).

--- a/language-reference-guide/docs/the-i-beam-operator/mark-thread-as-uninterruptible.md
+++ b/language-reference-guide/docs/the-i-beam-operator/mark-thread-as-uninterruptible.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  2503⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/memory-manager-statistics.md
+++ b/language-reference-guide/docs/the-i-beam-operator/memory-manager-statistics.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  2000⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/monadic-operator-generator.md
+++ b/language-reference-guide/docs/the-i-beam-operator/monadic-operator-generator.md
@@ -1,3 +1,9 @@
+
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  43⌶
+</div>
+
 <h1 class="heading"><span class="name">Monadic Operator Generator</span> <span class="command">R←43⌶Y</span></h1>
 
 Returns a monadic operator, with functionality determined by the value of `Y`.

--- a/language-reference-guide/docs/the-i-beam-operator/number-of-threads.md
+++ b/language-reference-guide/docs/the-i-beam-operator/number-of-threads.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  1111⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/override-com-default-value.md
+++ b/language-reference-guide/docs/the-i-beam-operator/override-com-default-value.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  2041⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/overwrite-free-pockets.md
+++ b/language-reference-guide/docs/the-i-beam-operator/overwrite-free-pockets.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  127⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/parallel-execution-threshold.md
+++ b/language-reference-guide/docs/the-i-beam-operator/parallel-execution-threshold.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  1112⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/read-datatable.md
+++ b/language-reference-guide/docs/the-i-beam-operator/read-datatable.md
@@ -1,3 +1,9 @@
+
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  2011⌶
+</div>
+
 <h1 class="heading"><span class="name">Read DataTable</span> <span class="command">R←{X}2011⌶Y</span></h1>
 
 !!! note

--- a/language-reference-guide/docs/the-i-beam-operator/reap-forked-tasks.md
+++ b/language-reference-guide/docs/the-i-beam-operator/reap-forked-tasks.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  4002⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/remove-data-binding.md
+++ b/language-reference-guide/docs/the-i-beam-operator/remove-data-binding.md
@@ -1,3 +1,9 @@
+
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  2014⌶
+</div>
+
 <h1 class="heading"><span class="name">Remove Data Binding</span> <span class="command">R←2014⌶Y</span></h1>
 
 !!! note

--- a/language-reference-guide/docs/the-i-beam-operator/remove-loaded-file-object-info.md
+++ b/language-reference-guide/docs/the-i-beam-operator/remove-loaded-file-object-info.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  5178⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/sample-probability-distribution.md
+++ b/language-reference-guide/docs/the-i-beam-operator/sample-probability-distribution.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  16808⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/send-text-to-ride-embedded-browser.md
+++ b/language-reference-guide/docs/the-i-beam-operator/send-text-to-ride-embedded-browser.md
@@ -1,3 +1,9 @@
+
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  3500⌶
+</div>
+
 <h1 class="heading"><span class="name">Send Text to Ride-embedded Browser</span> <span class="command">R←{X}(3500⌶)Y</span></h1>
 
 Optionally, `X` is a simple character vector or scalar, the contents of which are used as the caption for the tab in the Ride client that contains the embedded browser. If omitted, then the caption defaults to "`3500⌶`".

--- a/language-reference-guide/docs/the-i-beam-operator/serialise-array.md
+++ b/language-reference-guide/docs/the-i-beam-operator/serialise-array.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  220⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/set-aplcore-parameters.md
+++ b/language-reference-guide/docs/the-i-beam-operator/set-aplcore-parameters.md
@@ -1,6 +1,8 @@
 
-
-
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  1302⌶
+</div>
 
 
 <h1 class="heading"><span class="name">Set aplcore Parameters</span> <span class="command">R←1302⌶Y</span></h1>

--- a/language-reference-guide/docs/the-i-beam-operator/set-dyalog-pixel-type.md
+++ b/language-reference-guide/docs/the-i-beam-operator/set-dyalog-pixel-type.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  2035⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/set-shell-script-debug-options.md
+++ b/language-reference-guide/docs/the-i-beam-operator/set-shell-script-debug-options.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  1010⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/set-workspace-save-options.md
+++ b/language-reference-guide/docs/the-i-beam-operator/set-workspace-save-options.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  2400⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/shell-process-control.md
+++ b/language-reference-guide/docs/the-i-beam-operator/shell-process-control.md
@@ -1,3 +1,9 @@
+
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  8373⌶
+</div>
+
 <h1 class="heading"><span class="name">Shell Process Control</span> <span class="command">R←{X}(8373⌶)Y</span></h1>
 
 This function provides a way to determine the process IDs of processes started by [`⎕SHELL`](../system-functions/shell.md), as well as enabling the sending of signals to any of those processes.

--- a/language-reference-guide/docs/the-i-beam-operator/signal-counts.md
+++ b/language-reference-guide/docs/the-i-beam-operator/signal-counts.md
@@ -1,3 +1,9 @@
+
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  4007⌶
+</div>
+
 <h1 class="heading"><span class="name">Signal Counts</span> <span class="command">R←4007⌶Y</span></h1>
 
 !!! note

--- a/language-reference-guide/docs/the-i-beam-operator/singular-value-decomposition.md
+++ b/language-reference-guide/docs/the-i-beam-operator/singular-value-decomposition.md
@@ -1,3 +1,9 @@
+
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  8415⌶
+</div>
+
 <h1 class="heading"><span class="name">Singular Value Decomposition</span> <span class="command">R←(8415⌶)Y</span></h1>
 
 `Y` is a simple numeric matrix. `⎕FR` must be 645.

--- a/language-reference-guide/docs/the-i-beam-operator/specify-workspace-available.md
+++ b/language-reference-guide/docs/the-i-beam-operator/specify-workspace-available.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  2002⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/syntax-colour-tokens.md
+++ b/language-reference-guide/docs/the-i-beam-operator/syntax-colour-tokens.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  201⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/syntax-colouring.md
+++ b/language-reference-guide/docs/the-i-beam-operator/syntax-colouring.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  200⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/temporary-directory.md
+++ b/language-reference-guide/docs/the-i-beam-operator/temporary-directory.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  739⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/trap-control.md
+++ b/language-reference-guide/docs/the-i-beam-operator/trap-control.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  600⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/unsqueezed-type.md
+++ b/language-reference-guide/docs/the-i-beam-operator/unsqueezed-type.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  181⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/update-datatable.md
+++ b/language-reference-guide/docs/the-i-beam-operator/update-datatable.md
@@ -1,3 +1,9 @@
+
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  2010⌶
+</div>
+
 <h1 class="heading"><span class="name">Update DataTable</span> <span class="command">R←{X}2010⌶Y</span></h1>
 
 !!! note

--- a/language-reference-guide/docs/the-i-beam-operator/update-function-timestamp.md
+++ b/language-reference-guide/docs/the-i-beam-operator/update-function-timestamp.md
@@ -1,3 +1,9 @@
+
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  1159⌶
+</div>
+
 <h1 class="heading"><span class="name">Update Function Timestamp</span> <span class="command">{R}←X(1159⌶)Y</span></h1>
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/use-separate-thread-for-net.md
+++ b/language-reference-guide/docs/the-i-beam-operator/use-separate-thread-for-net.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  2520⌶
+</div>
+
+
 
 
 

--- a/language-reference-guide/docs/the-i-beam-operator/verify-net-interface.md
+++ b/language-reference-guide/docs/the-i-beam-operator/verify-net-interface.md
@@ -1,4 +1,10 @@
 
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  2250⌶
+</div>
+
+
 
 
 


### PR DESCRIPTION
Add a search keyword field to the i-beam pages to ensure they show at the top for a direct search:

```html
<!-- Hidden search keywords -->
<div style="display: none;">
  900⌶
</div>
```

Closes: #187 