### PR TITLE
Operator syntax headings

### DIFF
--- a/language-reference-guide/docs/primitive-operators/atop.md
+++ b/language-reference-guide/docs/primitive-operators/atop.md
@@ -19,7 +19,7 @@ If `X` is omitted, `g` must be a monadic function. If `X` is specified, `g` must
 The derived function is equivalent to `fgY` or `fXgY` and need not return a result.
 
 
-The Atop operator allows functions to be *glued* together to build up more complex functions. For further information, see [Function Composition](./operator-syntax.md).
+The Atop operator allows functions to be *glued* together to build up more complex functions. For further information, see [Function Composition](../operator-syntax#function-composition).
 
 <h2 class="example">Examples</h2>
 ```apl

--- a/language-reference-guide/docs/primitive-operators/beside.md
+++ b/language-reference-guide/docs/primitive-operators/beside.md
@@ -16,7 +16,7 @@ If `X` is omitted, `f` must be a monadic function. If `X` is specified, `f` must
 The derived function is equivalent to `fgY` or `XfgY` and need not return a result.
 
 
-The Beside operator allows functions to be glued together to build up more complex functions. For further information, see [Function Composition](./operator-syntax.md).
+The Beside operator allows functions to be glued together to build up more complex functions. For further information, see [Function Composition](../operator-syntax#function-composition).
 
 
 <h2 class="example">Examples</h2>

--- a/language-reference-guide/docs/primitive-operators/operator-syntax.md
+++ b/language-reference-guide/docs/primitive-operators/operator-syntax.md
@@ -2,11 +2,11 @@
 
 Operators take one or two operands.  An operator with one operand is monadic.  The operand of a monadic operator is to the left of the operator.  An operator with two operands is dyadic.  Both operands are required for a dyadic operator.
 
-Operators have long scope to the left.  That is, the left operand is the longest function or array expression to its left (see [Programmer's Guide: "Operators"](../../../programming-reference-guide/introduction/operators)).  A dyadic operator has short scope on the right.  Right scope may be extended by the use of parentheses.
+Operators have long scope to the left.  That is, the left operand is the longest function or array expression to its left (see [Programmer's Guide: "Operators"](../../../programming-reference-guide/introduction/operators)). A dyadic operator has short scope on the right.  Right scope may be extended by the use of parentheses.
 
-An operand may be an array, a primitive function, a system function, a defined function or a derived function.  An array may be the result of an array expression.
+An operand may be an array, a primitive function, a system function, a defined function or a derived function. An array may be the result of an array expression.
 
-An operator with its operand(s) forms a derived function.  The derived function may be monadic or dyadic and it may or may not return an explicit result.
+An operator with its operand(s) forms a derived function. The derived function may be monadic or dyadic and it may or may not return an explicit result.
 
 <h2 class="example">Examples</h2>
 ```apl
@@ -26,7 +26,7 @@ X
       ⎕NL 2
 ```
 
-# Monadic Operators
+## Monadic Operators
 
 Like primitive functions, monadic operators can be:
 
@@ -50,7 +50,7 @@ Like primitive functions, monadic operators can be:
 1
 ```
 
-# Right Operand Currying
+## Right Operand Currying
 
 A dyadic operator may be bound or *curried* with its right operand to form a monadic operator:
 
@@ -66,10 +66,10 @@ A dyadic operator may be bound or *curried* with its right operand to form a mon
 1.61803
 ```
 
-# Function Composition
+## Function Composition
 
 Function composition refers to the "gluing" together of two functions using a dyadic operator such that the functions are applied to the argument(s) as normal, but in a particular pattern specific to the operator that is being used. The term function composition comes from traditional mathematics where it is used for a function `h(x)=f(g(x))` when written as  `h(x)=(f∘g)(x)` APL generalises this idea to dyadic functions, allowing various patterns of application in addition to the simple application of one monadic function to the result of another monadic function. The three main patterns, represented by Atop, Beside, and Over can be visualised as follows:
 
-![compositions](../img/compositions.png)
+![](../img/compositions.png)
 
 When any of these are applied monadically, the dotted branch falls away, and they are all equivalent to each other and to `h(x)=(f∘g)(x)` of traditional mathematics.

--- a/language-reference-guide/docs/primitive-operators/over.md
+++ b/language-reference-guide/docs/primitive-operators/over.md
@@ -9,7 +9,7 @@ If `X` is omitted, `f` must be a monadic function. If `X` is specified, `f` must
 
 The derived function is equivalent to `fgY` or `(gX)f(gY)` and need not return a result.
 
-The Over operator allows functions to be *glued* together to build up more complex functions. For further information, see [Function Composition](./operator-syntax.md).
+The Over operator allows functions to be *glued* together to build up more complex functions. For further information, see [Function Composition](../operator-syntax#function-composition).
 
 <h2 class="example">Examples</h2>
 ```apl


### PR DESCRIPTION
The operator syntax page had bad headings 

- Change H1s to H2
- Change combinator pages to refer to the Function Composition section, not the page itself

Closes: #190 