### PR TITLE
Highlight default option for ⎕NDELETE in table

### DIFF
--- a/language-reference-guide/docs/system-functions/ndelete.md
+++ b/language-reference-guide/docs/system-functions/ndelete.md
@@ -7,7 +7,7 @@ This function deletes files and directories.
 The optional left argument `X` is a numeric scalar; valid values are  shown in the following table. If omitted, its default value is 0.
 
 |---|------------------------------------------------------------------------------------------|
-|`0`|Each file or directory with the given name must exist.                                    |
+|0 { .shaded } |Each file or directory with the given name must exist.                                    |
 |`1`|If the file or directory with the given name does not exist then no action is taken. The result `R` may be used to determine whether the file or directory was deleted or not.|
 |`2`|If a name identifies a non-empty directory it, and all its contents, are to be deleted.   |
 |`3`|Combination of 1 and 2.                                                                   |


### PR DESCRIPTION
The table for `⎕NDELETE` options did not highlight the default.

Closes: #185 