### PR TITLE
Remove TOC entry for array editor for PDF

### DIFF
--- a/windows-ui-guide/print_mkdocs.yml
+++ b/windows-ui-guide/print_mkdocs.yml
@@ -62,7 +62,6 @@ nav:
   - Value Tips: value-tips.md
   - Value Tips for External Functions: value-tips-external.md
   - Configuring Value Tips: value-tips-configuring.md
-  - Array Editor: array-editor.md
   - Session GUI: session-gui.md
   - Session MenuBar: session-menubar.md
   - Session Popup Menu: session-popup-menu.md


### PR DESCRIPTION
Remove array editor TOC entry in the print_mkdocs.yml file, as the page no longer exists.