### PR TITLE
Fix significant spacing in examples column of 1200I

### DIFF
--- a/language-reference-guide/docs/the-i-beam-operator/format-datetime.md
+++ b/language-reference-guide/docs/the-i-beam-operator/format-datetime.md
@@ -25,7 +25,7 @@ more times to indicate format. As noted below, some sequences allow the first ch
 <table>
     <thead>
         <tr>
-            <th class="text-left">letter</th>
+            <th class="text-left">Format letter</th>
             <th class="text-left">Length</th>
             <th class="text-left">Meaning</th>
             <th class="text-left">Variations</th>
@@ -59,18 +59,18 @@ more times to indicate format. As noted below, some sequences allow the first ch
             <td class="Dyalog">MM</td>
             <td>2 character numeric</td>
             <td class="Dyalog">MM<br />_M</td>
-            <td class="Dyalog">03<br />3</td>
+            <td class="Dyalog">03<br />&nbsp;3</td>
         </tr>
         <tr>
             <td class="Dyalog">MMM</td>
             <td>Abbreviated name</td>
-            <td class="Dyalog">MMM<br />Mmm<br />mmm<br />_mm</td>
+            <td class="Dyalog">MMM<br />Mmm<br />mmm<br />_mm<sup>1</sup></td>
             <td class="Dyalog">MAR<br />Mar<br />mar<br />Mar</td>
         </tr>
         <tr>
             <td class="Dyalog">MMMM </td>
             <td>Full name </td>
-            <td class="Dyalog">MMMM<br />Mmmm<br />mmmm<br />_mmm</td>
+            <td class="Dyalog">MMMM<br />Mmmm<br />mmmm<br />_mmm<sup>1</sup></td>
             <td class="Dyalog">MARCH<br />March<br />march<br />March</td>
         </tr>
         <tr>
@@ -85,7 +85,7 @@ more times to indicate format. As noted below, some sequences allow the first ch
             <td class="Dyalog">DD</td>
             <td>2 character numeric</td>
             <td class="Dyalog">DD<br />_D</td>
-            <td class="Dyalog">04<br />4</td>
+            <td class="Dyalog">04<br />&nbsp;4</td>
         </tr>
         <tr>
             <td rowspan="2" style="vertical-align: middle;">
@@ -99,7 +99,7 @@ more times to indicate format. As noted below, some sequences allow the first ch
             <td class="Dyalog">hh</td>
             <td>2 character numeric</td>
             <td class="Dyalog">hh<br />_h</td>
-            <td class="Dyalog">08<br />8</td>
+            <td class="Dyalog">08<br />&nbsp;8</td>
         </tr>
         <tr>
             <td rowspan="2" style="vertical-align: middle;">
@@ -113,7 +113,7 @@ more times to indicate format. As noted below, some sequences allow the first ch
             <td class="Dyalog">mm</td>
             <td>2 character numeric</td>
             <td class="Dyalog">mm<br />_m</td>
-            <td class="Dyalog">05<br />5</td>
+            <td class="Dyalog">05<br />&nbsp;5</td>
         </tr>
         <tr>
             <td rowspan="2" style="vertical-align: middle;">
@@ -127,7 +127,7 @@ more times to indicate format. As noted below, some sequences allow the first ch
             <td class="Dyalog">ss </td>
             <td>2 character numeric </td>
             <td class="Dyalog">ss<br />_s</td>
-            <td class="Dyalog">00<br />0</td>
+            <td class="Dyalog">00<br />&nbsp;0</td>
         </tr>
         <tr>
             <td rowspan="6" style="vertical-align: middle;">
@@ -178,13 +178,13 @@ more times to indicate format. As noted below, some sequences allow the first ch
         <tr>
             <td class="Dyalog">ddd</td>
             <td>Abbreviated name</td>
-            <td class="Dyalog">DDD<br />Ddd<br />ddd<br />_dd</td>
+            <td class="Dyalog">DDD<br />Ddd<br />ddd<br />_dd<sup>1</sup></td>
             <td class="Dyalog">MON<br />Mon<br />mon<br />Mon</td>
         </tr>
         <tr>
             <td class="Dyalog">dddd</td>
             <td>Full name</td>
-            <td class="Dyalog">DDDD<br />Dddd<br />dddd<br />_ddd</td>
+            <td class="Dyalog">DDDD<br />Dddd<br />dddd<br />_ddd<sup>1</sup></td>
             <td class="Dyalog">MONDAY<br />Monday<br />monday<br />Monday</td>
         </tr>
         <tr>
@@ -201,7 +201,7 @@ more times to indicate format. As noted below, some sequences allow the first ch
             <td class="Dyalog">10<br />10</td>
         </tr>
         <tr>
-            <td rowspan="2" style="vertical-align: middle;">year of ISO<br /><ins>W</ins>eek<br />number</td>
+            <td rowspan="2" style="vertical-align: middle;">year of ISO<br /><ins>W</ins>eek<br />number<sup>2</sup></td>
             <td class="Dyalog">WW</td>
             <td>Without century</td>
             <td class="Dyalog">WW</td>
@@ -224,11 +224,11 @@ more times to indicate format. As noted below, some sequences allow the first ch
             <td class="Dyalog">yy</td>
             <td>3 character numeric</td>
             <td class="Dyalog">yy<br />_y</td>
-            <td class="Dyalog">063<br />63</td>
+            <td class="Dyalog">063<br />&nbsp;63</td>
         </tr>
         <tr>
             <td rowspan="2" style="vertical-align: middle;">
-                <ins>O</ins>rdinal indicator<br />for day of month</td>
+                <ins>O</ins>rdinal indicator<sup>3</sup><br />for day of month</td>
             <td class="Dyalog">O</td>
             <td>Short</td>
             <td class="Dyalog">O<br />o</td>
@@ -251,7 +251,7 @@ more times to indicate format. As noted below, some sequences allow the first ch
             <td class="Dyalog">tt</td>
             <td>2 character numeric</td>
             <td class="Dyalog">tt<br />_t</td>
-            <td class="Dyalog">08<br /></td>
+            <td class="Dyalog">08<br />&nbsp;8</td>
         </tr>
         <tr>
             <td rowspan="2">AM/<ins>P</ins>M Indicator</td>
@@ -268,6 +268,18 @@ more times to indicate format. As noted below, some sequences allow the first ch
         </tr>
     </tbody>
 </table>
+
+**Footnotes**
+
+1. Natural sentence case, which may be specified for M(month name) and d(day
+name) only, causes the text to be substituted in the case which is natural for
+the language; some languages (for example, English) always capitalise the
+first letter of day and month names whereas others (for example, French) do
+not.
+2. Dates at the start of the year may be in the final week of the previous year,
+and dates at the end of the year may be in the first week of the following year.
+3. An ordinal indicator is a character or group of characters following a numeral,
+such as (in English) the suffixes -st, -nd, -rd, -th as in 1st, 2nd, 3rd, 4th.
 
 The upper and lower case letters, underscore `_`, dollar `$` and percent `%` are all reserved for introducing format
 sequences, even though not all currently have meaning. The remaining, non-reserved, characters are copied to the result


### PR DESCRIPTION
The main table on the 1200⌶ had several errors:

- Significant leading spaces in the examples column for formatting options with a leading underscore was lost (also a problem in the v19 "old" docs) - added
- The example for "hours in twelve hour clock" for "tt" was missing a cell " 8" (note leading space) - added
- The footnotes could not be converted to appear in a HTML table easily using the mkdocs feature -- added as static section

References: #225 #230 
