### PR TITLE
Correct typo in ⎕NTIE documentation

### DIFF
--- a/language-reference-guide/docs/system-functions/ntie.md
+++ b/language-reference-guide/docs/system-functions/ntie.md
@@ -72,7 +72,7 @@ ntie←{                  ⍝ tie file and return tie no.
 ```
 
 !!! note
-    If the native file is already tied, executing `⎕NTIE` with the same or a different tie number simply re-ties it with the same or the new tie number. Re-tying a file with a tie number of 0, re-ties it with the same tie number. This feature may be used to re--tie the file using a different mode.
+    If the native file is already tied, executing `⎕NTIE` with the same or a different tie number simply re-ties it with the same or the new tie number. Re-tying a file with a tie number of 0, re-ties it with the same tie number. This feature can be used to re-tie the file using a different mode.
 
 
 


### PR DESCRIPTION
Correct typo in ⎕NTIE documentation

References #265 