### PR TITLE
Correct profanity filter example

### DIFF
--- a/language-reference-guide/docs/system-functions/r.md
+++ b/language-reference-guide/docs/system-functions/r.md
@@ -697,7 +697,7 @@ Output file:
       out (dateptn valptn ⎕R f) in
       ⎕nuntie¨in out
 ```
-Create a simple profanity filter:
+## Create a simple profanity filter:
 
 For the list of objectionable words
 ```apl

--- a/language-reference-guide/docs/system-functions/r.md
+++ b/language-reference-guide/docs/system-functions/r.md
@@ -697,8 +697,9 @@ Output file:
       out (dateptn valptn ⎕R f) in
       ⎕nuntie¨in out
 ```
+Create a simple profanity filter:
 
-## Create a simple profanity filter. For the list of objectionable words
+For the list of objectionable words
 ```apl
        profanity←'bleeding' 'heck'
 ```


### PR DESCRIPTION
Header text accidentally contained following paragraph text - remove this

References #217 