### PR TITLE
Correct ⎕ninfo heading levels

### DIFF
--- a/language-reference-guide/docs/system-functions/ninfo.md
+++ b/language-reference-guide/docs/system-functions/ninfo.md
@@ -98,7 +98,7 @@ In the Unicode Edition, if the UTF-8 encoding is invalid, Dyalog replaces each o
 
 In the Classic Edition, offending bytes are replaced by the `?` symbol, which means that the names reported do not accurately identify the files.
 
-## <h2 class="example">Examples</h2>
+<h2 class="example">Examples</h2>
 ```apl
 
       (0 1 2) ⎕NINFO 'c:/Users/Pete/Documents'

--- a/language-reference-guide/docs/system-functions/ninfo.md
+++ b/language-reference-guide/docs/system-functions/ninfo.md
@@ -98,7 +98,7 @@ In the Unicode Edition, if the UTF-8 encoding is invalid, Dyalog replaces each o
 
 In the Classic Edition, offending bytes are replaced by the `?` symbol, which means that the names reported do not accurately identify the files.
 
-<h2 class="example">Examples</h2>
+## <h2 class="example">Examples</h2>
 ```apl
 
       (0 1 2) ⎕NINFO 'c:/Users/Pete/Documents'

--- a/language-reference-guide/docs/system-functions/ninfo.md
+++ b/language-reference-guide/docs/system-functions/ninfo.md
@@ -11,30 +11,6 @@ This function queries or sets information about one or more files or directories
 - a character vector or scalar containing a file or directory name that conforms to the naming rules of the host Operating System.
 - a vector of character vectors and/or tie numbers
 
-## Variant Options
-
-`⎕NINFO` may be applied using the _variant_ operator with the options **Wildcard** (the Principal option), **Recurse**, **Follow** and **ProgressCallback**.
-
-## Wildcard Option (Boolean)
-
-|---|---|
-|0 { .shaded } |The name or names in `Y` identifies a specific file name.|
-|`1`|The name or names in `Y` that specify the *base name* and *extension* (see [NParts](./nparts.md) ), may also contain the wildcard characters "?" and "*". An asterisk is a substitute for any 0 or more characters in a file name or extension; a question-mark is a substitute for any single character.|
-
-## Recurse Option
-
-|---|---|
-|0 { .shaded } |the name(s) in `Y` are searched for only in the corresponding specified directory.|
-|`1`|the name(s) in `Y` are searched for in the corresponding specified directory as well as all sub-directories. If **Wildcard** is also 1, the wild card search is performed recursively.|
-|`1 n`|the name(s) in `Y` are searched for in the corresponding specified directory as well as its sub-directories to the n <sup>th</sup> -level sub-directory. If n is 0, no sub-directories are searched. If n is `¯1` all sub-directories are searched.|
-|`2 (n)`|same as 1 but if any unreadable directories are encountered they are skipped (whereas if **Recurse** is `1 (n)` , `⎕NINFO` stops and generates an error).|
-
-## Follow Option (Boolean)
-
-|---|----------------------------------------------------------------------------------------|
-|`0`|the properties reported are those of the symbolic link itself                           |
-|1 { .shaded } |the properties reported for a symbolic link are those of the target of the symbolic link|
-
 Optionally, `X` specifies properties of the files/directories identifed in `Y`. `X` can be an array of any shape; the shape determines whether the specified properties are queried or set:
 
 - If `X` is a simple numeric array, the properties are queried. In this case, the values of `X` correspond to properties of the file/directory specified in `Y` that are to be queried, as defined in the following table.
@@ -82,7 +58,32 @@ If the Wildcard option is enabled, zero or more files and/or directories may mat
 
 When using the **Wildcard** option, matching of names is done case insensitively on Windows and macOS, and case sensitively on other platforms. The names '.' and '..' are excluded from any matches. The order in which the names match is not defined.
 
-## ProgressCallback Option
+## Variant Options
+
+`⎕NINFO` may be applied using the _variant_ operator with the options **Wildcard** (the Principal option), **Recurse**, **Follow** and **ProgressCallback**.
+
+### Wildcard Option (Boolean)
+
+|---|---|
+|0 { .shaded } |The name or names in `Y` identifies a specific file name.|
+|`1`|The name or names in `Y` that specify the *base name* and *extension* (see [NParts](./nparts.md) ), may also contain the wildcard characters "?" and "*". An asterisk is a substitute for any 0 or more characters in a file name or extension; a question-mark is a substitute for any single character.|
+
+### Recurse Option
+
+|---|---|
+|0 { .shaded } |the name(s) in `Y` are searched for only in the corresponding specified directory.|
+|`1`|the name(s) in `Y` are searched for in the corresponding specified directory as well as all sub-directories. If **Wildcard** is also 1, the wild card search is performed recursively.|
+|`1 n`|the name(s) in `Y` are searched for in the corresponding specified directory as well as its sub-directories to the n <sup>th</sup> -level sub-directory. If n is 0, no sub-directories are searched. If n is `¯1` all sub-directories are searched.|
+|`2 (n)`|same as 1 but if any unreadable directories are encountered they are skipped (whereas if **Recurse** is `1 (n)` , `⎕NINFO` stops and generates an error).|
+
+### Follow Option (Boolean)
+
+|---|----------------------------------------------------------------------------------------|
+|`0`|the properties reported are those of the symbolic link itself                           |
+|1 { .shaded } |the properties reported for a symbolic link are those of the target of the symbolic link|
+
+
+### ProgressCallback Option
 
 The **ProgressCallback** variant option is described in the [Dyalog Programming Reference Guide](../../../programming-reference-guide/native-files#progress-callbacks). The following is specific to `⎕NINFO`:
 


### PR DESCRIPTION
As #248 shows, the variant sections in ⎕NINFO needed moving to prevent confusion with the argument description.