### PR TITLE
Help for DT has a stray "{: .bigtable }" in table on time numbers

### DIFF
--- a/language-reference-guide/docs/system-functions/dt.md
+++ b/language-reference-guide/docs/system-functions/dt.md
@@ -68,7 +68,6 @@ If a value in `X` is positive it indicates that a time number type is expected i
 |Decimal encoded[^9]     |60|Floating-point decimal encoded format Digits take the form yyyymmdd.hhmmss|Encoded broken-down time 1s resolution|N/A|No|
 |_                      _|61|Integer decimal encoded format Digits take the form yyyymmddhhmmss(J digit time)|Encoded broken-down time 1s resolution|N/A|No|
 |Misc. Operating Systems |70|AmigaOS|Tick count 1ms ticks[^2]|1978-01-01 00:00|No|
-{: .bigtable }
 
 ## Time Stamps
 


### PR DESCRIPTION
As #177 states, there's a stray "{: .bigtable }" in dt.md - remove it.