### PR TITLE
Move note regarding APs on from mondaic to dyadic form of ⎕SH

### DIFF
--- a/language-reference-guide/docs/system-functions/execute-unix-command.md
+++ b/language-reference-guide/docs/system-functions/execute-unix-command.md
@@ -42,8 +42,3 @@ bin:!:2:2::/bin:
 ## Note
 
 This function is disabled and instead generates a `DOMAIN ERROR` if the RIDE_SPAWNED parameter is non-zero. This is designed to prevent it being invoked from a Ride session which does not support this type of user interface. For further details, see the [Ride User Guide](https://dyalog.github.io/ride).
-
-
-Under macOS and Linux, if the configuration parameter **ENABLE_CEF** is 1, Auxiliary Processors cannot be used (they hang on error). The default value is 1 unless you are not running under a desktop (for example, you are running Dyalog in a PuTTY session when the default is 0).
-
-

--- a/language-reference-guide/docs/system-functions/start-unix-auxiliary-processor.md
+++ b/language-reference-guide/docs/system-functions/start-unix-auxiliary-processor.md
@@ -49,3 +49,6 @@ The syntax of dyadic `⎕SH` is similar to the UNIX execl(2) system call, where 
 ```
 
 
+## Note
+
+Under macOS and Linux, if the configuration parameter **ENABLE_CEF** is 1, Auxiliary Processors cannot be used (they hang on error). The default value is 1 unless you are not running under a desktop (for example, you are running Dyalog in a PuTTY session when the default is 0).

--- a/language-reference-guide/docs/system-functions/start-unix-auxiliary-processor.md
+++ b/language-reference-guide/docs/system-functions/start-unix-auxiliary-processor.md
@@ -49,6 +49,6 @@ The syntax of dyadic `⎕SH` is similar to the UNIX execl(2) system call, where 
 ```
 
 
-## Note
+!!! Warning "Warning"
 
-Under macOS and Linux, if the configuration parameter **ENABLE_CEF** is 1, Auxiliary Processors cannot be used (they hang on error). The default value is 1 unless you are not running under a desktop (for example, you are running Dyalog in a PuTTY session when the default is 0).
+	Under macOS and Linux, if the configuration parameter **ENABLE_CEF** is 1, Auxiliary Processors cannot be used (they hang on error). The default value is 1 unless you are not running under a desktop (for example, you are running Dyalog in a PuTTY session when the default is 0).


### PR DESCRIPTION
As #258 states, the note stating that APs and CEF don't work together is on the wrong page.
