### PR TITLE
Add ⋄ as prefix for editing array notation

### DIFF
--- a/language-reference-guide/docs/system-commands/ed.md
+++ b/language-reference-guide/docs/system-commands/ed.md
@@ -32,6 +32,7 @@ The type of a new object may be specified explicitly by preceding its name with 
 |`⍟`|Namespace script           |
 |`○`|Class script               |
 |`∘`|Interface                  |
+|`⋄`|Array Notation             |
 
 
 

--- a/language-reference-guide/docs/system-functions/ed.md
+++ b/language-reference-guide/docs/system-functions/ed.md
@@ -23,6 +23,7 @@
 |`⍟`|Namespace script           |
 |`○`|Class script               |
 |`∘`|Interface                  |
+|`⋄`|Array Notation             |
 
 
 


### PR DESCRIPTION
Add ⋄ to the prefix tables for `)ED` and `⎕ED`

References #227 