### PR TITLE
Add synonyms to the primitive functions and operator pages

### DIFF
--- a/language-reference-guide/docs/primitive-functions/abort.md
+++ b/language-reference-guide/docs/primitive-functions/abort.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  →
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/add.md
+++ b/language-reference-guide/docs/primitive-functions/add.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  +
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/and-lowest-common-multiple.md
+++ b/language-reference-guide/docs/primitive-functions/and-lowest-common-multiple.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ^
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/assignment-indexed.md
+++ b/language-reference-guide/docs/primitive-functions/assignment-indexed.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ←
+</div>
+
 <h1 class="heading"><span class="name">Assignment (Indexed)</span> <span class="command">{R}←X[I]←Y</span></h1>
 
 Indexed Assignment is the Assignment function modified by the Indexing function.  The phrase `[I]←` is treated as the function for descriptive purposes.

--- a/language-reference-guide/docs/primitive-functions/assignment-selective.md
+++ b/language-reference-guide/docs/primitive-functions/assignment-selective.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ←
+</div>
+
 <h1 class="heading"><span class="name">Assignment (Selective)</span> <span class="command">(EXP X)←Y</span></h1>
 
 `X` is the *name* of a variable in the workspace, possibly modified by the indexing function `(EXP X[I])←Y`, see [Assignment (Indexed)](assignment-indexed.md).  `EXP` is an expression that **selects** elements of `X`.  `Y` is an array expression. The result of the expression `Y` is allocated to the elements of `X` selected by `EXP`. Note that `X` may refer to a single name only.

--- a/language-reference-guide/docs/primitive-functions/assignment.md
+++ b/language-reference-guide/docs/primitive-functions/assignment.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ←
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/axis.md
+++ b/language-reference-guide/docs/primitive-functions/axis.md
@@ -1,8 +1,3 @@
----
-search:
-  exclude: true
----
-
 <h1 class="heading"><span class="name">Axis Operator</span></h1>
 
 The axis operator may be applied to all scalar dyadic primitive functions and certain mixed primitive functions.  An integer axis identifies a specific axis along which the function is to be applied to one or both of its arguments.  If the primitive function is to be applied without an axis specification, a default axis is implied, either the first or last.

--- a/language-reference-guide/docs/primitive-functions/binomial.md
+++ b/language-reference-guide/docs/primitive-functions/binomial.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  !
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/branch.md
+++ b/language-reference-guide/docs/primitive-functions/branch.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  →
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/catenate-first.md
+++ b/language-reference-guide/docs/primitive-functions/catenate-first.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍪
+</div>
+
 <h1 class="heading"><span class="name">Catenate First</span> <span class="command">R←X⍪[K]Y</span></h1>
 
 The form `R←X⍪Y` implies catenation along the first axis whereas the form `R←X,Y` implies catenation along the last axis (columns).  See [Catenate/Laminate](catenate-laminate.md).

--- a/language-reference-guide/docs/primitive-functions/catenate-laminate.md
+++ b/language-reference-guide/docs/primitive-functions/catenate-laminate.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ,
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/ceiling.md
+++ b/language-reference-guide/docs/primitive-functions/ceiling.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⌈
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/circular.md
+++ b/language-reference-guide/docs/primitive-functions/circular.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ○
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/conjugate.md
+++ b/language-reference-guide/docs/primitive-functions/conjugate.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  +
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/deal.md
+++ b/language-reference-guide/docs/primitive-functions/deal.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ?
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/decode.md
+++ b/language-reference-guide/docs/primitive-functions/decode.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⊥
+</div>
+
 <h1 class="heading"><span class="name">Decode</span> <span class="command">R←X⊥Y</span></h1>
 
 `Y` must be a simple numeric array.  `X` must be a simple numeric array.  `R` is the numeric array which results from

--- a/language-reference-guide/docs/primitive-functions/depth.md
+++ b/language-reference-guide/docs/primitive-functions/depth.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ≡
+</div>
+
 <h1 class="heading"><span class="name">Depth</span> <span class="command">(⎕ML) R←≡Y</span></h1>
 
 `Y` may be any array. `R` is the maximum number of levels of nesting of `Y`. A simple scalar (rank-0 number, character or namespace-reference) has a depth of 0.

--- a/language-reference-guide/docs/primitive-functions/direction.md
+++ b/language-reference-guide/docs/primitive-functions/direction.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ×
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/disclose.md
+++ b/language-reference-guide/docs/primitive-functions/disclose.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ↑
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/divide.md
+++ b/language-reference-guide/docs/primitive-functions/divide.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ÷
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/drop-with-axes.md
+++ b/language-reference-guide/docs/primitive-functions/drop-with-axes.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ↓
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/drop.md
+++ b/language-reference-guide/docs/primitive-functions/drop.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ↓
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/enclose-with-axes.md
+++ b/language-reference-guide/docs/primitive-functions/enclose-with-axes.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⊂
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/enclose.md
+++ b/language-reference-guide/docs/primitive-functions/enclose.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⊂
+</div>
+
 <h1 class="heading"><span class="name">Enclose</span> <span class="command">R←⊂Y</span></h1>
 
 `Y` may be any array.  `R` is a scalar array whose item is the array `Y`.  If `Y` is a simple scalar, `R` is the simple scalar unchanged.  Otherwise, `R` has a depth whose magnitude is one greater than the magnitude of the depth of `Y`.

--- a/language-reference-guide/docs/primitive-functions/encode.md
+++ b/language-reference-guide/docs/primitive-functions/encode.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⊤
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/enlist.md
+++ b/language-reference-guide/docs/primitive-functions/enlist.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ∊
+</div>
+
 <h1 class="heading"><span class="name">Enlist</span> <span class="command">(⎕ML≥1) R←∊Y</span></h1>
 
 Migration level must be such that `⎕ML≥1` (otherwise see [Type](type.md)).

--- a/language-reference-guide/docs/primitive-functions/equal.md
+++ b/language-reference-guide/docs/primitive-functions/equal.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  =
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/excluding.md
+++ b/language-reference-guide/docs/primitive-functions/excluding.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ~
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/execute.md
+++ b/language-reference-guide/docs/primitive-functions/execute.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍎
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/expand-first.md
+++ b/language-reference-guide/docs/primitive-functions/expand-first.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍀
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/expand.md
+++ b/language-reference-guide/docs/primitive-functions/expand.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  \
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/exponential.md
+++ b/language-reference-guide/docs/primitive-functions/exponential.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  *
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/factorial.md
+++ b/language-reference-guide/docs/primitive-functions/factorial.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  !
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/find.md
+++ b/language-reference-guide/docs/primitive-functions/find.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍷
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/first.md
+++ b/language-reference-guide/docs/primitive-functions/first.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ↑
+</div>
+
 <h1 class="heading"><span class="name">First</span> <span class="command">(⎕ML) R←⊃Y or R←↑Y</span></h1>
 
 See function [Disclose](disclose.md).

--- a/language-reference-guide/docs/primitive-functions/floor.md
+++ b/language-reference-guide/docs/primitive-functions/floor.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⌊
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/format-dyadic.md
+++ b/language-reference-guide/docs/primitive-functions/format-dyadic.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍕
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/format-monadic.md
+++ b/language-reference-guide/docs/primitive-functions/format-monadic.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍕
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/grade-down-dyadic.md
+++ b/language-reference-guide/docs/primitive-functions/grade-down-dyadic.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍒
+</div>
+
 <h1 class="heading"><span class="name">Grade Down (Dyadic)</span> <span class="command">R←X⍒Y</span></h1>
 
 `Y` must be a simple character array of rank greater than 0.  `X` must be a simple character array of rank 1 or greater.  `R` is a simple integer vector of shape `1↑⍴Y` containing the permutation of `⍳1↑⍴Y` that places the sub-arrays of `Y` along the first axis in descending order according to the collation sequence `X`.  The indices of any set of identical sub-arrays in `Y` occur in `R` in ascending order.

--- a/language-reference-guide/docs/primitive-functions/grade-down-monadic.md
+++ b/language-reference-guide/docs/primitive-functions/grade-down-monadic.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍒
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/grade-up-dyadic.md
+++ b/language-reference-guide/docs/primitive-functions/grade-up-dyadic.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍋
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/grade-up-monadic.md
+++ b/language-reference-guide/docs/primitive-functions/grade-up-monadic.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍋
+</div>
+
 <h1 class="heading"><span class="name">Grade Up (Monadic)</span> <span class="command">R←⍋Y</span></h1>
 
 `Y` may be any array of rank greater than 0 but may not contain namespaces.  `R` is an integer vector being the permutation of `⍳1↑⍴Y` that places the sub-arrays along the first axis in ascending order. The rules for comparing items of `Y` with one another are as follows:

--- a/language-reference-guide/docs/primitive-functions/greater-or-equal.md
+++ b/language-reference-guide/docs/primitive-functions/greater-or-equal.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ≥
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/greater.md
+++ b/language-reference-guide/docs/primitive-functions/greater.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  >
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/identity.md
+++ b/language-reference-guide/docs/primitive-functions/identity.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⊢
+</div>
+
 ---
 search:
   exclude: true

--- a/language-reference-guide/docs/primitive-functions/index-generator.md
+++ b/language-reference-guide/docs/primitive-functions/index-generator.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍳
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/index-of.md
+++ b/language-reference-guide/docs/primitive-functions/index-of.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍳
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/index-with-axes.md
+++ b/language-reference-guide/docs/primitive-functions/index-with-axes.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⌷
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/indexing.md
+++ b/language-reference-guide/docs/primitive-functions/indexing.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ←
+</div>
+
 <h1 class="heading"><span class="name">Indexing</span> <span class="command">R←X[Y]</span></h1>
 
 `X` may be  any array. `Y` must be a valid index specification. `R` is an array composed of elements indexed from `X` and the shape of `X` is determined by the index specification.

--- a/language-reference-guide/docs/primitive-functions/intersection.md
+++ b/language-reference-guide/docs/primitive-functions/intersection.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ∩
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/interval-index.md
+++ b/language-reference-guide/docs/primitive-functions/interval-index.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍸
+</div>
+
 <h1 class="heading"><span class="name">Interval Index</span> <span class="command">R←X⍸Y</span></h1>
 
 !!! note "Classic Edition"

--- a/language-reference-guide/docs/primitive-functions/left.md
+++ b/language-reference-guide/docs/primitive-functions/left.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⊣
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/less-or-equal.md
+++ b/language-reference-guide/docs/primitive-functions/less-or-equal.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ≤
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/less.md
+++ b/language-reference-guide/docs/primitive-functions/less.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  <
+</div>
+
 <h1 class="heading"><span class="name">Less</span> <span class="command">R←X&lt;Y</span></h1>
 
 `Y` may be any numeric array.  `X` may be any numeric array.  `R` is Boolean.  `R` is 1 if `X` is less than `Y` and `X=Y` is 0.  Otherwise `R` is 0.

--- a/language-reference-guide/docs/primitive-functions/logarithm.md
+++ b/language-reference-guide/docs/primitive-functions/logarithm.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍟
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/magnitude.md
+++ b/language-reference-guide/docs/primitive-functions/magnitude.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  |
+</div>
+
 <h1 class="heading"><span class="name">Magnitude</span> <span class="command">R←|Y</span></h1>
 
 `Y` may be any numeric array. `R` is numeric composed of the absolute (unsigned) values of `Y`.

--- a/language-reference-guide/docs/primitive-functions/match.md
+++ b/language-reference-guide/docs/primitive-functions/match.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ≡
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/materialise.md
+++ b/language-reference-guide/docs/primitive-functions/materialise.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⌷
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/matrix-divide.md
+++ b/language-reference-guide/docs/primitive-functions/matrix-divide.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⌹
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/matrix-inverse.md
+++ b/language-reference-guide/docs/primitive-functions/matrix-inverse.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⌹
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/maximum.md
+++ b/language-reference-guide/docs/primitive-functions/maximum.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⌈
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/membership.md
+++ b/language-reference-guide/docs/primitive-functions/membership.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ∊
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/minimum.md
+++ b/language-reference-guide/docs/primitive-functions/minimum.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⌊
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/minus.md
+++ b/language-reference-guide/docs/primitive-functions/minus.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  -
+</div>
+
 <h1 class="heading"><span class="name">Minus</span> <span class="command">R←X-Y</span></h1>
 
 See [Subtract](subtract.md).

--- a/language-reference-guide/docs/primitive-functions/mix.md
+++ b/language-reference-guide/docs/primitive-functions/mix.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⊃
+</div>
+
 <h1 class="heading"><span class="name">Mix</span> <span class="command">(⎕ML) R←↑[K]Y or R←⊃[K]Y</span></h1>
 
 The symbol chosen to represent Mix depends on the current Migration Level.

--- a/language-reference-guide/docs/primitive-functions/multiply.md
+++ b/language-reference-guide/docs/primitive-functions/multiply.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ×
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/nand.md
+++ b/language-reference-guide/docs/primitive-functions/nand.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍲
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/natural-logarithm.md
+++ b/language-reference-guide/docs/primitive-functions/natural-logarithm.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍟
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/negative.md
+++ b/language-reference-guide/docs/primitive-functions/negative.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  -
+</div>
+
 <h1 id="negative" class="heading"><span class="name">Negative</span> <span class="command">R←-Y</span></h1>
 
 `Y` may be any numeric array. `R` is numeric and is the negative value of `Y`. For complex numbers both the real and imaginary parts are negated.

--- a/language-reference-guide/docs/primitive-functions/nest.md
+++ b/language-reference-guide/docs/primitive-functions/nest.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⊆
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/nor.md
+++ b/language-reference-guide/docs/primitive-functions/nor.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍱
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/not-equal.md
+++ b/language-reference-guide/docs/primitive-functions/not-equal.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ≠
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/not-match.md
+++ b/language-reference-guide/docs/primitive-functions/not-match.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ≢
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/not.md
+++ b/language-reference-guide/docs/primitive-functions/not.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ~
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/or-greatest-common-divisor.md
+++ b/language-reference-guide/docs/primitive-functions/or-greatest-common-divisor.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ∨
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/partitioned-enclose.md
+++ b/language-reference-guide/docs/primitive-functions/partitioned-enclose.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⊂
+</div>
+
 <h1 class="heading"><span class="name">Partitioned Enclose</span> <span class="command">(⎕ML<3) R←X⊂[K]Y</span></h1>
 
 `Y` may be any array.  `X` must be a simple integer scalar or vector. If `X` is a scalar it is extended to `(≢Y)⍴X`.

--- a/language-reference-guide/docs/primitive-functions/pi-times.md
+++ b/language-reference-guide/docs/primitive-functions/pi-times.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ○
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/pick.md
+++ b/language-reference-guide/docs/primitive-functions/pick.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⊃
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/plus.md
+++ b/language-reference-guide/docs/primitive-functions/plus.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  +
+</div>
+
 <h1 class="heading"><span class="name">Plus</span> <span class="command">R←X+Y</span></h1>
 
 See [Add](add.md).

--- a/language-reference-guide/docs/primitive-functions/power.md
+++ b/language-reference-guide/docs/primitive-functions/power.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  *
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/ravel-with-axes.md
+++ b/language-reference-guide/docs/primitive-functions/ravel-with-axes.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ,
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/ravel.md
+++ b/language-reference-guide/docs/primitive-functions/ravel.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ,
+</div>
+
 <h1 class="heading"><span class="name">Ravel</span> <span class="command">R←,Y</span></h1>
 
 `Y` may be any array.  `R` is a vector of the elements of `Y` taken in row-major order.

--- a/language-reference-guide/docs/primitive-functions/reciprocal.md
+++ b/language-reference-guide/docs/primitive-functions/reciprocal.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ÷
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/replicate-first.md
+++ b/language-reference-guide/docs/primitive-functions/replicate-first.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⌿
+</div>
+
 <h1 class="heading"><span class="name">Replicate First</span> <span class="command">R←X⌿[K]Y</span></h1>
 
 The form `R←X⌿Y` implies replication along the first axis of `Y`.  See [Replicate](replicate.md).

--- a/language-reference-guide/docs/primitive-functions/replicate.md
+++ b/language-reference-guide/docs/primitive-functions/replicate.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  /
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/reshape.md
+++ b/language-reference-guide/docs/primitive-functions/reshape.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍴
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/residue.md
+++ b/language-reference-guide/docs/primitive-functions/residue.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  |
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/reverse-first.md
+++ b/language-reference-guide/docs/primitive-functions/reverse-first.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⊖
+</div>
+
 <h1 class="heading"><span class="name">Reverse First</span> <span class="command">R←⊖[K]Y</span></h1>
 
 The form `R←⊖Y` implies reversal along the first axis.  See [Reverse](reverse.md).

--- a/language-reference-guide/docs/primitive-functions/reverse.md
+++ b/language-reference-guide/docs/primitive-functions/reverse.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⌽
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/right.md
+++ b/language-reference-guide/docs/primitive-functions/right.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⊢
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/roll.md
+++ b/language-reference-guide/docs/primitive-functions/roll.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ?
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/rotate-first.md
+++ b/language-reference-guide/docs/primitive-functions/rotate-first.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⊖
+</div>
+
 <h1 class="heading"><span class="name">Rotate First</span> <span class="command">R←X⊖[K]Y</span></h1>
 
 The form `R←X⊖Y` implies rotation along the first axis.  See [Rotate](rotate.md).

--- a/language-reference-guide/docs/primitive-functions/rotate.md
+++ b/language-reference-guide/docs/primitive-functions/rotate.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⌽
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/same.md
+++ b/language-reference-guide/docs/primitive-functions/same.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⊢
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/shape.md
+++ b/language-reference-guide/docs/primitive-functions/shape.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍴
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/split.md
+++ b/language-reference-guide/docs/primitive-functions/split.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ↓
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/squad.md
+++ b/language-reference-guide/docs/primitive-functions/squad.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⌷
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/subtract.md
+++ b/language-reference-guide/docs/primitive-functions/subtract.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  -
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/table.md
+++ b/language-reference-guide/docs/primitive-functions/table.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍪
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/take-with-axes.md
+++ b/language-reference-guide/docs/primitive-functions/take-with-axes.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ↑
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/take.md
+++ b/language-reference-guide/docs/primitive-functions/take.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ↑
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/tally.md
+++ b/language-reference-guide/docs/primitive-functions/tally.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ≢
+</div>
+
 <h1 class="heading"><span class="name">Tally</span> <span class="command">R←≢Y</span></h1>
 
 `Y` may be any array.  `R` is a simple numeric scalar.

--- a/language-reference-guide/docs/primitive-functions/times.md
+++ b/language-reference-guide/docs/primitive-functions/times.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ×
+</div>
+
 <h1 class="heading"><span class="name">Times</span> <span class="command">R←X×Y</span></h1>
 
 See [Multiply](multiply.md).

--- a/language-reference-guide/docs/primitive-functions/transpose-dyadic.md
+++ b/language-reference-guide/docs/primitive-functions/transpose-dyadic.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍉
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/transpose-monadic.md
+++ b/language-reference-guide/docs/primitive-functions/transpose-monadic.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍉
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/type.md
+++ b/language-reference-guide/docs/primitive-functions/type.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ∊
+</div>
+
 <h1 class="heading"><span class="name">Type</span> <span class="command">(⎕ML<1) R←∊Y</span></h1>
 
 Migration level must be such that `⎕ML<1` (otherwise `∊` means Enlist. See [Enlist](enlist.md)).

--- a/language-reference-guide/docs/primitive-functions/union.md
+++ b/language-reference-guide/docs/primitive-functions/union.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ∪
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/unique-mask.md
+++ b/language-reference-guide/docs/primitive-functions/unique-mask.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ≠
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/unique.md
+++ b/language-reference-guide/docs/primitive-functions/unique.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ∪
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/where.md
+++ b/language-reference-guide/docs/primitive-functions/where.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍸
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-functions/without.md
+++ b/language-reference-guide/docs/primitive-functions/without.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ~
+</div>
+
 <h1 class="heading"><span class="name">Without</span> <span class="command">R←X~Y</span></h1>
 
 See [Excluding](excluding.md).

--- a/language-reference-guide/docs/primitive-functions/zilde.md
+++ b/language-reference-guide/docs/primitive-functions/zilde.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍬
+</div>
+
 <h1 class="heading"><span class="name">Zilde</span> <span class="command">R←⍬</span></h1>
 
 The empty vector (`⍳0`) may be represented by the numeric constant `⍬` called ZILDE.

--- a/language-reference-guide/docs/primitive-operators/assignment-indexed-modified.md
+++ b/language-reference-guide/docs/primitive-operators/assignment-indexed-modified.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ←
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-operators/assignment-modified.md
+++ b/language-reference-guide/docs/primitive-operators/assignment-modified.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ←
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-operators/assignment-selective-modified.md
+++ b/language-reference-guide/docs/primitive-operators/assignment-selective-modified.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ←
+</div>
+
 <h1 class="heading"><span class="name">Assignment (Selective Modified)</span> <span class="command">{R}←(EXP X)f←Y</span></h1>
 
 `f` may be any dyadic function which returns an explicit result.  `Y` may be any array whose items are appropriate to function `f`.  `X` must be the *name* of an existing array.  `EXP` is an expression that **selects** elements of `X`. (See [Assignment (Selective)](../primitive-functions/assignment-selective.md) for a list of allowed selection functions.)  The selected elements of `X` must be appropriate to function `f`.

--- a/language-reference-guide/docs/primitive-operators/at.md
+++ b/language-reference-guide/docs/primitive-operators/at.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  @
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-operators/atop.md
+++ b/language-reference-guide/docs/primitive-operators/atop.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍤
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-operators/axis-with-dyadic-operand.md
+++ b/language-reference-guide/docs/primitive-operators/axis-with-dyadic-operand.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ←
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-operators/axis-with-monadic-operand.md
+++ b/language-reference-guide/docs/primitive-operators/axis-with-monadic-operand.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ←
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-operators/behind.md
+++ b/language-reference-guide/docs/primitive-operators/behind.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍛
+</div>
+
 <h1 class="heading"><span class="name">Behind</span> <span class="command">{R}←{X}f⍛gY</span></h1>
 
 !!! Info "Information"

--- a/language-reference-guide/docs/primitive-operators/beside.md
+++ b/language-reference-guide/docs/primitive-operators/beside.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ∘
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-operators/bind.md
+++ b/language-reference-guide/docs/primitive-operators/bind.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ∘
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-operators/commute.md
+++ b/language-reference-guide/docs/primitive-operators/commute.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍨
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-operators/constant.md
+++ b/language-reference-guide/docs/primitive-operators/constant.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍨
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-operators/each-with-dyadic-operand.md
+++ b/language-reference-guide/docs/primitive-operators/each-with-dyadic-operand.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ¨
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-operators/each-with-monadic-operand.md
+++ b/language-reference-guide/docs/primitive-operators/each-with-monadic-operand.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ¨
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-operators/i-beam-short.md
+++ b/language-reference-guide/docs/primitive-operators/i-beam-short.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⌶
+</div>
+
 <h1 class="heading"><span class="name">I-Beam</span> <span class="command">R←{X}(A⌶)Y</span></h1>
 
 I-Beam is a monadic operator that provides a range of system related services.

--- a/language-reference-guide/docs/primitive-operators/i-beam.md
+++ b/language-reference-guide/docs/primitive-operators/i-beam.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⌶
+</div>
+
 ---
 search:
   exclude: true

--- a/language-reference-guide/docs/primitive-operators/inner-product.md
+++ b/language-reference-guide/docs/primitive-operators/inner-product.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  .
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-operators/key.md
+++ b/language-reference-guide/docs/primitive-operators/key.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⌸
+</div>
+
 <h1 class="heading"><span class="name">Key</span> <span class="command">R←{X}f⌸Y</span></h1>
 
 !!! note "Classic Edition"

--- a/language-reference-guide/docs/primitive-operators/outer-product.md
+++ b/language-reference-guide/docs/primitive-operators/outer-product.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  .
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-operators/over.md
+++ b/language-reference-guide/docs/primitive-operators/over.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍥
+</div>
+
 <h1 class="heading"><span class="name">Over</span> <span class="command">{R}←{X}f⍥gY</span></h1>
 
 !!! note "Classic Edition"

--- a/language-reference-guide/docs/primitive-operators/power-operator.md
+++ b/language-reference-guide/docs/primitive-operators/power-operator.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍣
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-operators/rank.md
+++ b/language-reference-guide/docs/primitive-operators/rank.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍤
+</div>
+
 <h1 class="heading"><span class="name">Rank</span> <span class="command">R←{X}(f⍤B)Y</span></h1>
 
 !!! note "Classic Edition"

--- a/language-reference-guide/docs/primitive-operators/reduce-first-n-wise.md
+++ b/language-reference-guide/docs/primitive-operators/reduce-first-n-wise.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⌿
+</div>
+
 <h1 class="heading"><span class="name">Reduce First N-Wise</span> <span class="command">R←Xf⌿[K]Y</span></h1>
 
 The form `R←Xf⌿Y` implies N-Wise reduction along the first axis of `Y`. See [Reduce N-Wise](reduce-n-wise.md).

--- a/language-reference-guide/docs/primitive-operators/reduce-first.md
+++ b/language-reference-guide/docs/primitive-operators/reduce-first.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⌿
+</div>
+
 <h1 class="heading"><span class="name">Reduce First</span> <span class="command">R←f⌿Y</span></h1>
 
 The form `R←f⌿Y` implies reduction along the first axis of `Y`. See [Reduce](reduce.md) above.

--- a/language-reference-guide/docs/primitive-operators/reduce-n-wise.md
+++ b/language-reference-guide/docs/primitive-operators/reduce-n-wise.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  /
+</div>
+
 <h1 class="heading"><span class="name">Reduce N-Wise</span> <span class="command">R←Xf/[K]Y</span></h1>
 
 `f` must be a dyadic function. `X` must be a simple scalar or one-item integer array. `Y` may be any array whose sub-arrays along the `K`th axis are appropriate to function `f`.

--- a/language-reference-guide/docs/primitive-operators/reduce.md
+++ b/language-reference-guide/docs/primitive-operators/reduce.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  /
+</div>
+
 <h1 class="heading"><span class="name">Reduce</span> <span class="command">R←f/[K]Y</span></h1>
 
 `f` must be a dyadic function.  `Y` may be any array whose items in the sub-arrays along the `K`<sup>th</sup> axis are appropriate to function `f`.

--- a/language-reference-guide/docs/primitive-operators/scan-first.md
+++ b/language-reference-guide/docs/primitive-operators/scan-first.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍀
+</div>
+
 <h1 class="heading"><span class="name">Scan First</span> <span class="command">R←f⍀Y</span></h1>
 
 The form `R←f⍀Y` implies scan along the first axis of `Y`.  See [Scan](scan.md).

--- a/language-reference-guide/docs/primitive-operators/scan.md
+++ b/language-reference-guide/docs/primitive-operators/scan.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  \
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-operators/spawn.md
+++ b/language-reference-guide/docs/primitive-operators/spawn.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  &
+</div>
+
 
 
 

--- a/language-reference-guide/docs/primitive-operators/stencil.md
+++ b/language-reference-guide/docs/primitive-operators/stencil.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⌺
+</div>
+
 <h1 class="heading"><span class="name">Stencil</span> <span class="command">R←(f⌺g)Y</span></h1>
 
 !!! note "Classic Edition"

--- a/language-reference-guide/docs/primitive-operators/variant.md
+++ b/language-reference-guide/docs/primitive-operators/variant.md
@@ -1,3 +1,7 @@
+<div style="display: none;">
+  ⍠
+</div>
+
 <h1 class="heading"><span class="name">Variant</span> <span class="command">{R}←{X}(f⍠B)Y</span></h1>
 
 !!! note "Classic Edition"

--- a/tools/utils/add_synonyms.py
+++ b/tools/utils/add_synonyms.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Add APL symbol synonyms to markdown files.
+
+This script processes all .md files in a directory (non-recursively) and:
+1. Finds the first <h1> tag
+2. Checks if it has a <span class="command"> child
+3. Extracts any non-alphanumeric symbol from that span
+4. Adds a hidden div with the symbol at the beginning of the file
+"""
+
+import os
+import sys
+import argparse
+import re
+from bs4 import BeautifulSoup
+
+
+def extract_apl_symbol(html_content):
+    """
+    Extract APL symbol from the first h1 tag with a command span.
+    
+    Returns the symbol if found, None otherwise.
+    """
+    soup = BeautifulSoup(html_content, 'html.parser')
+    
+    # Find the first h1 tag
+    h1 = soup.find('h1')
+    if not h1:
+        return None
+    
+    # Check if h1 has a span with class "command"
+    command_span = h1.find('span', class_='command')
+    if not command_span:
+        return None
+    
+    # Get the text content
+    command_text = command_span.get_text()
+    
+    # Characters to ignore
+    ignore_chars = set('{}()[]\'"\' ')
+    
+    # Extract non-alphanumeric symbols (excluding the ignore list)
+    symbols = []
+    for char in command_text:
+        if not char.isalnum() and char not in ignore_chars:
+            symbols.append(char)
+    
+    # Return the last symbol found (if any)
+    if symbols:
+        return symbols[-1]
+    
+    return None
+
+
+def process_file(filepath, dry_run=False):
+    """
+    Process a single markdown file.
+    
+    Returns True if the file was modified (or would be modified in dry-run), False otherwise.
+    """
+    with open(filepath, 'r', encoding='utf-8') as f:
+        content = f.read()
+    
+    # Check if the file already has the hidden div
+    if content.startswith('<div style="display: none;">'):
+        print(f"  Skipping {os.path.basename(filepath)} - already has hidden div")
+        return False
+    
+    # Extract the APL symbol
+    symbol = extract_apl_symbol(content)
+    
+    if symbol:
+        if dry_run:
+            print(f"  Would add symbol '{symbol}' to {os.path.basename(filepath)}")
+        else:
+            # Create the hidden div
+            hidden_div = f'<div style="display: none;">\n  {symbol}\n</div>\n\n'
+            
+            # Add the div to the beginning of the file
+            new_content = hidden_div + content
+            
+            # Write the modified content back
+            with open(filepath, 'w', encoding='utf-8') as f:
+                f.write(new_content)
+            
+            print(f"  Added symbol '{symbol}' to {os.path.basename(filepath)}")
+        return True
+    else:
+        print(f"  No APL symbol found in {os.path.basename(filepath)}")
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Add APL symbol synonyms to markdown files'
+    )
+    parser.add_argument(
+        'directory',
+        help='Directory containing markdown files to process'
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Only list files that would be modified without making changes'
+    )
+    
+    args = parser.parse_args()
+    
+    # Validate directory
+    if not os.path.isdir(args.directory):
+        print(f"Error: '{args.directory}' is not a valid directory")
+        sys.exit(1)
+    
+    # Get all .md files in the directory (non-recursive)
+    md_files = [
+        os.path.join(args.directory, f)
+        for f in os.listdir(args.directory)
+        if f.endswith('.md') and os.path.isfile(os.path.join(args.directory, f))
+    ]
+    
+    if not md_files:
+        print(f"No .md files found in {args.directory}")
+        return
+    
+    if args.dry_run:
+        print(f"DRY RUN: Checking {len(md_files)} markdown files in {args.directory}...")
+    else:
+        print(f"Processing {len(md_files)} markdown files in {args.directory}...")
+    
+    modified_count = 0
+    for filepath in md_files:
+        if process_file(filepath, dry_run=args.dry_run):
+            modified_count += 1
+    
+    if args.dry_run:
+        print(f"\nDRY RUN Complete! Would modify {modified_count} files.")
+    else:
+        print(f"\nComplete! Modified {modified_count} files.")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Added hidden synonym div at the beginning of primitive function and operator pages to ensure that searching for the primitive glyph will result in both monadic and dyadic versions.