### PR TITLE
CHM: link to text-only version of license

### DIFF
--- a/chm/welcome.md
+++ b/chm/welcome.md
@@ -26,6 +26,6 @@ The documentation is updated throughout the life of each version of Dyalog; the 
 
 If you report an issue with the documentation, could you please include the following information in your report: Version {{ version_majmin }}, revision {{ build_date }}:{{ git_info }}.
 
-Except where otherwise noted, this content is licensed under a [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/) licence. 
+Except where otherwise noted, this content is licensed under a [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/legalcode.txt) licence. 
 
 Please note that unless otherwise stated, all the examples in the documentation assume `⎕IO` is 1, and `⎕ML` is 1.


### PR DESCRIPTION
The win help viewer struggles with modern js, so let's refer to the text-only version.