### PR TITLE
Fix gh-pahes checkout 

### DIFF
--- a/.github/workflows/mkdocs-publish.yml
+++ b/.github/workflows/mkdocs-publish.yml
@@ -82,6 +82,9 @@ jobs:
     
     - name: Copy Jenkins files to gh-pages
       run: |
+        # Discard local changes to mkdocs.yml before switching branches
+        git checkout -- mkdocs.yml
+        
         # Checkout gh-pages branch
         git checkout gh-pages
         


### PR DESCRIPTION
We need to commit the Jenkins files to gh-pages, but we've edited the mkdocs.yml file in the github action to expand config variables. As these changes have been picked up my 'mike', we can simply revert before we check out the gh-pages branch.