### PR TITLE
Ensure we also allow symlinks in the rsync

### DIFF
--- a/tools/jenkins/Jenkinsfile
+++ b/tools/jenkins/Jenkinsfile
@@ -191,7 +191,7 @@ pipeline {
                     fi
                     
                     echo "Syncing content from ${WORKSPACE} to ${WEB_ROOT}/"
-                    rsync -r --delete --exclude-from="${WORKSPACE}/.rsync-exclude" "${WORKSPACE}/" "${WEB_ROOT}/"
+                    rsync -rl --delete --exclude-from="${WORKSPACE}/.rsync-exclude" "${WORKSPACE}/" "${WEB_ROOT}/"
                     
                     echo "Storing new git hash (${LATEST_HASH})."
                     echo "${LATEST_HASH}" | tee "${WEB_ROOT}/.git-hash" >/dev/null


### PR DESCRIPTION
We need `-l` in our call to `rsync` to retain symbolic links which `mike` uses for its aliases.