### PR TITLE
Enhance )SAVE documentation.

### DIFF
--- a/language-reference-guide/docs/system-commands/save.md
+++ b/language-reference-guide/docs/system-commands/save.md
@@ -37,7 +37,7 @@ A workspace may not be saved if any threads (other than the root thread 0) are r
 |`Can't save - file could not be created.`|The workspace name supplied did not represent a valid file name for the current Operating System.|
 |`cannot create`|The user does not have access to create the file OR the workspace name conflicts with an existing non-workspace file.|
 |`cannot save with windows open`|A workspace may not be saved if trace or edit windows are open.|
-
+|`Cannot overwrite old workspace`|An attempt was made to save the workspace with a newer version of the interpreter than the workspace was saved with. This error can be overridden by specifying **-force** .|
 
 
 After a successful save, the system reports the workspace name, followed by the word  "`saved`" and the current time and date; and if `ws` specified a new name, `⎕WSID` is assigned that name.

--- a/language-reference-guide/docs/system-commands/save.md
+++ b/language-reference-guide/docs/system-commands/save.md
@@ -37,7 +37,7 @@ A workspace may not be saved if any threads (other than the root thread 0) are r
 |`Can't save - file could not be created.`|The workspace name supplied did not represent a valid file name for the current Operating System.|
 |`cannot create`|The user does not have access to create the file OR the workspace name conflicts with an existing non-workspace file.|
 |`cannot save with windows open`|A workspace may not be saved if trace or edit windows are open.|
-|`Cannot overwrite old workspace`|An attempt was made to save the workspace with a newer version of the interpreter than the workspace was saved with. This error can be overridden by specifying **-force** .|
+|`Cannot overwrite old workspace`|n attempt was made to save the workspace with a newer version of the interpreter than that with which it was originally saved. This error can be avoided by specifying the `-force` argument.|
 
 
 After a successful save, the system reports the workspace name, followed by the word  "`saved`" and the current time and date; and if `ws` specified a new name, `⎕WSID` is assigned that name.

--- a/language-reference-guide/docs/system-commands/save.md
+++ b/language-reference-guide/docs/system-commands/save.md
@@ -32,7 +32,7 @@ A workspace may not be saved if any threads (other than the root thread 0) are r
 
 |---|---|
 |`unacceptable char`|The given workspace name was ill-formed|
-|`not saved this ws is WSID`|An attempt was made to change the name of the workspace for the save, and the renamed workspace already existed. This error can be overridden by specifying **-force** .|
+|`not saved this ws is WSID`|An attempt was made to change the name of the workspace for the save, and the renamed workspace already existed. This error can be overridden by specifying the `-force` argument.|
 |`not saved this ws is CLEAR WS`|The active workspace was `CLEAR WS` and no attempt was made to change the name.|
 |`Can't save - file could not be created.`|The workspace name supplied did not represent a valid file name for the current Operating System.|
 |`cannot create`|The user does not have access to create the file OR the workspace name conflicts with an existing non-workspace file.|


### PR DESCRIPTION
As #302 states, there is now a 'Cannot overwrite old workspace' error.
Add this to the documentation for )SAVE