### PR TITLE
Syncfusion no longer incuded

### DIFF
--- a/dotnet-framework-interface/docs/overview/prerequisites.md
+++ b/dotnet-framework-interface/docs/overview/prerequisites.md
@@ -3,7 +3,6 @@
 The Dyalog version {{ version_majmin }} .NET Framework interface requires version 4.0 or greater of Microsoft .NET Framework. It does *not* operate with earlier versions of the .NET Framework. In addition:
 
 - .NET Framework version 4.5 is needed for full Data Binding support (including support for the `INotifyCollectionChanged` interface, which is used by Dyalog to notify a data consumer when the contents of a variable, that is data bound as a list of items, changes).
-- .NET Framework version 4.6 is needed to run the Syncfusion libraries supplied with Dyalog version {{ version_majmin }}.
 - IIS needs to be installed before installing Dyalog APL in order to access the examples in the `Samples/asp.net` sub-directory – if IIS and ASP.NET are not present, the `asp.net` sub-directory will not be installed during the Dyalog installation.
 
 Note that .NET Framework is specific to Microsoft Windows; the cross-platform .NET is also supported (see below).

--- a/dotnet-framework-interface/docs/wpf/syncfusion-circulargauge.md
+++ b/dotnet-framework-interface/docs/wpf/syncfusion-circulargauge.md
@@ -1,7 +1,9 @@
 <h1 class="heading"><span class="name">Syncfusion Circular Gauge Example</span></h1>
 
+Dyalog no longer includes the [Syncfusion](https://www.syncfusion.com/) library of WPF controls. If you have your own licence for the Syncfusion WPF controls, these can be used by Dyalog APL users to develop applications. 
+
 !!! note "Note"
-     From version 20.0, Syncfusion is no longer included in Dyalog APL. If you have your own license for Syncfusion, you may use that with Dyalog APL. You can not use the Syncfusion controls shipped with earlier versions of Dyalog APL with version 20.0 or later.
+    You may not use the Syncfusion library distributed with previous versions of Dyalog APL with version 20.0 or later.
 
 ![syncfusion gauge 1](../img/syncfusion-gauge-1.png)
 
@@ -80,7 +82,7 @@ The `LoadXAML` function used in this example is subtly different from previous 
 [2]    ⎕USING,←⊂'System.Windows.Markup'
 [3]    ⎕USING,←⊂'System.Xml,system.xml.dll'
 [4]    ⎕USING,←⊂'System.Windows.Controls,WPF/PresentationFramework.dll'
-[5]    ⎕USING,←⊂'Syncfusion.Windows.Gauge,Syncfusion/4.6/Syncfusion.Gauge.WPF.dll'
+[5]    ⎕USING,←⊂'Syncfusion.Windows.Gauge,YOUR_INSTALL_DIR/Syncfusion.Gauge.WPF.dll'
 [6]    str←⎕NEW StringReader(⊂xaml)
 [7]    xml←⎕NEW XmlTextReader str
 [8]    win←XamlReader.Load xml
@@ -92,7 +94,7 @@ In particular, it contains the all-important statement:
 ```apl
 
 [5]    ⎕USING,←⊂'Syncfusion.Windows.Gauge,
-                 Syncfusion/4.6/Syncfusion.Gauge.WPF.dll'
+                 YOUR_INSTALL_DIR/Syncfusion.Gauge.WPF.dll'
 ```
 
-This statement tells APL to search the .NET namespace named *Syncfusion.Windows.Gauge*, which is located in the assembly file whose path (relative to the Dyalog installation directory) is  `Syncfusion/4.6/Syncfusion.Gauge.WPF.dll`.
+This statement tells APL to search the .NET namespace named *Syncfusion.Windows.Gauge*, which is located in the assembly file whose path depends on your exact Syncfusion installation.

--- a/dotnet-framework-interface/docs/wpf/syncfusion-circulargauge.md
+++ b/dotnet-framework-interface/docs/wpf/syncfusion-circulargauge.md
@@ -77,7 +77,7 @@ The `LoadXAML` function used in this example is subtly different from previous 
 [2]    ⎕USING,←⊂'System.Windows.Markup'
 [3]    ⎕USING,←⊂'System.Xml,system.xml.dll'
 [4]    ⎕USING,←⊂'System.Windows.Controls,WPF/PresentationFramework.dll'
-[5]    ⎕USING,←⊂'Syncfusion.Windows.Gauge,Syncfusion/4.5/Syncfusion.Gauge.WPF.dll'
+[5]    ⎕USING,←⊂'Syncfusion.Windows.Gauge,Syncfusion/4.6/Syncfusion.Gauge.WPF.dll'
 [6]    str←⎕NEW StringReader(⊂xaml)
 [7]    xml←⎕NEW XmlTextReader str
 [8]    win←XamlReader.Load xml
@@ -89,7 +89,7 @@ In particular, it contains the all-important statement:
 ```apl
 
 [5]    ⎕USING,←⊂'Syncfusion.Windows.Gauge,
-                 Syncfusion/4.5/Syncfusion.Gauge.WPF.dll'
+                 Syncfusion/4.6/Syncfusion.Gauge.WPF.dll'
 ```
 
-This statement tells APL to search the .NET namespace named *Syncfusion.Windows.Gauge*, which is located in the assembly file whose path (relative to the Dyalog installation directory) is  `Syncfusion/4.5/Syncfusion.Gauge.WPF.dll`.
+This statement tells APL to search the .NET namespace named *Syncfusion.Windows.Gauge*, which is located in the assembly file whose path (relative to the Dyalog installation directory) is  `Syncfusion/4.6/Syncfusion.Gauge.WPF.dll`.

--- a/dotnet-framework-interface/docs/wpf/syncfusion-circulargauge.md
+++ b/dotnet-framework-interface/docs/wpf/syncfusion-circulargauge.md
@@ -1,6 +1,6 @@
 <h1 class="heading"><span class="name">Syncfusion Circular Gauge Example</span></h1>
 
-Dyalog no longer includes the [Syncfusion](https://www.syncfusion.com/) library of WPF controls. If you have your own licence for the Syncfusion WPF controls, these can be used by Dyalog APL users to develop applications. 
+Dyalog no longer includes the [Syncfusion](https://www.syncfusion.com/) library of WPF controls. If you have your own license for the Syncfusion WPF controls, these can be used by Dyalog APL users to develop applications. 
 
 !!! note "Note"
     You may not use the Syncfusion library distributed with previous versions of Dyalog APL with version 20.0 or later.

--- a/dotnet-framework-interface/docs/wpf/syncfusion-circulargauge.md
+++ b/dotnet-framework-interface/docs/wpf/syncfusion-circulargauge.md
@@ -1,5 +1,8 @@
 <h1 class="heading"><span class="name">Syncfusion Circular Gauge Example</span></h1>
 
+!!! note "Note"
+     From version 20.0, Syncfusion is no longer included in Dyalog APL. If you have your own license for Syncfusion, you may use that with Dyalog APL. You can not use the Syncfusion controls shipped with earlier versions of Dyalog APL with version 20.0 or later.
+
 ![syncfusion gauge 1](../img/syncfusion-gauge-1.png)
 
 ## The XAML

--- a/dotnet-framework-interface/docs/wpf/syncfusion-circulargauge.md
+++ b/dotnet-framework-interface/docs/wpf/syncfusion-circulargauge.md
@@ -1,9 +1,9 @@
 <h1 class="heading"><span class="name">Syncfusion Circular Gauge Example</span></h1>
 
-Dyalog no longer includes the [Syncfusion](https://www.syncfusion.com/) library of WPF controls. If you have your own license for the Syncfusion WPF controls, these can be used by Dyalog APL users to develop applications. 
+Dyalog does not include the [Syncfusion](https://www.syncfusion.com/) library of WPF controls. A separate licence is required from Syncfusion to use these in application development and to distribute them with run-time applications.
 
 !!! note "Note"
-    You may not use the Syncfusion library distributed with previous versions of Dyalog APL with version 20.0 or later.
+    From Dyalog v20.0 onwards, you must not use the Syncfusion libraries that were distributed with previous versions of Dyalog.
 
 ![syncfusion gauge 1](../img/syncfusion-gauge-1.png)
 

--- a/dotnet-framework-interface/docs/wpf/syncfusion-introduction.md
+++ b/dotnet-framework-interface/docs/wpf/syncfusion-introduction.md
@@ -1,9 +1,9 @@
 <h1 class="heading"><span class="name">Syncfusion Libraries</span></h1>
 
-Dyalog no longer includes the [Syncfusion](https://www.syncfusion.com/) library of WPF controls. If you have your own license for the Syncfusion WPF controls, these can be used by Dyalog APL users to develop applications. 
+Dyalog does not include the [Syncfusion](https://www.syncfusion.com/) library of WPF controls. A separate licence is required from Syncfusion to use these in application development and to distribute them with run-time applications.
 
 !!! note "Note"
-    You may not use the Syncfusion library distributed with previous versions of Dyalog APL with version 20.0 or later.
+    From Dyalog v20.0 onwards, you must not use the Syncfusion libraries that were distributed with previous versions of Dyalog.
 
 
 ## Requirements

--- a/dotnet-framework-interface/docs/wpf/syncfusion-introduction.md
+++ b/dotnet-framework-interface/docs/wpf/syncfusion-introduction.md
@@ -1,12 +1,14 @@
 <h1 class="heading"><span class="name">Syncfusion Libraries</span></h1>
 
-Under a licensing agreement with Syncfusion, Dyalog includes the Syncfusion library of WPF controls. These may be used by Dyalog APL users to develop applications, and may be distributed with Dyalog APL run-time applications.
+Dyalog no longer includes the [Syncfusion](https://www.syncfusion.com/) library of WPF controls. If you have your own licence for the Syncfusion WPF controls, these can be used by Dyalog APL users to develop applications. 
 
-The Syncfusion libraries comprise a set of .NET assemblies which are supplied in the *Syncfusion/4.6* sub-directory of the main Dyalog APL installation directory (for example: *c:\Program Files\Dyalog\Dyalog APL-64 19.0 Unicode\Syncfusion\4.6*.
+!!! note "Note"
+    You may not use the Syncfusion library distributed with previous versions of Dyalog APL with Dyalog v{{ version_majmin }}.
+
 
 ## Requirements
 
-To use the Syncfusion libraries you must be using Microsoft .NET Version 4.5.
+To use the Syncfusion libraries you must be using Microsoft .NET Version 4.6.
 
 In addition, to use the controls contained in these assemblies it is necessary to perform one or both of the following steps.
 
@@ -27,7 +29,6 @@ The above statement defines the prefix `syncfusion` to mean the specified Syncfu
 
 In common with all .NET types, when a Syncfusion control is loaded using XAML or using `⎕NEW` it is essential that the current value of `⎕USING` identifies the .NET namespace and assembly in which the control will be found. For example:
 ```apl
-
        ⎕USING,←⊂'Syncfusion.Windows.Gauge,Syncfusion/4.6/Syncfusion.Gauge.WPF.dll'
 ```
 

--- a/dotnet-framework-interface/docs/wpf/syncfusion-introduction.md
+++ b/dotnet-framework-interface/docs/wpf/syncfusion-introduction.md
@@ -3,7 +3,7 @@
 Dyalog no longer includes the [Syncfusion](https://www.syncfusion.com/) library of WPF controls. If you have your own licence for the Syncfusion WPF controls, these can be used by Dyalog APL users to develop applications. 
 
 !!! note "Note"
-    You may not use the Syncfusion library distributed with previous versions of Dyalog APL with Dyalog v{{ version_majmin }}.
+    You may not use the Syncfusion library distributed with previous versions of Dyalog APL with version 20.0 or later.
 
 
 ## Requirements
@@ -29,7 +29,7 @@ The above statement defines the prefix `syncfusion` to mean the specified Syncfu
 
 In common with all .NET types, when a Syncfusion control is loaded using XAML or using `⎕NEW` it is essential that the current value of `⎕USING` identifies the .NET namespace and assembly in which the control will be found. For example:
 ```apl
-       ⎕USING,←⊂'Syncfusion.Windows.Gauge,Syncfusion/4.6/Syncfusion.Gauge.WPF.dll'
+       ⎕USING,←⊂'Syncfusion.Windows.Gauge,YOUR_INSTALL_PATH/Syncfusion.Gauge.WPF.dll'
 ```
 
-This statement tells APL to search the .NET namespace named *Syncfusion.Windows.Gauge*, which is located in the assembly file whose path (relative to the Dyalog installation directory) is  `Syncfusion/4.6/Syncfusion.Gauge.WPF.dll`.
+This statement tells APL to search the .NET namespace named *Syncfusion.Windows.Gauge*, which is located in the assembly file whose path depends on your specific Syncfusion installation.

--- a/dotnet-framework-interface/docs/wpf/syncfusion-introduction.md
+++ b/dotnet-framework-interface/docs/wpf/syncfusion-introduction.md
@@ -1,6 +1,6 @@
 <h1 class="heading"><span class="name">Syncfusion Libraries</span></h1>
 
-Dyalog no longer includes the [Syncfusion](https://www.syncfusion.com/) library of WPF controls. If you have your own licence for the Syncfusion WPF controls, these can be used by Dyalog APL users to develop applications. 
+Dyalog no longer includes the [Syncfusion](https://www.syncfusion.com/) library of WPF controls. If you have your own license for the Syncfusion WPF controls, these can be used by Dyalog APL users to develop applications. 
 
 !!! note "Note"
     You may not use the Syncfusion library distributed with previous versions of Dyalog APL with version 20.0 or later.


### PR DESCRIPTION
Highlight that the Syncfusion controls are no longer included with Dyalog APL,  but if the user have their own license, it will still work.