### PR TITLE
Add the function name to the ToC entry for system functions

### DIFF
--- a/language-reference-guide/mkdocs.yml
+++ b/language-reference-guide/mkdocs.yml
@@ -387,410 +387,410 @@ nav:
           - System Settings:
               - Introduction: system-functions/system-settings.md
               - State Settings:
-                  - Comparison Tolerance: system-functions/ct.md
-                  - Decimal Comparison Tolerance: system-functions/dct.md
-                  - Division Method: system-functions/div.md
-                  - Floating Point Representation: system-functions/fr.md
-                  - Index Origin: system-functions/io.md
-                  - Migration Level: system-functions/ml.md
-                  - Print Precision: system-functions/pp.md
-                  - Random Link: system-functions/rl.md
+                  - '<code>⎕CT</code>: Comparison Tolerance': system-functions/ct.md
+                  - '<code>⎕DCT</code>: Decimal Comparison Tolerance': system-functions/dct.md
+                  - '<code>⎕DIV</code>: Division Method': system-functions/div.md
+                  - '<code>⎕FR</code>: Floating Point Representation': system-functions/fr.md
+                  - '<code>⎕IO</code>: Index Origin': system-functions/io.md
+                  - '<code>⎕ML</code>: Migration Level': system-functions/ml.md
+                  - '<code>⎕PP</code>: Print Precision': system-functions/pp.md
+                  - '<code>⎕RL</code>: Random Link': system-functions/rl.md
           - Session Information and Management:
               - Introduction: system-functions/session-information-and-management.md
-              - Account Information: system-functions/ai.md
-              - Account Name: system-functions/an.md
-              - Clear Workspace: system-functions/clear.md
-              - Copy Workspace: system-functions/cy.md
-              - Delay: system-functions/dl.md
-              - Load Workspace: system-functions/load.md
-              - Sign Off APL: system-functions/off.md
-              - Search Path: system-functions/path.md
-              - Save Workspace: system-functions/save.md
-              - Timestamp: system-functions/ts.md
+              - '<code>⎕AI</code>: Account Information': system-functions/ai.md
+              - '<code>⎕AN</code>: Account Name': system-functions/an.md
+              - '<code>⎕CLEAR</code>: Clear Workspace': system-functions/clear.md
+              - '<code>⎕CY</code>: Copy Workspace': system-functions/cy.md
+              - '<code>⎕DL</code>: Delay': system-functions/dl.md
+              - '<code>⎕LOAD</code>: Load Workspace': system-functions/load.md
+              - '<code>⎕OFF</code>: Sign Off APL': system-functions/off.md
+              - '<code>⎕PATH</code>: Search Path': system-functions/path.md
+              - '<code>⎕SAVE</code>: Save Workspace': system-functions/save.md
+              - '<code>⎕TS</code>: Timestamp': system-functions/ts.md
           - System Constants:
               - Introduction: system-functions/constants.md
               - Constants:
-                  - Alphabetic Characters: system-functions/a.md
-                  - Digits: system-functions/d.md
-                  - Null Item: system-functions/null.md
+                  - '<code>⎕A</code>: Alphabetic Characters': system-functions/a.md
+                  - '<code>⎕D</code>: Digits': system-functions/d.md
+                  - '<code>⎕NULL</code>: Null Item': system-functions/null.md
           - Tools and Access to External Facilities:
               - Introduction: system-functions/tools-and-external-access.md
               - Tools and Access to External Utilities:
-                  - Execute Windows Command: system-functions/execute-windows-command.md
-                  - Start Windows Auxiliary Processor: system-functions/start-windows-auxiliary-processor.md
-                  - Comma Separated Values: system-functions/csv.md
-                  - Data Representation Monadic: system-functions/data-representation-monadic.md
-                  - Data Representation Dyadic: system-functions/data-representation-dyadic.md
-                  - Format Monadic: system-functions/format-monadic.md
-                  - Format Dyadic: system-functions/format-dyadic.md
-                  - JSON Convert: system-functions/json.md
-                  - Map File: system-functions/map.md
-                  - Name Association: system-functions/na.md
-                  - Replace: system-functions/r.md
-                  - Search: system-functions/s.md
-                  - Execute UNIX Command: system-functions/execute-unix-command.md
-                  - Start UNIX Auxiliary Processor: system-functions/start-unix-auxiliary-processor.md
-                  - Execute External Program: system-functions/shell.md
-                  - Unicode Convert: system-functions/ucs.md
-                  - Using Microsoft Net Search Path: system-functions/using.md
-                  - Verify Fix Input: system-functions/vfi.md
-                  - XML Convert: system-functions/xml.md
+                  - '<code>⎕CMD</code>: Execute Windows Command': system-functions/execute-windows-command.md
+                  - '<code>⎕CMD</code>: Start Windows Auxiliary Processor': system-functions/start-windows-auxiliary-processor.md
+                  - '<code>⎕CSV</code>: Comma Separated Values': system-functions/csv.md
+                  - '<code>⎕DR</code>: Data Representation Monadic': system-functions/data-representation-monadic.md
+                  - '<code>⎕DR</code>: Data Representation Dyadic': system-functions/data-representation-dyadic.md
+                  - '<code>⎕FMT</code>: Format Monadic': system-functions/format-monadic.md
+                  - '<code>⎕FMT</code>: Format Dyadic': system-functions/format-dyadic.md
+                  - '<code>⎕JSON</code>: JSON Convert': system-functions/json.md
+                  - '<code>⎕MAP</code>: Map File': system-functions/map.md
+                  - '<code>⎕NA</code>: Name Association': system-functions/na.md
+                  - '<code>⎕R</code>: Replace': system-functions/r.md
+                  - '<code>⎕S</code>: Search': system-functions/s.md
+                  - '<code>⎕SH</code>: Execute UNIX Command': system-functions/execute-unix-command.md
+                  - '<code>⎕SH</code>: Start UNIX Auxiliary Processor': system-functions/start-unix-auxiliary-processor.md
+                  - '<code>⎕SHELL</code>: Execute external program': system-functions/shell.md
+                  - '<code>⎕UCS</code>: Unicode Convert': system-functions/ucs.md
+                  - '<code>⎕USING</code>: Using Microsoft Net Search Path': system-functions/using.md
+                  - '<code>⎕VFI</code>: Verify Fix Input': system-functions/vfi.md
+                  - '<code>⎕XML</code>: XML Convert': system-functions/xml.md
           - Manipulating Functions and Operators:
               - Introduction: system-functions/manipulating-functions-and-operators.md
-              - Attributes: system-functions/at.md
-              - Canonical Representation: system-functions/cr.md
-              - Edit Object: system-functions/ed.md
-              - Expunge Object: system-functions/ex.md
-              - Fix Definition: system-functions/fx.md
-              - Lock Definition: system-functions/lock.md
-              - Set Monitor: system-functions/set-monitor.md
-              - Query Monitor: system-functions/query-monitor.md
-              - Object Representation: system-functions/or.md
-              - Nested Representation: system-functions/nr.md
-              - Profile Application: system-functions/profile.md
-              - Cross References: system-functions/refs.md
-              - Set Stop: system-functions/set-stop.md
-              - Query Stop: system-functions/query-stop.md
-              - Set Trace: system-functions/set-trace.md
-              - Query Trace: system-functions/query-trace.md
-              - Vector Representation: system-functions/vr.md
+              - '<code>⎕AT</code>: Attributes': system-functions/at.md
+              - '<code>⎕CR</code>: Canonical Representation': system-functions/cr.md
+              - '<code>⎕ED</code>: Edit Object': system-functions/ed.md
+              - '<code>⎕EX</code>: Expunge Object': system-functions/ex.md
+              - '<code>⎕FX</code>: Fix Definition': system-functions/fx.md
+              - '<code>⎕LOCK</code>: Lock Definition': system-functions/lock.md
+              - '<code>⎕MONITOR</code>: Set Monitor': system-functions/set-monitor.md
+              - '<code>⎕MONITOR</code>: Query Monitor': system-functions/query-monitor.md
+              - '<code>⎕OR</code>: Object Representation': system-functions/or.md
+              - '<code>⎕NR</code>: Nested Representation': system-functions/nr.md
+              - '<code>⎕PROFILE</code>: Profile Application': system-functions/profile.md
+              - '<code>⎕REFS</code>: Cross References': system-functions/refs.md
+              - '<code>⎕STOP</code>: Set Stop': system-functions/set-stop.md
+              - '<code>⎕STOP</code>: Query Stop': system-functions/query-stop.md
+              - '<code>⎕TRACE</code>: Set Trace': system-functions/set-trace.md
+              - '<code>⎕TRACE</code>: Query Trace': system-functions/query-trace.md
+              - '<code>⎕VR</code>: Vector Representation': system-functions/vr.md
           - Namespaces and Objects:
               - Introduction: system-functions/namespaces-and-objects.md
-              - Base Class: system-functions/base.md
-              - Class: system-functions/class.md
-              - Change Space: system-functions/cs.md
-              - Display Form: system-functions/df.md
-              - Fix Script: system-functions/fix.md
-              - Instances: system-functions/instances.md
-              - New Instance: system-functions/new.md
-              - Namespace: system-functions/ns.md
-              - Source: system-functions/src.md
-              - This Space: system-functions/this.md
+              - '<code>⎕BASE</code>: Base Class': system-functions/base.md
+              - '<code>⎕CLASS</code>: Class': system-functions/class.md
+              - '<code>⎕CS</code>: Change Space': system-functions/cs.md
+              - '<code>⎕DF</code>: Display Form': system-functions/df.md
+              - '<code>⎕FIX</code>: Fix Script': system-functions/fix.md
+              - '<code>⎕INSTANCES</code>: Instances': system-functions/instances.md
+              - '<code>⎕NEW</code>: New Instance': system-functions/new.md
+              - '<code>⎕NS</code>: Namespace': system-functions/ns.md
+              - '<code>⎕SRC</code>: Source': system-functions/src.md
+              - '<code>⎕THIS</code>: This Space': system-functions/this.md
           - Input and Output:
               - Introduction: system-functions/input-and-output.md
               - Input/Output:
                   - Character Input/Output: system-functions/character-input-output.md
                   - Evaluated Input/Output: system-functions/evaluated-input-output.md
-                  - Arbitrary Input: system-functions/arbin.md
-                  - Arbitrary Output: system-functions/arbout.md
-                  - Response Time Limit: system-functions/rtl.md
+                  - '<code>⎕ARBIN</code>: Arbitrary Input': system-functions/arbin.md
+                  - '<code>⎕ARBOUT</code>: Arbitrary Output': system-functions/arbout.md
+                  - '<code>⎕RTL</code>: Response Time Limit': system-functions/rtl.md
           - Component Files:
               - Introduction: system-functions/component-files.md
-              - Append Component: system-functions/fappend.md
-              - File System Availability: system-functions/favail.md
-              - File Check and Repair: system-functions/fchk.md
-              - Copy File: system-functions/fcopy.md
-              - Create File: system-functions/fcreate.md
-              - Drop Components: system-functions/fdrop.md
-              - Erase File: system-functions/ferase.md
-              - File History: system-functions/fhist.md
-              - Hold File: system-functions/fhold.md
-              - File Library List: system-functions/flib.md
-              - Tied File Names: system-functions/fnames.md
-              - Tied File Numbers: system-functions/fnums.md
-              - File Properties: system-functions/fprops.md
-              - Read File Access Matrix: system-functions/frdac.md
-              - Read File Component Information: system-functions/frdci.md
-              - Read Component: system-functions/fread.md
-              - Rename File: system-functions/frename.md
-              - Replace Component: system-functions/freplace.md
-              - Resize File: system-functions/fresize.md
-              - File Size: system-functions/fsize.md
-              - Set File Access Matrix: system-functions/fstac.md
-              - Share Tie File: system-functions/fstie.md
-              - Tie File: system-functions/ftie.md
-              - Untie Files: system-functions/funtie.md
+              - '<code>⎕FAPPEND</code>: File Append Component': system-functions/fappend.md
+              - '<code>⎕FAVAIL</code>: File System Available': system-functions/favail.md
+              - '<code>⎕FCHK</code>: File Check and Repair': system-functions/fchk.md
+              - '<code>⎕FCOPY</code>: File Copy': system-functions/fcopy.md
+              - '<code>⎕FCREATE</code>: File Create': system-functions/fcreate.md
+              - '<code>⎕FDROP</code>: File Drop Component': system-functions/fdrop.md
+              - '<code>⎕FERASE</code>: File Erase': system-functions/ferase.md
+              - '<code>⎕FHIST</code>: File History': system-functions/fhist.md
+              - '<code>⎕FHOLD</code>: File Hold': system-functions/fhold.md
+              - '<code>⎕FLIB</code>: Component File Library': system-functions/flib.md
+              - '<code>⎕FNAMES</code>: File Names': system-functions/fnames.md
+              - '<code>⎕FNUMS</code>: File Numbers': system-functions/fnums.md
+              - '<code>⎕FPROPS</code>: File Properties': system-functions/fprops.md
+              - '<code>⎕FRDAC</code>: File Read Access': system-functions/frdac.md
+              - '<code>⎕FRDCI</code>: File Read Component Information': system-functions/frdci.md
+              - '<code>⎕FREAD</code>: File Read Component': system-functions/fread.md
+              - '<code>⎕FRENAME</code>: File Rename': system-functions/frename.md
+              - '<code>⎕FREPLACE</code>: File Replace Component': system-functions/freplace.md
+              - '<code>⎕FRESIZE</code>: File Resize': system-functions/fresize.md
+              - '<code>⎕FSIZE</code>: File Size': system-functions/fsize.md
+              - '<code>⎕FSTAC</code>: File Set Access': system-functions/fstac.md
+              - '<code>⎕FSTIE</code>: File Share Tie': system-functions/fstie.md
+              - '<code>⎕FTIE</code>: Exclusive File Tie': system-functions/ftie.md
+              - '<code>⎕FUNTIE</code>: File Untie': system-functions/funtie.md
           - Native Files:
               - Introduction: system-functions/native-files.md
-              - File Parts: system-functions/nparts.md
-              - Make Directory: system-functions/mkdir.md
-              - Append Value to a Native File: system-functions/nappend.md
-              - Create Native File: system-functions/ncreate.md
-              - Native File Copy: system-functions/ncopy.md
-              - Delete Native File or Directory: system-functions/ndelete.md
-              - Erase Native File: system-functions/nerase.md
-              - Determine if Native File Exists: system-functions/nexists.md
-              - Read Text File: system-functions/nget.md
-              - Native File Information: system-functions/ninfo.md
-              - Lock Native File: system-functions/nlock.md
-              - Native File Move: system-functions/nmove.md
-              - Names of open Native Files: system-functions/nnames.md
-              - Tie Numbers of open Native Files: system-functions/nnums.md
-              - File Name Parts: system-functions/nparts.md
-              - Write Text File: system-functions/nput.md
-              - Read data from a Native File: system-functions/nread.md
-              - Rename Native File: system-functions/nrename.md
-              - Write data to a Native File: system-functions/nreplace.md
-              - Change size of Native File: system-functions/nresize.md
-              - Report current size of native file: system-functions/nsize.md
-              - Open Native File: system-functions/ntie.md
-              - Close one or more Native Files: system-functions/nuntie.md
-              - Specify/report Native File translation: system-functions/nxlate.md
+              - '<code>⎕NPARTS</code>: File Name Parts': system-functions/nparts.md
+              - '<code>⎕MKDIR</code>: Make Directory': system-functions/mkdir.md
+              - '<code>⎕NAPPEND</code>: Native File Append': system-functions/nappend.md
+              - '<code>⎕NCREATE</code>: Native File Create': system-functions/ncreate.md
+              - '<code>⎕NCOPY</code>: Native File Copy': system-functions/ncopy.md
+              - '<code>⎕NDELETE</code>: Native File Delete': system-functions/ndelete.md
+              - '<code>⎕NERASE</code>: Native File Erase': system-functions/nerase.md
+              - '<code>⎕NEXISTS</code>: Native File Exists': system-functions/nexists.md
+              - '<code>⎕NGET</code>: Read Text File': system-functions/nget.md
+              - '<code>⎕NINFO</code>: Native File Information': system-functions/ninfo.md
+              - '<code>⎕NLOCK</code>: Native File Lock': system-functions/nlock.md
+              - '<code>⎕NMOVE</code>: Native File Move': system-functions/nmove.md
+              - '<code>⎕NNAMES</code>: Native File Names': system-functions/nnames.md
+              - '<code>⎕NNUMS</code>: Native File Numbers': system-functions/nnums.md
+              - '<code>⎕NPARTS</code>: File Name Parts': system-functions/nparts.md
+              - '<code>⎕NPUT</code>: Write Text File': system-functions/nput.md
+              - '<code>⎕NREAD</code>: Native File Read': system-functions/nread.md
+              - '<code>⎕NRENAME</code>: Native File Rename': system-functions/nrename.md
+              - '<code>⎕NREPLACE</code>: Native File Replace': system-functions/nreplace.md
+              - '<code>⎕NRESIZE</code>: Native File Resize': system-functions/nresize.md
+              - '<code>⎕NSIZE</code>: Native File Size': system-functions/nsize.md
+              - '<code>⎕NTIE</code>: Native File Tie': system-functions/ntie.md
+              - '<code>⎕NUNTIE</code>: Native File Untie': system-functions/nuntie.md
+              - '<code>⎕NXLATE</code>: Native File Translate': system-functions/nxlate.md
           - Threads:
               - Introduction: system-functions/threads.md
-              - Thread Child Numbers: system-functions/tcnums.md
-              - Current Thread Identity: system-functions/tid.md
-              - Kill Thread: system-functions/tkill.md
-              - Current Thread Name: system-functions/tname.md
-              - Thread Numbers: system-functions/tnums.md
-              - Wait for Threads to Terminate: system-functions/tsync.md
+              - '<code>⎕TCNUMS</code>: Thread Child Numbers': system-functions/tcnums.md
+              - '<code>⎕TID</code>: Current Thread Identity': system-functions/tid.md
+              - '<code>⎕TKILL</code>: Kill Thread': system-functions/tkill.md
+              - '<code>⎕TNAME</code>: Current Thread Name': system-functions/tname.md
+              - '<code>⎕TNUMS</code>: Thread Numbers': system-functions/tnums.md
+              - '<code>⎕TSYNC</code>: Wait for Threads to Terminate': system-functions/tsync.md
           - Synchronisation:
               - Introduction: system-functions/synchronisation.md
-              - Get Tokens: system-functions/tget.md
-              - Kill Thread: system-functions/tkill.md
-              - Token Pool: system-functions/tpool.md
-              - Put Tokens: system-functions/tput.md
-              - Token Requests: system-functions/treq.md
+              - '<code>⎕TGET</code>: Get Tokens': system-functions/tget.md
+              - '<code>⎕TKILL</code>: Kill Thread': system-functions/tkill.md
+              - '<code>⎕TPOOL</code>: Token Pool': system-functions/tpool.md
+              - '<code>⎕TPUT</code>: Put Tokens': system-functions/tput.md
+              - '<code>⎕TREQ</code>: Token Requests': system-functions/treq.md
           - Error Handling:
               - Introduction: system-functions/error-handling.md
-              - Diagnostic Message: system-functions/dm.md
-              - Extended Diagnostic Message: system-functions/dmx.md
-              - Event Message: system-functions/em.md
-              - Event Number: system-functions/en.md
-              - Exception: system-functions/exception.md
-              - Signal Event: system-functions/signal.md
-              - Trap Events: system-functions/trap.md
+              - '<code>⎕DM</code>: Diagnostic Message': system-functions/dm.md
+              - '<code>⎕DMX</code>: Extended Diagnostic Message': system-functions/dmx.md
+              - '<code>⎕EM</code>: Event Message': system-functions/em.md
+              - '<code>⎕EN</code>: Event Number': system-functions/en.md
+              - '<code>⎕EXCEPTION</code>: Exception': system-functions/exception.md
+              - '<code>⎕SIGNAL</code>: Signal Event': system-functions/signal.md
+              - '<code>⎕TRAP</code>: Trap Event': system-functions/trap.md
           - Stack and Workspace:
               - Introduction: system-functions/stack-and-workspace.md
               - Stack and Workspace Information:
-                  - Line Count: system-functions/lc.md
-                  - Latent Expression: system-functions/lx.md
-                  - Name Classification: system-functions/nc.md
-                  - Name List: system-functions/nl.md
-                  - Namespace Indicator: system-functions/nsi.md
-                  - Space Indicator: system-functions/rsi.md
-                  - State Indicator: system-functions/si.md
-                  - Shadow Name: system-functions/shadow.md
-                  - Size of Object: system-functions/size.md
-                  - State Indicator Stack: system-functions/stack.md
-                  - State of Object: system-functions/state.md
-                  - Value Get: system-functions/vget.md
-                  - Value Set: system-functions/vset.md
-                  - Workspace Available: system-functions/wa.md
-                  - Workspace Identification: system-functions/wsid.md
-                  - Extended State Indicator: system-functions/xsi.md
+                  - '<code>⎕LC</code>: Line Count': system-functions/lc.md
+                  - '<code>⎕LX</code>: Latent Expression': system-functions/lx.md
+                  - '<code>⎕NC</code>: Name Classification': system-functions/nc.md
+                  - '<code>⎕NL</code>: Name List': system-functions/nl.md
+                  - '<code>⎕NSI</code>: Namespace Indicator': system-functions/nsi.md
+                  - '<code>⎕RSI</code>: Space Indicator': system-functions/rsi.md
+                  - '<code>⎕SI</code>: State Indicator': system-functions/si.md
+                  - '<code>⎕SHADOW</code>: Shadow Name': system-functions/shadow.md
+                  - '<code>⎕SIZE</code>: Size of Object': system-functions/size.md
+                  - '<code>⎕STACK</code>: State Indicator Stack': system-functions/stack.md
+                  - '<code>⎕STATE</code>: State of Object': system-functions/state.md
+                  - '<code>⎕VGET</code>: Value Get': system-functions/vget.md
+                  - '<code>⎕VSET</code>: Value Set': system-functions/vset.md
+                  - '<code>⎕WA</code>: Workspace Available': system-functions/wa.md
+                  - '<code>⎕WSID</code>: Workspace Identification': system-functions/wsid.md
+                  - '<code>⎕XSI</code>: Extended State Indicator': system-functions/xsi.md
           - Shared Variables:
               - Introduction: system-functions/shared-variables.md
-              - Query Access Control: system-functions/query-access-control.md
-              - Set Access Control: system-functions/set-access-control.md
+              - '<code>⎕SVC</code>: Query Access Control': system-functions/query-access-control.md
+              - '<code>⎕SVC</code>: Set Access Control': system-functions/set-access-control.md
               - Offer Shared Variable: system-functions/svo.md
-              - Shared Variable Offer: system-functions/shared-variable-offer.md
-              - Query Degree of Coupling: system-functions/query-degree-of-coupling.md
-              - Shared Variable Query: system-functions/svq.md
-              - Shared Variable Retract Offer: system-functions/svr.md
-              - Shared Variable State: system-functions/svs.md
+              - '<code>⎕SVO</code>: Shared Variable Offer': system-functions/shared-variable-offer.md
+              - '<code>⎕SVO</code>: Query Degree of Coupling': system-functions/query-degree-of-coupling.md
+              - '<code>⎕SVQ</code>: Shared Variable Query': system-functions/svq.md
+              - '<code>⎕SVR</code>: Shared Variable Retract Offer': system-functions/svr.md
+              - '<code>⎕SVS</code>: Shared Variable State': system-functions/svs.md
           - GUI and COM Support:
               - Introduction: system-functions/gui-and-com-support.md
-              - Dequeue Events: system-functions/dq.md
-              - Export Object: system-functions/export.md
-              - Enqueue Event: system-functions/nq.md
-              - Windows Create Object: system-functions/wc.md
-              - Windows Get Property: system-functions/wg.md
-              - Windows Child Names: system-functions/wn.md
-              - Windows Set Property: system-functions/ws.md
-              - Window Expose: system-functions/wx.md
+              - '<code>⎕DQ</code>: Dequeue Events': system-functions/dq.md
+              - '<code>⎕EXPORT</code>: Export Object': system-functions/export.md
+              - '<code>⎕NQ</code>: Enqueue Event': system-functions/nq.md
+              - '<code>⎕WC</code>: Windows Create Object': system-functions/wc.md
+              - '<code>⎕WG</code>: Windows Get Property': system-functions/wg.md
+              - '<code>⎕WN</code>: Windows Child Names': system-functions/wn.md
+              - '<code>⎕WS</code>: Windows Set Property': system-functions/ws.md
+              - '<code>⎕WX</code>: Window Expose': system-functions/wx.md
           - Miscellaneous:
               - Introduction: system-functions/miscellaneous.md
               - Underscored Alphabetic Characters: system-functions/underscored-alphabetic-characters.md
-              - Atomic Vector: system-functions/av.md
-              - Atomic Vector Unicode: system-functions/avu.md
-              - Key Label: system-functions/kl.md
-              - Program Function Key: system-functions/pfkey.md
-              - Screen Dimensions: system-functions/sd.md
-              - Screen Map: system-functions/sm.md
-              - Screen Read: system-functions/sr.md
-              - Variant: system-functions/opt.md
-              - Terminal Control: system-functions/tc.md
-              - Set External Variable: system-functions/set-external-variable.md
-              - Query External Variable: system-functions/query-external-variable.md
+              - '<code>⎕AV</code>: Atomic Vector': system-functions/av.md
+              - '<code>⎕AVU</code>: Atomic Vector Unicode': system-functions/avu.md
+              - '<code>⎕KL</code>: Key Label': system-functions/kl.md
+              - '<code>⎕PFKEY</code>: Program Function Key': system-functions/pfkey.md
+              - '<code>⎕SD</code>: Screen Dimensions': system-functions/sd.md
+              - '<code>⎕SM</code>: Screen Map': system-functions/sm.md
+              - '<code>⎕SR</code>: Screen Read': system-functions/sr.md
+              - '<code>⎕OPT</code>: Variant': system-functions/opt.md
+              - '<code>⎕TC</code>: Terminal Control': system-functions/tc.md
+              - '<code>⎕XT</code>: Set External Variable': system-functions/set-external-variable.md
+              - '<code>⎕XT</code>: Query External Variable': system-functions/query-external-variable.md
       - System Variables: system-functions/system-variables.md
       - System Functions (A-Z):
           - Introduction: system-functions/system-functions-and-variables-colwise.md
           - Character Input Output: system-functions/character-input-output.md
           - Evaluated Input Output: system-functions/evaluated-input-output.md
           - Underscored Alphabetic Characters: system-functions/underscored-alphabetic-characters.md
-          - Alphabetic Characters: system-functions/a.md
-          - Account Information: system-functions/ai.md
-          - Account Name: system-functions/an.md
-          - Arbitrary Input: system-functions/arbin.md
-          - Arbitrary Output: system-functions/arbout.md
-          - Attributes: system-functions/at.md
-          - Extended Attributes: system-functions/atx.md
-          - Atomic Vector: system-functions/av.md
-          - Atomic Vector Unicode: system-functions/avu.md
-          - Base Class: system-functions/base.md
-          - Case Convert: system-functions/c.md
-          - Class: system-functions/class.md
-          - Clear Workspace: system-functions/clear.md
-          - Execute Windows Command: system-functions/execute-windows-command.md
-          - Start Windows Auxiliary Processor: system-functions/start-windows-auxiliary-processor.md
-          - Canonical Representation: system-functions/cr.md
-          - Change Space: system-functions/cs.md
-          - Comma Separated Values: system-functions/csv.md
-          - Comparison Tolerance: system-functions/ct.md
-          - Copy Workspace: system-functions/cy.md
-          - Digits: system-functions/d.md
-          - Decimal Comparison Tolerance: system-functions/dct.md
-          - Display Form: system-functions/df.md
-          - Division Method: system-functions/div.md
-          - Delay: system-functions/dl.md
-          - Diagnostic Message: system-functions/dm.md
-          - Extended Diagnostic Message: system-functions/dmx.md
-          - Dequeue Events: system-functions/dq.md
-          - Data Representation Monadic: system-functions/data-representation-monadic.md
-          - Data Representation Dyadic: system-functions/data-representation-dyadic.md
-          - Datetime: system-functions/dt.md
-          - Edit Object: system-functions/ed.md
-          - Event Message: system-functions/em.md
-          - Event Number: system-functions/en.md
-          - Exception: system-functions/exception.md
-          - Expunge Object: system-functions/ex.md
-          - Export Object: system-functions/export.md
-          - File Append Component: system-functions/fappend.md
-          - File System Available: system-functions/favail.md
-          - File Check and Repair: system-functions/fchk.md
-          - File Copy: system-functions/fcopy.md
-          - File Create: system-functions/fcreate.md
-          - File Drop Component: system-functions/fdrop.md
-          - File Erase: system-functions/ferase.md
-          - File History: system-functions/fhist.md
-          - File Hold: system-functions/fhold.md
-          - Fix Script: system-functions/fix.md
-          - Component File Library: system-functions/flib.md
-          - Format Monadic: system-functions/format-monadic.md
-          - Format Dyadic: system-functions/format-dyadic.md
-          - File Names: system-functions/fnames.md
-          - File Numbers: system-functions/fnums.md
-          - File Properties: system-functions/fprops.md
-          - Floating Point Representation: system-functions/fr.md
-          - File Read Access: system-functions/frdac.md
-          - File Read Component Information: system-functions/frdci.md
-          - File Read Component: system-functions/fread.md
-          - File Rename: system-functions/frename.md
-          - File Replace Component: system-functions/freplace.md
-          - File Resize: system-functions/fresize.md
-          - File Size: system-functions/fsize.md
-          - File Set Access: system-functions/fstac.md
-          - File Share Tie: system-functions/fstie.md
-          - Exclusive File Tie: system-functions/ftie.md
-          - File Untie: system-functions/funtie.md
-          - Fix Definition: system-functions/fx.md
-          - Instances: system-functions/instances.md
-          - Index Origin: system-functions/io.md
-          - JSON Convert: system-functions/json.md
-          - Key Label: system-functions/kl.md
-          - Line Count: system-functions/lc.md
-          - Load Workspace: system-functions/load.md
-          - Lock Definition: system-functions/lock.md
-          - Latent Expression: system-functions/lx.md
-          - Map File: system-functions/map.md
-          - Make Directory: system-functions/mkdir.md
-          - Migration Level: system-functions/ml.md
-          - Set Monitor: system-functions/set-monitor.md
-          - Query Monitor: system-functions/query-monitor.md
-          - Name Association: system-functions/na.md
-          - Native File Append: system-functions/nappend.md
-          - Name Classification: system-functions/nc.md
-          - Native File Copy: system-functions/ncopy.md
-          - Native File Create: system-functions/ncreate.md
-          - Native File Delete: system-functions/ndelete.md
-          - Native File Erase: system-functions/nerase.md
-          - New Instance: system-functions/new.md
-          - Native File Exists: system-functions/nexists.md
-          - Read Text File: system-functions/nget.md
-          - Native File Information: system-functions/ninfo.md
-          - Name List: system-functions/nl.md
-          - Native File Lock: system-functions/nlock.md
-          - Native File Move: system-functions/nmove.md
-          - Native File Names: system-functions/nnames.md
-          - Native File Numbers: system-functions/nnums.md
-          - File Name Parts: system-functions/nparts.md
-          - Write Text File: system-functions/nput.md
-          - Enqueue Event: system-functions/nq.md
-          - Nested Representation: system-functions/nr.md
-          - Native File Read: system-functions/nread.md
-          - Native File Rename: system-functions/nrename.md
-          - Native File Replace: system-functions/nreplace.md
-          - Native File Resize: system-functions/nresize.md
-          - Namespace: system-functions/ns.md
-          - Namespace Indicator: system-functions/nsi.md
-          - Native File Size: system-functions/nsize.md
-          - Native File Tie: system-functions/ntie.md
-          - Null Item: system-functions/null.md
-          - Native File Untie: system-functions/nuntie.md
-          - Native File Translate: system-functions/nxlate.md
-          - Sign Off APL: system-functions/off.md
-          - Variant: system-functions/opt.md
-          - Object Representation: system-functions/or.md
-          - Search Path: system-functions/path.md
-          - Program Function Key: system-functions/pfkey.md
-          - Print Precision: system-functions/pp.md
-          - Profile Application: system-functions/profile.md
-          - Print Width: system-functions/pw.md
-          - Replace: system-functions/r.md
-          - Cross References: system-functions/refs.md
-          - Random Link: system-functions/rl.md
-          - Space Indicator: system-functions/rsi.md
-          - Response Time Limit: system-functions/rtl.md
-          - Search: system-functions/s.md
-          - Save Workspace: system-functions/save.md
-          - Screen Dimensions: system-functions/sd.md
-          - Session Namespace: system-functions/se.md
-          - Execute UNIX Command: system-functions/execute-unix-command.md
-          - Start UNIX Auxiliary Processor: system-functions/start-unix-auxiliary-processor.md
-          - Shadow Name: system-functions/shadow.md
-          - Execute external program: system-functions/shell.md
-          - State Indicator: system-functions/si.md
-          - Signal Event: system-functions/signal.md
-          - Size of Object: system-functions/size.md
-          - Screen Map: system-functions/sm.md
-          - Screen Read: system-functions/sr.md
-          - Source: system-functions/src.md
-          - State Indicator Stack: system-functions/stack.md
-          - State of Object: system-functions/state.md
-          - Set Stop: system-functions/set-stop.md
-          - Query Stop: system-functions/query-stop.md
-          - Set Access Control: system-functions/set-access-control.md
-          - Query Access Control: system-functions/query-access-control.md
-          - Shared Variable Offer: system-functions/shared-variable-offer.md
-          - Query Degree of Coupling: system-functions/query-degree-of-coupling.md
-          - Shared Variable Query: system-functions/svq.md
-          - Shared Variable Retract Offer: system-functions/svr.md
-          - Shared Variable State: system-functions/svs.md
-          - Allocate Token Range: system-functions/talloc.md
-          - Terminal Control: system-functions/tc.md
-          - Thread Child Numbers: system-functions/tcnums.md
-          - Get Tokens: system-functions/tget.md
-          - This Space: system-functions/this.md
-          - Current Thread Identity: system-functions/tid.md
-          - Kill Thread: system-functions/tkill.md
-          - Current Thread Name: system-functions/tname.md
-          - Thread Numbers: system-functions/tnums.md
-          - Token Pool: system-functions/tpool.md
-          - Put Tokens: system-functions/tput.md
-          - Set Trace: system-functions/set-trace.md
-          - Query Trace: system-functions/query-trace.md
-          - Trap Event: system-functions/trap.md
-          - Token Requests: system-functions/treq.md
-          - Timestamp: system-functions/ts.md
-          - Wait for Threads to Terminate: system-functions/tsync.md
-          - Unicode Convert: system-functions/ucs.md
-          - Using Microsoft Net Search Path: system-functions/using.md
-          - Value Get: system-functions/vget.md
-          - Vector Representation: system-functions/vr.md
-          - Value Set: system-functions/vset.md
-          - Verify Fix Input: system-functions/vfi.md
-          - Workspace Available: system-functions/wa.md
-          - Windows Create Object: system-functions/wc.md
-          - Windows Get Property: system-functions/wg.md
-          - Windows Child Names: system-functions/wn.md
-          - Windows Set Property: system-functions/ws.md
-          - Workspace Identification: system-functions/wsid.md
-          - Window Expose: system-functions/wx.md
-          - XML Convert: system-functions/xml.md
-          - Extended State Indicator: system-functions/xsi.md
-          - Set External Variable: system-functions/set-external-variable.md
-          - Query External Variable: system-functions/query-external-variable.md
+          - '<code>⎕A</code>: Alphabetic Characters': system-functions/a.md
+          - '<code>⎕AI</code>: Account Information': system-functions/ai.md
+          - '<code>⎕AN</code>: Account Name': system-functions/an.md
+          - '<code>⎕ARBIN</code>: Arbitrary Input': system-functions/arbin.md
+          - '<code>⎕ARBOUT</code>: Arbitrary Output': system-functions/arbout.md
+          - '<code>⎕AT</code>: Attributes': system-functions/at.md
+          - '<code>⎕ATX</code>: Extended Attributes': system-functions/atx.md
+          - '<code>⎕AV</code>: Atomic Vector': system-functions/av.md
+          - '<code>⎕AVU</code>: Atomic Vector Unicode': system-functions/avu.md
+          - '<code>⎕BASE</code>: Base Class': system-functions/base.md
+          - '<code>⎕C</code>: Case Convert': system-functions/c.md
+          - '<code>⎕CLASS</code>: Class': system-functions/class.md
+          - '<code>⎕CLEAR</code>: Clear Workspace': system-functions/clear.md
+          - '<code>⎕CMD</code>: Execute Windows Command': system-functions/execute-windows-command.md
+          - '<code>⎕CMD</code>: Start Windows Auxiliary Processor': system-functions/start-windows-auxiliary-processor.md
+          - '<code>⎕CR</code>: Canonical Representation': system-functions/cr.md
+          - '<code>⎕CS</code>: Change Space': system-functions/cs.md
+          - '<code>⎕CSV</code>: Comma Separated Values': system-functions/csv.md
+          - '<code>⎕CT</code>: Comparison Tolerance': system-functions/ct.md
+          - '<code>⎕CY</code>: Copy Workspace': system-functions/cy.md
+          - '<code>⎕D</code>: Digits': system-functions/d.md
+          - '<code>⎕DCT</code>: Decimal Comparison Tolerance': system-functions/dct.md
+          - '<code>⎕DF</code>: Display Form': system-functions/df.md
+          - '<code>⎕DIV</code>: Division Method': system-functions/div.md
+          - '<code>⎕DL</code>: Delay': system-functions/dl.md
+          - '<code>⎕DM</code>: Diagnostic Message': system-functions/dm.md
+          - '<code>⎕DMX</code>: Extended Diagnostic Message': system-functions/dmx.md
+          - '<code>⎕DQ</code>: Dequeue Events': system-functions/dq.md
+          - '<code>⎕DR</code>: Data Representation Monadic': system-functions/data-representation-monadic.md
+          - '<code>⎕DR</code>: Data Representation Dyadic': system-functions/data-representation-dyadic.md
+          - '<code>⎕DT</code>: Datetime': system-functions/dt.md
+          - '<code>⎕ED</code>: Edit Object': system-functions/ed.md
+          - '<code>⎕EM</code>: Event Message': system-functions/em.md
+          - '<code>⎕EN</code>: Event Number': system-functions/en.md
+          - '<code>⎕EX</code>: Expunge Object': system-functions/ex.md
+          - '<code>⎕EXCEPTION</code>: Exception': system-functions/exception.md
+          - '<code>⎕EXPORT</code>: Export Object': system-functions/export.md
+          - '<code>⎕FAPPEND</code>: File Append Component': system-functions/fappend.md
+          - '<code>⎕FAVAIL</code>: File System Available': system-functions/favail.md
+          - '<code>⎕FCHK</code>: File Check and Repair': system-functions/fchk.md
+          - '<code>⎕FCOPY</code>: File Copy': system-functions/fcopy.md
+          - '<code>⎕FCREATE</code>: File Create': system-functions/fcreate.md
+          - '<code>⎕FDROP</code>: File Drop Component': system-functions/fdrop.md
+          - '<code>⎕FERASE</code>: File Erase': system-functions/ferase.md
+          - '<code>⎕FHIST</code>: File History': system-functions/fhist.md
+          - '<code>⎕FHOLD</code>: File Hold': system-functions/fhold.md
+          - '<code>⎕FIX</code>: Fix Script': system-functions/fix.md
+          - '<code>⎕FLIB</code>: Component File Library': system-functions/flib.md
+          - '<code>⎕FMT</code>: Format Monadic': system-functions/format-monadic.md
+          - '<code>⎕FMT</code>: Format Dyadic': system-functions/format-dyadic.md
+          - '<code>⎕FNAMES</code>: File Names': system-functions/fnames.md
+          - '<code>⎕FNUMS</code>: File Numbers': system-functions/fnums.md
+          - '<code>⎕FPROPS</code>: File Properties': system-functions/fprops.md
+          - '<code>⎕FR</code>: Floating Point Representation': system-functions/fr.md
+          - '<code>⎕FRDAC</code>: File Read Access': system-functions/frdac.md
+          - '<code>⎕FRDCI</code>: File Read Component Information': system-functions/frdci.md
+          - '<code>⎕FREAD</code>: File Read Component': system-functions/fread.md
+          - '<code>⎕FRENAME</code>: File Rename': system-functions/frename.md
+          - '<code>⎕FREPLACE</code>: File Replace Component': system-functions/freplace.md
+          - '<code>⎕FRESIZE</code>: File Resize': system-functions/fresize.md
+          - '<code>⎕FSIZE</code>: File Size': system-functions/fsize.md
+          - '<code>⎕FSTAC</code>: File Set Access': system-functions/fstac.md
+          - '<code>⎕FSTIE</code>: File Share Tie': system-functions/fstie.md
+          - '<code>⎕FTIE</code>: Exclusive File Tie': system-functions/ftie.md
+          - '<code>⎕FUNTIE</code>: File Untie': system-functions/funtie.md
+          - '<code>⎕FX</code>: Fix Definition': system-functions/fx.md
+          - '<code>⎕INSTANCES</code>: Instances': system-functions/instances.md
+          - '<code>⎕IO</code>: Index Origin': system-functions/io.md
+          - '<code>⎕JSON</code>: JSON Convert': system-functions/json.md
+          - '<code>⎕KL</code>: Key Label': system-functions/kl.md
+          - '<code>⎕LC</code>: Line Count': system-functions/lc.md
+          - '<code>⎕LOAD</code>: Load Workspace': system-functions/load.md
+          - '<code>⎕LOCK</code>: Lock Definition': system-functions/lock.md
+          - '<code>⎕LX</code>: Latent Expression': system-functions/lx.md
+          - '<code>⎕MAP</code>: Map File': system-functions/map.md
+          - '<code>⎕MKDIR</code>: Make Directory': system-functions/mkdir.md
+          - '<code>⎕ML</code>: Migration Level': system-functions/ml.md
+          - '<code>⎕MONITOR</code>: Set Monitor': system-functions/set-monitor.md
+          - '<code>⎕MONITOR</code>: Query Monitor': system-functions/query-monitor.md
+          - '<code>⎕NA</code>: Name Association': system-functions/na.md
+          - '<code>⎕NAPPEND</code>: Native File Append': system-functions/nappend.md
+          - '<code>⎕NC</code>: Name Classification': system-functions/nc.md
+          - '<code>⎕NCOPY</code>: Native File Copy': system-functions/ncopy.md
+          - '<code>⎕NCREATE</code>: Native File Create': system-functions/ncreate.md
+          - '<code>⎕NDELETE</code>: Native File Delete': system-functions/ndelete.md
+          - '<code>⎕NERASE</code>: Native File Erase': system-functions/nerase.md
+          - '<code>⎕NEW</code>: New Instance': system-functions/new.md
+          - '<code>⎕NEXISTS</code>: Native File Exists': system-functions/nexists.md
+          - '<code>⎕NGET</code>: Read Text File': system-functions/nget.md
+          - '<code>⎕NINFO</code>: Native File Information': system-functions/ninfo.md
+          - '<code>⎕NL</code>: Name List': system-functions/nl.md
+          - '<code>⎕NLOCK</code>: Native File Lock': system-functions/nlock.md
+          - '<code>⎕NMOVE</code>: Native File Move': system-functions/nmove.md
+          - '<code>⎕NNAMES</code>: Native File Names': system-functions/nnames.md
+          - '<code>⎕NNUMS</code>: Native File Numbers': system-functions/nnums.md
+          - '<code>⎕NPARTS</code>: File Name Parts': system-functions/nparts.md
+          - '<code>⎕NPUT</code>: Write Text File': system-functions/nput.md
+          - '<code>⎕NQ</code>: Enqueue Event': system-functions/nq.md
+          - '<code>⎕NR</code>: Nested Representation': system-functions/nr.md
+          - '<code>⎕NREAD</code>: Native File Read': system-functions/nread.md
+          - '<code>⎕NRENAME</code>: Native File Rename': system-functions/nrename.md
+          - '<code>⎕NREPLACE</code>: Native File Replace': system-functions/nreplace.md
+          - '<code>⎕NRESIZE</code>: Native File Resize': system-functions/nresize.md
+          - '<code>⎕NS</code>: Namespace': system-functions/ns.md
+          - '<code>⎕NSI</code>: Namespace Indicator': system-functions/nsi.md
+          - '<code>⎕NSIZE</code>: Native File Size': system-functions/nsize.md
+          - '<code>⎕NTIE</code>: Native File Tie': system-functions/ntie.md
+          - '<code>⎕NULL</code>: Null Item': system-functions/null.md
+          - '<code>⎕NUNTIE</code>: Native File Untie': system-functions/nuntie.md
+          - '<code>⎕NXLATE</code>: Native File Translate': system-functions/nxlate.md
+          - '<code>⎕OFF</code>: Sign Off APL': system-functions/off.md
+          - '<code>⎕OPT</code>: Variant': system-functions/opt.md
+          - '<code>⎕OR</code>: Object Representation': system-functions/or.md
+          - '<code>⎕PATH</code>: Search Path': system-functions/path.md
+          - '<code>⎕PFKEY</code>: Program Function Key': system-functions/pfkey.md
+          - '<code>⎕PP</code>: Print Precision': system-functions/pp.md
+          - '<code>⎕PROFILE</code>: Profile Application': system-functions/profile.md
+          - '<code>⎕PW</code>: Print Width': system-functions/pw.md
+          - '<code>⎕R</code>: Replace': system-functions/r.md
+          - '<code>⎕REFS</code>: Cross References': system-functions/refs.md
+          - '<code>⎕RL</code>: Random Link': system-functions/rl.md
+          - '<code>⎕RSI</code>: Space Indicator': system-functions/rsi.md
+          - '<code>⎕RTL</code>: Response Time Limit': system-functions/rtl.md
+          - '<code>⎕S</code>: Search': system-functions/s.md
+          - '<code>⎕SAVE</code>: Save Workspace': system-functions/save.md
+          - '<code>⎕SD</code>: Screen Dimensions': system-functions/sd.md
+          - '<code>⎕SE</code>: Session Namespace': system-functions/se.md
+          - '<code>⎕SH</code>: Execute UNIX Command': system-functions/execute-unix-command.md
+          - '<code>⎕SH</code>: Start UNIX Auxiliary Processor': system-functions/start-unix-auxiliary-processor.md
+          - '<code>⎕SHADOW</code>: Shadow Name': system-functions/shadow.md
+          - '<code>⎕SHELL</code>: Execute external program': system-functions/shell.md
+          - '<code>⎕SI</code>: State Indicator': system-functions/si.md
+          - '<code>⎕SIGNAL</code>: Signal Event': system-functions/signal.md
+          - '<code>⎕SIZE</code>: Size of Object': system-functions/size.md
+          - '<code>⎕SM</code>: Screen Map': system-functions/sm.md
+          - '<code>⎕SR</code>: Screen Read': system-functions/sr.md
+          - '<code>⎕SRC</code>: Source': system-functions/src.md
+          - '<code>⎕STACK</code>: State Indicator Stack': system-functions/stack.md
+          - '<code>⎕STATE</code>: State of Object': system-functions/state.md
+          - '<code>⎕STOP</code>: Set Stop': system-functions/set-stop.md
+          - '<code>⎕STOP</code>: Query Stop': system-functions/query-stop.md
+          - '<code>⎕SVC</code>: Set Access Control': system-functions/set-access-control.md
+          - '<code>⎕SVC</code>: Query Access Control': system-functions/query-access-control.md
+          - '<code>⎕SVO</code>: Shared Variable Offer': system-functions/shared-variable-offer.md
+          - '<code>⎕SVO</code>: Query Degree of Coupling': system-functions/query-degree-of-coupling.md
+          - '<code>⎕SVQ</code>: Shared Variable Query': system-functions/svq.md
+          - '<code>⎕SVR</code>: Shared Variable Retract Offer': system-functions/svr.md
+          - '<code>⎕SVS</code>: Shared Variable State': system-functions/svs.md
+          - '<code>⎕TALLOC</code>: Allocate Token Range': system-functions/talloc.md
+          - '<code>⎕TC</code>: Terminal Control': system-functions/tc.md
+          - '<code>⎕TCNUMS</code>: Thread Child Numbers': system-functions/tcnums.md
+          - '<code>⎕TGET</code>: Get Tokens': system-functions/tget.md
+          - '<code>⎕THIS</code>: This Space': system-functions/this.md
+          - '<code>⎕TID</code>: Current Thread Identity': system-functions/tid.md
+          - '<code>⎕TKILL</code>: Kill Thread': system-functions/tkill.md
+          - '<code>⎕TNAME</code>: Current Thread Name': system-functions/tname.md
+          - '<code>⎕TNUMS</code>: Thread Numbers': system-functions/tnums.md
+          - '<code>⎕TPOOL</code>: Token Pool': system-functions/tpool.md
+          - '<code>⎕TPUT</code>: Put Tokens': system-functions/tput.md
+          - '<code>⎕TRACE</code>: Set Trace': system-functions/set-trace.md
+          - '<code>⎕TRACE</code>: Query Trace': system-functions/query-trace.md
+          - '<code>⎕TRAP</code>: Trap Event': system-functions/trap.md
+          - '<code>⎕TREQ</code>: Token Requests': system-functions/treq.md
+          - '<code>⎕TS</code>: Timestamp': system-functions/ts.md
+          - '<code>⎕TSYNC</code>: Wait for Threads to Terminate': system-functions/tsync.md
+          - '<code>⎕UCS</code>: Unicode Convert': system-functions/ucs.md
+          - '<code>⎕USING</code>: Using Microsoft Net Search Path': system-functions/using.md
+          - '<code>⎕VFI</code>: Verify Fix Input': system-functions/vfi.md
+          - '<code>⎕VGET</code>: Value Get': system-functions/vget.md
+          - '<code>⎕VR</code>: Vector Representation': system-functions/vr.md
+          - '<code>⎕VSET</code>: Value Set': system-functions/vset.md
+          - '<code>⎕WA</code>: Workspace Available': system-functions/wa.md
+          - '<code>⎕WC</code>: Windows Create Object': system-functions/wc.md
+          - '<code>⎕WG</code>: Windows Get Property': system-functions/wg.md
+          - '<code>⎕WN</code>: Windows Child Names': system-functions/wn.md
+          - '<code>⎕WS</code>: Windows Set Property': system-functions/ws.md
+          - '<code>⎕WSID</code>: Workspace Identification': system-functions/wsid.md
+          - '<code>⎕WX</code>: Window Expose': system-functions/wx.md
+          - '<code>⎕XML</code>: XML Convert': system-functions/xml.md
+          - '<code>⎕XSI</code>: Extended State Indicator': system-functions/xsi.md
+          - '<code>⎕XT</code>: Set External Variable': system-functions/set-external-variable.md
+          - '<code>⎕XT</code>: Query External Variable': system-functions/query-external-variable.md
   - System Commands:
       - Introduction: system-commands/introduction.md
       - System Commands (A-Z):

--- a/pdf/mkdocs2pdf.py
+++ b/pdf/mkdocs2pdf.py
@@ -26,6 +26,13 @@ Optional switches:
 The results will end up as
 
     <project-dir>/<document>.[htm|pdf]
+
+
+NOTES:
+
+The PDF table of contents is generated entirely in paged-media CSS. It ignores the mkdocs.yml navigation titles, relying entirely on the headings in the markdown files: CSS for obvious reasons doesn't see the mkdocs.yml file.
+
+For anyone tempted to change how the ToC is generated, remember Chesterton's Fence. You break it, you own it -- and break it you will.
 """
 
 import argparse
@@ -43,97 +50,104 @@ import markdown
 from markdown.extensions.toc import slugify_unicode
 from ruamel.yaml import YAML
 
-NavItem = Union[str, List['NavItem']]
+NavItem = Union[str, List["NavItem"]]
 NavDict = Dict[str, NavItem]
 NavType = Union[List[NavDict], NavDict]
 
-def create_title_page(soup, title, subtitle=None, version_majmin=''):
+
+def create_title_page(soup, title, subtitle=None, version_majmin=""):
     """Create a title page with the specified metadata."""
-    title_page = soup.new_tag('div', **{'class': 'title-page'})
-    
+    title_page = soup.new_tag("div", **{"class": "title-page"})
+
     # Create header container
-    header_div = soup.new_tag('div', **{'class': 'header-group'})
-    
+    header_div = soup.new_tag("div", **{"class": "header-group"})
+
     # Add main title
-    h1 = soup.new_tag('h1')
+    h1 = soup.new_tag("h1")
     h1.string = title
     header_div.append(h1)
-    
+
     # Add subtitle if provided
     if subtitle:
-        h2 = soup.new_tag('h2')
+        h2 = soup.new_tag("h2")
         h2.string = subtitle
         header_div.append(h2)
-    
+
     title_page.append(header_div)
-    
+
     # Add background image and stripes
-    bg_image = soup.new_tag('div', **{'class': 'title-background'})
-    top_stripe = soup.new_tag('div', **{'class': 'title-stripe-top'})
-    bottom_stripe = soup.new_tag('div', **{'class': 'title-stripe-bottom'})
-    
+    bg_image = soup.new_tag("div", **{"class": "title-background"})
+    top_stripe = soup.new_tag("div", **{"class": "title-stripe-top"})
+    bottom_stripe = soup.new_tag("div", **{"class": "title-stripe-bottom"})
+
     title_page.append(bg_image)
     title_page.append(top_stripe)
     title_page.append(bottom_stripe)
-    
+
     # Add version info
-    version_div = soup.new_tag('div', **{'class': 'version'})        
-    version_span = soup.new_tag('span', **{'class': 'version-number'})
+    version_div = soup.new_tag("div", **{"class": "version"})
+    version_span = soup.new_tag("span", **{"class": "version-number"})
     version_span.string = str(version_majmin or "")
-    
+
     # Add "Version " text node followed by the span with the number
     version_div.append("Dyalog version ")
     version_div.append(version_span)
-    
+
     title_page.append(version_div)
-    
+
     # Create container for bottom image and tagline
-    bottom_container = soup.new_tag('div', **{'class': 'bottom-content'})
-    
+    bottom_container = soup.new_tag("div", **{"class": "bottom-content"})
+
     # Add bottom DocDyalog image
     # doc_image = soup.new_tag('img', src="../assets/img/DocDyalog.png", **{'class': 'doc-dyalog'})
     # bottom_container.append(doc_image)
 
-    doc_image = soup.new_tag('img', src="../assets/img/dyalog-logo-2025_orange.svg", **{'class': 'doc-dyalog'})
+    doc_image = soup.new_tag(
+        "img",
+        src="../assets/img/dyalog-logo-2025_orange.svg",
+        **{"class": "doc-dyalog"},
+    )
     bottom_container.append(doc_image)
-    
+
     # Add tagline
     # tagline = soup.new_tag('div', **{'class': 'tagline'})
     # tagline.string = "The tool of thought for software solutions"
     # bottom_container.append(tagline)
-    
+
     title_page.append(bottom_container)
-    
+
     return title_page
+
 
 def format_copyright(name, version, revision):
     # Get the current directory of the script
     current_dir = os.path.dirname(os.path.abspath(__file__))
-    template_path = os.path.join(current_dir, 'assets', 'templates', 'copyright.md')
-    
+    template_path = os.path.join(current_dir, "assets", "templates", "copyright.md")
+
     # Read the template file
     try:
-        with open(template_path, 'r', encoding='utf-8') as file:
+        with open(template_path, "r", encoding="utf-8") as file:
             template = file.read()
     except FileNotFoundError:
         raise FileNotFoundError(f"Copyright template not found at {template_path}")
-    
+
     # Replace the placeholders
-    content = template.replace('{NAME}', str(name))
-    content = content.replace('{VERSION}', str(version))
-    content = content.replace('{REVISION}', str(revision))
-    
+    content = template.replace("{NAME}", str(name))
+    content = content.replace("{VERSION}", str(version))
+    content = content.replace("{REVISION}", str(revision))
+
     # Convert markdown to HTML
     # Use extra=True to enable line breaks with <br>
     # Use extensions=['extra'] to enable additional markdown features
-    html = markdown.markdown(content, extensions=['extra'])
-    
+    html = markdown.markdown(content, extensions=["extra"])
+
     return html
+
 
 def get_git_info(repo_path=None):
     """Get git info from environment variable or git commands."""
     # First try environment variable
-    git_info = os.environ.get('GIT_INFO')
+    git_info = os.environ.get("GIT_INFO")
     if git_info:
         return git_info
 
@@ -141,49 +155,53 @@ def get_git_info(repo_path=None):
     try:
         # Get branch name
         branch = run(
-            ['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
-            capture_output=True, 
-            text=True, 
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
             check=True,
-            cwd=repo_path
+            cwd=repo_path,
         )
 
         # Get commit hash
         hash_result = run(
-            ['git', 'rev-parse', '--short', 'HEAD'],
-            capture_output=True, 
-            text=True, 
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
             check=True,
-            cwd=repo_path
+            cwd=repo_path,
         )
-        
+
         return f"{branch.stdout.strip()}:{hash_result.stdout.strip()}"
     except (CalledProcessError, FileNotFoundError):
         return "unknown"
-    
+
+
 def get_build_date():
     """Get build date from environment variable or current time."""
     # First try environment variable
-    build_date = os.environ.get('BUILD_DATE')
+    build_date = os.environ.get("BUILD_DATE")
     if build_date:
         return build_date
 
     # Fall back to current date
     return datetime.now().strftime("%Y-%m-%d")
 
+
 def shift_headings(soup: BeautifulSoup, n: int, article_id: str) -> None:
     # Find all heading tags
-    headings = soup.find_all(re.compile('^h[1-6]$'))
+    headings = soup.find_all(re.compile("^h[1-6]$"))
 
     delta = 0  # The first heading is considered to be the "h1" -- the rest must be at least one deeper.
 
     # Modify each heading tag
     for tag in headings:
         current_level = int(tag.name[1])  # Extract the current heading level
-        new_level = min(max(current_level + n + delta, 1), 6)  # Ensure new level is between 1 and 6
-        tag.name = f'h{new_level}'
+        new_level = min(
+            max(current_level + n + delta, 1), 6
+        )  # Ensure new level is between 1 and 6
+        tag.name = f"h{new_level}"
         if delta == 0:
-            tag.attrs['id'] = f'{article_id}-header'
+            tag.attrs["id"] = f"{article_id}-header"
         delta = 1
 
 
@@ -191,29 +209,35 @@ def clean_img_src(soup: BeautifulSoup) -> None:
     """
     Find all image tags in the given HTML content and remove any leading dots and slashes
     """
-    for img_tag in soup.find_all('img'):
-        src = img_tag.get('src')
+    for img_tag in soup.find_all("img"):
+        src = img_tag.get("src")
         if src:
-            new_src = src.lstrip('./')
-            img_tag['src'] = new_src
+            new_src = src.lstrip("./")
+            img_tag["src"] = new_src
 
 
 def remove_paths(data: Union[dict, list], paths: List[List[str]]) -> Union[dict, list]:
     if isinstance(data, dict):
-        for key in list(data.keys()):  # Clone to avoid problems with mutation during iteration
+        for key in list(
+            data.keys()
+        ):  # Clone to avoid problems with mutation during iteration
             # Check if this key matches any of the first keys in paths
             matching_paths = [path for path in paths if path and path[0] == key]
             if matching_paths:
                 if len(matching_paths[0]) == 1:
                     del data[key]  # Full path matches; remove this key
                 else:  # Recurse into the value
-                    data[key] = remove_paths(data[key], [path[1:] for path in matching_paths])
+                    data[key] = remove_paths(
+                        data[key], [path[1:] for path in matching_paths]
+                    )
                     if not data[key]:  # If the value is now empty, remove the key
                         del data[key]
     elif isinstance(data, list):
         for item in data:
             remove_paths(item, paths)
-        data = [item for item in data if item]  # Remove any empty dictionaries from the list
+        data = [
+            item for item in data if item
+        ]  # Remove any empty dictionaries from the list
     return data
 
 
@@ -223,11 +247,11 @@ def parse_mkdocs_yml(yml_file: str, remove: List[List[str]]) -> dict:
     elements from the nav-section based on key paths.
     """
     yaml = YAML()
-    with (open(yml_file, 'r', encoding='utf-8')) as f:
+    with open(yml_file, "r", encoding="utf-8") as f:
         data = yaml.load(f)
 
-    if 'nav' in data and remove:
-        data['nav'] = remove_paths(data['nav'], remove)
+    if "nav" in data and remove:
+        data["nav"] = remove_paths(data["nav"], remove)
 
     return data
 
@@ -236,34 +260,36 @@ def extract_html_h1(data: str) -> str:
     """
     Some files will have a raw HTML <h1> for styling reasons.
     """
-    soup = BeautifulSoup(data, 'html.parser')
-    if h1 := soup.find('h1'):
-        if name_span := h1.find('span', class_='name'):
+    soup = BeautifulSoup(data, "html.parser")
+    if h1 := soup.find("h1"):
+        if name_span := h1.find("span", class_="name"):
             name = name_span.get_text() if name_span else None
             if name:
-                return name.strip().replace('"', '').replace('`', '')
+                return name.strip().replace('"', "").replace("`", "")
         else:
-            return h1.get_text().strip().replace('"', '').replace('`', '')
-    return ''
+            return h1.get_text().strip().replace('"', "").replace("`", "")
+    return ""
 
 
 def extract_h1(filename: str) -> str:
     """
     Find the H1, either markdown or HTML-style
     """
-    with open(filename, 'r', encoding='utf-8') as f:
+    with open(filename, "r", encoding="utf-8") as f:
         data = f.read()
 
     if h1 := extract_html_h1(data):
         return h1
 
-    if h1 := re.findall(r'^#\s+(.+)$', data):
+    if h1 := re.findall(r"^#\s+(.+)$", data):
         return h1[0]
 
-    return ''
+    return ""
 
 
-def find_source_files(prefix: str, nav: NavType, path: List[str] = None) -> Generator[Tuple[List[str], str], None, None]:
+def find_source_files(
+    prefix: str, nav: NavType, path: List[str] = None
+) -> Generator[Tuple[List[str], str], None, None]:
     if path is None:
         path = []
 
@@ -273,14 +299,14 @@ def find_source_files(prefix: str, nav: NavType, path: List[str] = None) -> Gene
             if isinstance(value, str):
                 yield current_path, value
             else:
-                yield current_path, ''  # Represent the key-path to an empty string
+                yield current_path, ""  # Represent the key-path to an empty string
                 yield from find_source_files(prefix, value, current_path)
     elif isinstance(nav, list):
         for item in nav:
             yield from find_source_files(prefix, item, path)
     elif isinstance(nav, str):
         # No key. Pick the H1.
-        key = extract_h1(os.path.join(prefix, 'docs', nav))
+        key = extract_h1(os.path.join(prefix, "docs", nav))
         current_path = path + [key]
         yield current_path, nav
 
@@ -296,11 +322,11 @@ def expand_macros(data: str, macros: dict) -> str:
         value = macros.get(key)
         return str(value) if not isinstance(value, dict) else match.group(0)
 
-    return re.sub(r'\{\{\s*(.*?)\s*}}', replace, data)
+    return re.sub(r"\{\{\s*(.*?)\s*}}", replace, data)
 
 
 def slug(text: str) -> str:
-    return re.sub(r'\W+', '-', text).lower()
+    return re.sub(r"\W+", "-", text).lower()
 
 
 def print_footnotes(soup: BeautifulSoup) -> None:
@@ -310,34 +336,38 @@ def print_footnotes(soup: BeautifulSoup) -> None:
     footnote_defs = {}
 
     # Find all footnote definitions
-    for footnote in soup.select('div.footnote ol li'):
-        footnote_id = footnote.get('id')
-        if footnote_id and footnote_id.startswith('fn:'):
+    for footnote in soup.select("div.footnote ol li"):
+        footnote_id = footnote.get("id")
+        if footnote_id and footnote_id.startswith("fn:"):
             # Extract the text from the footnote definition
-            p_tag = footnote.find('p')
-            footnote_text = ''.join(
-                str(c) for c in p_tag.contents if not (c.name == 'a' and 'footnote-backref' in c.get('class', [])))
+            p_tag = footnote.find("p")
+            footnote_text = "".join(
+                str(c)
+                for c in p_tag.contents
+                if not (c.name == "a" and "footnote-backref" in c.get("class", []))
+            )
             footnote_defs[footnote_id] = footnote_text.strip()
 
     # Find all footnote references
-    footnote_refs = soup.find_all('sup', id=lambda x: x and x.startswith('fnref:'))
+    footnote_refs = soup.find_all("sup", id=lambda x: x and x.startswith("fnref:"))
 
     # Replace footnote references with inlined footnotes
     for ref in footnote_refs:
-        footnote_id = ref.find('a').get('href', '').lstrip('#')
+        footnote_id = ref.find("a").get("href", "").lstrip("#")
         if footnote_id in footnote_defs:
-            new_span = soup.new_tag('span', **{'class': 'footnote'})
+            new_span = soup.new_tag("span", **{"class": "footnote"})
             new_span.string = footnote_defs[footnote_id]
             ref.replace_with(new_span)
 
     # Remove the original footnote definitions section
-    footnote_div = soup.find('div', class_='footnote')
+    footnote_div = soup.find("div", class_="footnote")
     if footnote_div:
         footnote_div.decompose()
 
+
 def add_caption(soup, table, caption_text, table_seq) -> None:
-    caption = soup.new_tag('caption', style="caption-side:top")
-    strong = soup.new_tag('strong')
+    caption = soup.new_tag("caption", style="caption-side:top")
+    strong = soup.new_tag("strong")
     strong.string = f"Table {table_seq}:"
     caption.append(strong)
     caption.append(" ")
@@ -347,20 +377,20 @@ def add_caption(soup, table, caption_text, table_seq) -> None:
 
 def caption_tables(soup: BeautifulSoup) -> Dict[str, int]:
     def is_chapter(tag):
-        return tag.name == 'section' and tag.has_attr('data-chapter-seq')
+        return tag.name == "section" and tag.has_attr("data-chapter-seq")
 
-    tables = soup.find_all('table')
+    tables = soup.find_all("table")
 
-    custom_id_caption_re = re.compile(r'^\s*Table:\s*([^{]+)\s*\{:\s*#([^ }]+)\s*}\s*$')
-    normal_caption_re = re.compile(r'^\s*Table:\s*(. *)\s*$')
+    custom_id_caption_re = re.compile(r"^\s*Table:\s*([^{]+)\s*\{:\s*#([^ }]+)\s*}\s*$")
+    normal_caption_re = re.compile(r"^\s*Table:\s*(. *)\s*$")
 
     table_refs: Dict[str, int] = {}
 
     for section in soup.find_all(is_chapter):
         table_seq = 1
-        for table in section.find_all('table'):
+        for table in section.find_all("table"):
             prev = table.find_previous_sibling()
-            if prev and prev.name == 'p' and 'Table:' in prev.text:
+            if prev and prev.name == "p" and "Table:" in prev.text:
                 table_id: str = None
                 tref = f'{section["data-chapter-seq"]}-{table_seq}'
                 if match := custom_id_caption_re.match(prev.text):
@@ -375,84 +405,96 @@ def caption_tables(soup: BeautifulSoup) -> Dict[str, int]:
                     continue
 
                 if table_id in table_refs:
-                    print(f'WARNING: recurring table id: {table_id}')
+                    print(f"WARNING: recurring table id: {table_id}")
 
                 table_refs[table_id] = tref
                 prev.decompose()
                 table_seq += 1
-                table['id'] = table_id
+                table["id"] = table_id
 
     return table_refs
 
 
 def convert_examples(soup: BeautifulSoup) -> None:
-    headers = soup.find_all(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'], class_='example')
+    headers = soup.find_all(["h1", "h2", "h3", "h4", "h5", "h6"], class_="example")
     for header in headers:
-        p_tag = soup.new_tag('p', **{'class': 'example'})
+        p_tag = soup.new_tag("p", **{"class": "example"})
         p_tag.string = header.string
         header.replace_with(p_tag)
 
+
 def update_seq_stack(seq_stack, s):
-    for i in range(s+1, len(seq_stack)):
+    for i in range(s + 1, len(seq_stack)):
         seq_stack[i] = 0
     seq_stack[s] += 1
 
 
-def convert_to_html(filenames: Iterator[str], prefix: str, title: str, macros: dict,
-    transforms: List[Callable[[str], str]], create_toc: bool = True, enumerate_sections: bool = True, 
-    syntax_hilite: bool = True, git_info = '', build_date = '') -> Tuple[Dict[str, str], str, Dict[str, str]]:
+def convert_to_html(
+    filenames: Iterator[str],
+    prefix: str,
+    title: str,
+    macros: dict,
+    transforms: List[Callable[[str], str]],
+    create_toc: bool = True,
+    enumerate_sections: bool = True,
+    syntax_hilite: bool = True,
+    git_info="",
+    build_date="",
+) -> Tuple[Dict[str, str], str, Dict[str, str]]:
     """
     Markdown to HTML, using the same markdown extensions as our mkdocs site. Concatenate all converted files
     into a single HTML file, wrapping into <section>s of <article>s.
     """
-    
+
     def process_markdown(file_path, article_id, remove_first_heading=False):
         """
         Convert Markdown to HTML, using the same extensions as used by our mkdocs setup.
         """
         extensions = [
-            'admonition',                # https://python-markdown.github.io/extensions/admonition/
-            'attr_list',                 # https://python-markdown.github.io/extensions/attr_list/
-            'footnotes',                 # https://python-markdown.github.io/extensions/footnotes/
-            'md_in_html',                # https://python-markdown.github.io/extensions/md_in_html/
-            'markdown_tables_extended',  # https://github.com/fumbles/tables_extended
-            'pymdownx.details',          # https://facelessuser.github.io/pymdown-extensions/extensions/details/
-            'toc',                       # https://python-markdown.github.io/extensions/toc/
+            "admonition",  # https://python-markdown.github.io/extensions/admonition/
+            "attr_list",  # https://python-markdown.github.io/extensions/attr_list/
+            "footnotes",  # https://python-markdown.github.io/extensions/footnotes/
+            "md_in_html",  # https://python-markdown.github.io/extensions/md_in_html/
+            "markdown_tables_extended",  # https://github.com/fumbles/tables_extended
+            "pymdownx.details",  # https://facelessuser.github.io/pymdown-extensions/extensions/details/
+            "toc",  # https://python-markdown.github.io/extensions/toc/
         ]
         if syntax_hilite:
-            extensions.append('pymdownx.superfences')
+            extensions.append("pymdownx.superfences")
         else:
-            extensions.append('fenced_code')
-        
+            extensions.append("fenced_code")
+
         def custom_slugify(value, separator):
-            return article_id + '-' + slugify_unicode(value, separator)
-        
-        extension_configs = {'toc': {'slugify': custom_slugify}}
+            return article_id + "-" + slugify_unicode(value, separator)
+
+        extension_configs = {"toc": {"slugify": custom_slugify}}
 
         with open(file_path, "r", encoding="utf-8") as f:
             md = f.read()
-        
+
         # Apply macros and any pre-html transforms
         md = expand_macros(md, macros)
         for fun in transforms:
             md = fun(md)
-        
+
         # Convert to HTML
-        body = markdown.markdown(md, extensions=extensions, extension_configs=extension_configs)
-        soup = BeautifulSoup(body, 'html.parser')
-        
+        body = markdown.markdown(
+            md, extensions=extensions, extension_configs=extension_configs
+        )
+        soup = BeautifulSoup(body, "html.parser")
+
         # Optionally remove the first h1 heading
         if remove_first_heading:
-            if h1 := soup.find('h1'):
+            if h1 := soup.find("h1"):
                 h1.decompose()
-        
+
         # Apply standard processing
         print_footnotes(soup)
         clean_img_src(soup)
         convert_examples(soup)
-        
-        return str(soup).replace('``', '')
-    
+
+        return str(soup).replace("``", "")
+
     # Initialise TOC and articles content
     toc = """
 <article id="contents">
@@ -466,7 +508,7 @@ def convert_to_html(filenames: Iterator[str], prefix: str, title: str, macros: d
     section_map = {}
     seq_stack = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     path_to_id = {}  # New mapping from file paths to article IDs
-    
+
     # Process all files
     for keypath, file in filenames:
         # Close any sections that need to be closed
@@ -476,20 +518,20 @@ def convert_to_html(filenames: Iterator[str], prefix: str, title: str, macros: d
             articles += "</section>\n"
 
         # Case 1: Directory/Section entry
-        if file == '':
+        if file == "":
             section_stack.append(keypath)
             heading_level = len(section_stack)
             heading_text = keypath[-1]
-            section_id = '-'.join(slug(part) for part in keypath)
+            section_id = "-".join(slug(part) for part in keypath)
 
             # Update section numbering
             update_seq_stack(seq_stack, len(section_stack) - 1)
-            section_map[section_id] = '.'.join(str(c) for c in seq_stack if c > 0)
+            section_map[section_id] = ".".join(str(c) for c in seq_stack if c > 0)
 
             # Top-level section = chapter
             if heading_level == 1:
                 chapter_number += 1
-                front_matter = ''
+                front_matter = ""
                 articles += f'<section id="{section_id}" data-chapter-seq="{chapter_number}">\n<h1 id="{section_id}-header" class="chapter">{heading_text}</h1>\n'
                 toc += f'<li class="toc-chapter"><a href="#{section_id}-header" class="toc"></a><ul class="first-level">\n'
             else:
@@ -499,62 +541,64 @@ def convert_to_html(filenames: Iterator[str], prefix: str, title: str, macros: d
 
         # Case 2: Top-level file (treat as chapter)
         is_top_level = len(keypath) == 1 and not section_stack
-        
+
         if is_top_level:
             chapter_number += 1
-            front_matter = ''
+            front_matter = ""
             heading_text = keypath[0]
-            
+
             # Create section for this chapter
             section_id = slug(heading_text)
             heading_id = f"{section_id}-header"
-            articles += f'<section id="{section_id}" data-chapter-seq="{chapter_number}">\n'
+            articles += (
+                f'<section id="{section_id}" data-chapter-seq="{chapter_number}">\n'
+            )
             articles += f'<h1 id="{heading_id}" class="chapter">{heading_text}</h1>\n'
-            
+
             # Add to TOC
             toc += f'<li class="toc-chapter"><a href="#{heading_id}" class="toc"></a><ul class="first-level">\n'
-            
+
             # Update section stack and numbering
             section_stack.append(keypath)
             update_seq_stack(seq_stack, 0)
             section_map[section_id] = str(chapter_number)
-        elif front_matter == '':
+        elif front_matter == "":
             update_seq_stack(seq_stack, len(section_stack))
 
         # Create article
-        article_id = file.replace('/', '-').replace('.md', '')
+        article_id = file.replace("/", "-").replace(".md", "")
         tie_breaker = 0
         test_id = article_id
         while test_id in section_map:
             tie_breaker += 1
-            test_id = article_id + f'-{tie_breaker}'
+            test_id = article_id + f"-{tie_breaker}"
         article_id = test_id
-        
+
         # Update mappings
-        section_map[article_id] = '.'.join(str(c) for c in seq_stack if c > 0)
+        section_map[article_id] = ".".join(str(c) for c in seq_stack if c > 0)
         path_to_id[file] = article_id  # Map file path to article ID
-        
+
         # Add to TOC (except for top-level file articles since they're already in TOC)
         if not is_top_level:
             toc += f'<li{front_matter}><a href="#{article_id}-header" class="toc"></a></li>\n'
-        
+
         # Process and add article content
         articles += f'<article id="{article_id}">\n'
         html_content = process_markdown(
-            os.path.join(prefix, file), 
+            os.path.join(prefix, file),
             article_id,  # Pass article_id to process_markdown
-            remove_first_heading=is_top_level
+            remove_first_heading=is_top_level,
         )
-        
+
         # For non-top-level files, handle headings
         if not is_top_level:
-            soup = BeautifulSoup(html_content, 'html.parser')
+            soup = BeautifulSoup(html_content, "html.parser")
             shift_headings(soup, len(section_stack), article_id)
             html_content = str(soup)
-        
+
         articles += html_content
         articles += "\n</article>\n"
-        
+
         # For top-level files, we're done with this file
         if is_top_level:
             continue
@@ -595,6 +639,7 @@ def convert_to_html(filenames: Iterator[str], prefix: str, title: str, macros: d
 """
     return section_map, result, path_to_id  # Return path_to_id
 
+
 def copy_directory(src, dst):
     """
     Copy a directory and all its content from src to dst.
@@ -608,11 +653,11 @@ def copy_directory(src, dst):
     shutil.copytree(src, dst)
 
 
-def static_assets(src_dir='assets', project='project') -> None:
+def static_assets(src_dir="assets", project="project") -> None:
     """
     Copy the entire 'assets' directory into the project directory
     """
-    dest_dir = os.path.join(project, 'assets')
+    dest_dir = os.path.join(project, "assets")
 
     if os.path.exists(dest_dir):
         shutil.rmtree(dest_dir)
@@ -646,36 +691,43 @@ def fix_links(b: str) -> str:
         # as a post-conversion step. Peel off any page reference
         # prior to the id. We're now dealing with a single page.
         # Let's hope table ids are unique.
-        if link_text == '':
+        if link_text == "":
             return f"[TABLE-REFERENCE]({re.sub(r'^[^#]+', '', link_target)})"
 
-        if link_target.startswith('http'):  # Off-site link: return unchanged
-            return f'[{link_text}]({link_target})'
-        
+        if link_target.startswith("http"):  # Off-site link: return unchanged
+            return f"[{link_text}]({link_target})"
+
         # If the link contains an internal anchor (#), return unchanged
-        if '#' in link_target:
-            return f'[{link_text}]({link_target})'
+        if "#" in link_target:
+            return f"[{link_text}]({link_target})"
 
         path, name = os.path.split(link_target)
         base, ext = os.path.splitext(name)
-        htm_target = f'{os.path.join(path, base)}.htm'
+        htm_target = f"{os.path.join(path, base)}.htm"
 
-        if ext == '.md':  # Intra-doc link: change extension to ".htm"
-            return f'[{link_text}]({htm_target})'
+        if ext == ".md":  # Intra-doc link: change extension to ".htm"
+            return f"[{link_text}]({htm_target})"
 
-        if ext == '':  # Inter-doc link: make absolute, change extension
+        if ext == "":  # Inter-doc link: make absolute, change extension
             # Replace any number of leading ../ with a single /
-            no_slashdot = re.sub(r'^[/.]+', '/', htm_target)
-            return f'[{link_text}]({no_slashdot})'
+            no_slashdot = re.sub(r"^[/.]+", "/", htm_target)
+            return f"[{link_text}]({no_slashdot})"
 
         # Something else; leave alone
-        return f'[{link_text}]({link_target})'
+        return f"[{link_text}]({link_target})"
 
     # Exclude markdown images (which start with !)
-    return re.sub(r'(?<!!)\[([^]]*)]\(([^)]+)\)', link_transform, b)
+    return re.sub(r"(?<!!)\[([^]]*)]\(([^)]+)\)", link_transform, b)
 
-def normalise_links(soup: BeautifulSoup, documents: Dict[str, str], table_refs: Dict[str, int], 
-                    section_map: Dict[str, str], path_to_id: Dict[str, str], rewrite_links: bool = True) -> None:
+
+def normalise_links(
+    soup: BeautifulSoup,
+    documents: Dict[str, str],
+    table_refs: Dict[str, int],
+    section_map: Dict[str, str],
+    path_to_id: Dict[str, str],
+    rewrite_links: bool = True,
+) -> None:
     """
     Rewrite internal links to point to correct article IDs within the single HTML file using file path resolution.
     Optionally rewrite link text to section numbers for print-friendliness.
@@ -684,134 +736,142 @@ def normalise_links(soup: BeautifulSoup, documents: Dict[str, str], table_refs: 
     def in_table(tag):
         # Check if a tag is nested inside a table
         while tag:
-            if tag.name == 'table':
+            if tag.name == "table":
                 return True
             tag = tag.parent
         return False
 
     def extract_components(href):
         # Remove leading ../ and .htm or .html extension. Split on '/'
-        href = re.sub(r'^[/.]+', '', href)
-        href = re.sub(r'\.html?$', '', href)
-        return [comp for comp in href.split('/') if comp]
+        href = re.sub(r"^[/.]+", "", href)
+        href = re.sub(r"\.html?$", "", href)
+        return [comp for comp in href.split("/") if comp]
 
     def unslug(text):
         # Convert slug to readable text
-        return text.replace('-', ' ').title()
+        return text.replace("-", " ").title()
 
     # Create inverse mapping from article IDs to file paths
     id_to_path = {v: k for k, v in path_to_id.items()}
-    
+
     # Find all articles and their IDs, excluding copyright page
-    articles = soup.find_all('article')
+    articles = soup.find_all("article")
     article_ids = {
-        article['id'] for article in articles 
-        if not article.get('class') or 'copyright-page' not in article.get('class')
+        article["id"]
+        for article in articles
+        if not article.get("class") or "copyright-page" not in article.get("class")
     }
 
     # Process all <a> tags
-    for a_tag in soup.find_all('a', href=True):
-        href = a_tag['href']
-        if 'noprint' in a_tag.get('class', []):
+    for a_tag in soup.find_all("a", href=True):
+        href = a_tag["href"]
+        if "noprint" in a_tag.get("class", []):
             a_tag.decompose()
             continue
 
         a_text = a_tag.get_text()
-        if a_text == 'TABLE-REFERENCE':
+        if a_text == "TABLE-REFERENCE":
             if table_id := table_refs.get(href[1:]):
-                a_tag.string = f'Table {table_id}'
-                if 'class' in a_tag.attrs:
-                    a_tag['class'].append('internal-link')
+                a_tag.string = f"Table {table_id}"
+                if "class" in a_tag.attrs:
+                    a_tag["class"].append("internal-link")
                 else:
-                    a_tag['class'] = ['internal-link']
+                    a_tag["class"] = ["internal-link"]
             else:
                 print(f'--> Warning: could not find a matching table for id "{href}"')
             continue
 
-        if not href.startswith('http'):
+        if not href.startswith("http"):
             # Split off anchor if present
-            path_parts = href.split('#', maxsplit=1)
+            path_parts = href.split("#", maxsplit=1)
             path = path_parts[0]
             anchor = path_parts[1] if len(path_parts) > 1 else None
-            
+
             if not path:
                 continue
 
-            if path.startswith('/'):
+            if path.startswith("/"):
                 # Handle potential inter-document links
                 components = extract_components(path)
                 if components and components[0] in documents:
-                    new_tag = soup.new_tag('i')
+                    new_tag = soup.new_tag("i")
                     text_parts = [documents[components[0]]]
                     if len(components) > 1:
                         text_parts.append(unslug(components[-1]))
-                    new_tag.string = ': '.join(text_parts)
+                    new_tag.string = ": ".join(text_parts)
                     a_tag.replace_with(new_tag)
                 else:
                     # For unresolvable absolute links, replace with italics
-                    new_tag = soup.new_tag('i')
+                    new_tag = soup.new_tag("i")
                     new_tag.string = a_text
                     a_tag.replace_with(new_tag)
                     print(f"--> Warning: can't resolve absolute link '{href}'")
             else:
                 # Internal link: resolve using source file path
-                parent_article = a_tag.find_parent('article')
-                if parent_article and 'id' in parent_article.attrs:
-                    source_id = parent_article['id']
+                parent_article = a_tag.find_parent("article")
+                if parent_article and "id" in parent_article.attrs:
+                    source_id = parent_article["id"]
                     if source_id in id_to_path:
                         source_path = id_to_path[source_id]
                         source_dir = os.path.dirname(source_path)
-                        target_rel_path = os.path.normpath(os.path.join(source_dir, path)).replace('.htm', '.md').replace('.html', '.md')
+                        target_rel_path = (
+                            os.path.normpath(os.path.join(source_dir, path))
+                            .replace(".htm", ".md")
+                            .replace(".html", ".md")
+                        )
                         if target_rel_path in path_to_id:
                             target_id = path_to_id[target_rel_path]
                             if anchor:
                                 new_href = f"#{target_id}-{anchor}"
                             else:
                                 new_href = f"#{target_id}-header"
-                            a_tag['href'] = new_href
+                            a_tag["href"] = new_href
                             if rewrite_links:
-                                if 'class' in a_tag.attrs:
-                                    a_tag['class'].append('internal-link')
+                                if "class" in a_tag.attrs:
+                                    a_tag["class"].append("internal-link")
                                 else:
-                                    a_tag['class'] = ['internal-link']
+                                    a_tag["class"] = ["internal-link"]
                                 if not in_table(a_tag):
                                     if reference := section_map.get(target_id):
-                                        if '.' in reference:
-                                            a_tag.string = f'Section {reference}'
+                                        if "." in reference:
+                                            a_tag.string = f"Section {reference}"
                                         else:
-                                            a_tag.string = f'Chapter {reference}'
+                                            a_tag.string = f"Chapter {reference}"
                         else:
                             # Replace unresolvable link with italics
-                            new_tag = soup.new_tag('i')
+                            new_tag = soup.new_tag("i")
                             new_tag.string = a_text
                             a_tag.replace_with(new_tag)
-                            print(f'--> Warning: target path "{target_rel_path}" not found')
+                            print(
+                                f'--> Warning: target path "{target_rel_path}" not found'
+                            )
                     else:
                         # Replace link with italics if source ID not found
-                        new_tag = soup.new_tag('i')
+                        new_tag = soup.new_tag("i")
                         new_tag.string = a_text
                         a_tag.replace_with(new_tag)
                         print(f'--> Warning: source article ID "{source_id}" not found')
                 else:
                     # Replace link with italics if no parent article found
-                    new_tag = soup.new_tag('i')
+                    new_tag = soup.new_tag("i")
                     new_tag.string = a_text
                     a_tag.replace_with(new_tag)
                     print(f'--> Warning: no parent article found for link "{href}"')
 
+
 def toc_friendly_headings(soup: BeautifulSoup) -> None:
     # Find all headings with class "heading"
-    for heading in soup.find_all(class_='heading'):
+    for heading in soup.find_all(class_="heading"):
         # Ensure it has the specific structure we're looking for
-        name_span = heading.find('span', class_='name')
-        command_span = heading.find('span', class_='command')
+        name_span = heading.find("span", class_="name")
+        command_span = heading.find("span", class_="command")
 
         if name_span and command_span:
             # Create the new structure
-            heading_container = soup.new_tag('div', **{'class': 'heading-container'})
+            heading_container = soup.new_tag("div", **{"class": "heading-container"})
             new_heading = soup.new_tag(heading.name, **heading.attrs)
             new_heading.string = name_span.text
-            command_div = soup.new_tag('div', **{'class': 'command'})
+            command_div = soup.new_tag("div", **{"class": "command"})
             command_div.string = command_span.text
 
             # Assemble the new structure
@@ -821,18 +881,19 @@ def toc_friendly_headings(soup: BeautifulSoup) -> None:
             # Replace the old heading with the new structure
             heading.replace_with(heading_container)
 
+
 def toplevel_docs(nav: List[Dict[str, str]]) -> Dict[str, str]:
     result = {}
     for entry in nav:
         for doc_name, include_path in entry.items():
             if "!include" in include_path:
                 # This is a directory include
-                path = include_path.split(' ')[1]
-                first_component = path.split('/')[1]
+                path = include_path.split(" ")[1]
+                first_component = path.split("/")[1]
                 result[first_component] = doc_name
             else:
                 # This is a direct file reference
-                path_parts = include_path.split('/')
+                path_parts = include_path.split("/")
                 # Use the filename without extension as the key
                 if len(path_parts) > 0:
                     filename = path_parts[-1]
@@ -840,25 +901,36 @@ def toplevel_docs(nav: List[Dict[str, str]]) -> Dict[str, str]:
                     result[file_base] = doc_name
     return result
 
+
 def process_document(document_path):
     """Process a single document directory."""
-    if document_path.endswith('/'):
+    if document_path.endswith("/"):
         document_path = document_path[:-1]
 
     # Get document metadata if using config file
     doc_metadata = None
     if args.config:
-        with open(args.config, 'r', encoding='utf-8') as f:
+        with open(args.config, "r", encoding="utf-8") as f:
             config = json.load(f)
-            if isinstance(config.get('documents'), dict):
-                doc_metadata = config['documents'].get(document_path)
+            if isinstance(config.get("documents"), dict):
+                doc_metadata = config["documents"].get(document_path)
 
     # If there is a print-specific yml file, use that. Otherwise, use the normal mkdocs.yml file.
-    doc_mkdocs_file = str(os.path.join(os.path.abspath(os.path.dirname(args.mkdocs_yml)), 
-                                      document_path, 'print_mkdocs.yml'))
+    doc_mkdocs_file = str(
+        os.path.join(
+            os.path.abspath(os.path.dirname(args.mkdocs_yml)),
+            document_path,
+            "print_mkdocs.yml",
+        )
+    )
     if not os.path.isfile(doc_mkdocs_file):
-        doc_mkdocs_file = str(os.path.join(os.path.abspath(os.path.dirname(args.mkdocs_yml)), 
-                                          document_path, 'mkdocs.yml'))
+        doc_mkdocs_file = str(
+            os.path.join(
+                os.path.abspath(os.path.dirname(args.mkdocs_yml)),
+                document_path,
+                "mkdocs.yml",
+            )
+        )
         if not os.path.isfile(doc_mkdocs_file):
             sys.exit(f'--> document mkdocs.yml file "{doc_mkdocs_file}" not found.')
 
@@ -866,54 +938,58 @@ def process_document(document_path):
     yml_data = parse_mkdocs_yml(doc_mkdocs_file, remove=excludes)
 
     # Find all source Markdown files in depth-first traversal order
-    md_files = find_source_files(os.path.dirname(doc_mkdocs_file), yml_data['nav'])
+    md_files = find_source_files(os.path.dirname(doc_mkdocs_file), yml_data["nav"])
 
     # Copy img dir for this document
-    img_dest_dir = str(os.path.join(args.project_dir, 'img'))
+    img_dest_dir = str(os.path.join(args.project_dir, "img"))
     if os.path.exists(img_dest_dir):
         shutil.rmtree(img_dest_dir)
-    copy_directory(str(os.path.join(os.path.dirname(doc_mkdocs_file), 'docs', 'img')), img_dest_dir)
+    copy_directory(
+        str(os.path.join(os.path.dirname(doc_mkdocs_file), "docs", "img")), img_dest_dir
+    )
 
     # Convert each Markdown file to HTML, and concatenate to a single string
-    source = f'{args.project_dir}/{document_path}.htm'
+    source = f"{args.project_dir}/{document_path}.htm"
     section_map, html_content, path_to_id = convert_to_html(  # Receive path_to_id
         md_files,
-        prefix=os.path.join(os.path.dirname(doc_mkdocs_file), 'docs'),
-        title=yml_data['site_name'],
-        macros=top_mkdocs_data.get('extra', {}),
+        prefix=os.path.join(os.path.dirname(doc_mkdocs_file), "docs"),
+        title=yml_data["site_name"],
+        macros=top_mkdocs_data.get("extra", {}),
         transforms=[fix_links],
         create_toc=args.toc,
         enumerate_sections=args.enumerate_sections,
         syntax_hilite=args.syntax_hilite,
         git_info=git_info,
-        build_date=build_date
+        build_date=build_date,
     )
 
     # Global transforms on the unified HTML-file.
-    soup = BeautifulSoup(html_content, 'html.parser')
+    soup = BeautifulSoup(html_content, "html.parser")
 
     # Add the title page if metadata is available
     if doc_metadata:
         version_majmin = top_mkdocs_data["extra"].get("version_majmin", "")
         title_page = create_title_page(
             soup,
-            doc_metadata.get('title'),
-            doc_metadata.get('subtitle'),
-            version_majmin
+            doc_metadata.get("title"),
+            doc_metadata.get("subtitle"),
+            version_majmin,
         )
 
         # Insert title page at the start of the body
         soup.body.insert(0, title_page)
 
         # Add copyright page
-        copyright_html = format_copyright(f"{doc_metadata.get('title')} {doc_metadata.get('subtitle', '')}", 
-                                         top_mkdocs_data["extra"].get("version_majmin", ""), 
-                                         f"{build_date} {git_info}")
-        copyright_soup = BeautifulSoup(copyright_html, 'html.parser')
+        copyright_html = format_copyright(
+            f"{doc_metadata.get('title')} {doc_metadata.get('subtitle', '')}",
+            top_mkdocs_data["extra"].get("version_majmin", ""),
+            f"{build_date} {git_info}",
+        )
+        copyright_soup = BeautifulSoup(copyright_html, "html.parser")
 
         # Create a section for the copyright page
-        copyright_section = soup.new_tag('section', **{'class': 'copyright-section'})
-        copyright_article = soup.new_tag('article', **{'class': 'copyright-page'})
+        copyright_section = soup.new_tag("section", **{"class": "copyright-section"})
+        copyright_article = soup.new_tag("article", **{"class": "copyright-page"})
         copyright_article.append(copyright_soup)
         copyright_section.append(copyright_article)
 
@@ -921,50 +997,114 @@ def process_document(document_path):
         title_page.insert_after(copyright_section)
 
     table_refs = caption_tables(soup)
-    normalise_links(soup, documents, table_refs, section_map, path_to_id, rewrite_links=args.link_rewrite)  # Pass path_to_id
+    normalise_links(
+        soup,
+        documents,
+        table_refs,
+        section_map,
+        path_to_id,
+        rewrite_links=args.link_rewrite,
+    )  # Pass path_to_id
     toc_friendly_headings(soup)
 
     # Insert link to title page CSS
-    css_link = soup.new_tag('link', rel='stylesheet', href='assets/styles/title-page.css')
+    css_link = soup.new_tag(
+        "link", rel="stylesheet", href="assets/styles/title-page.css"
+    )
     soup.head.append(css_link)
 
     html_content = str(soup)
 
-    with open(source, 'w', encoding='utf-8') as f:
+    with open(source, "w", encoding="utf-8") as f:
         f.write(html_content)
 
     if not args.html_only:
-        output_filename = (doc_metadata.get('filename', f'{document_path}.pdf')
-                        if doc_metadata else f'{document_path}.pdf')
-        
-        cmd = ['weasyprint', f'{document_path}.htm', output_filename]
+        output_filename = (
+            doc_metadata.get("filename", f"{document_path}.pdf")
+            if doc_metadata
+            else f"{document_path}.pdf"
+        )
+
+        cmd = ["weasyprint", f"{document_path}.htm", output_filename]
         if not args.verbose:
-            cmd.append('--quiet')
-        
+            cmd.append("--quiet")
+
         output = Popen(cmd, cwd=args.project_dir)
         output.wait()
 
+
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Generate PDF-files from mkdocs sites')
-    parser.add_argument('--mkdocs-yml', type=str, default='/app/documentation/mkdocs.yml', help='Path to the toplevel mkdocs.yml file')
-    parser.add_argument('--document', type=str, help='Name of dir containing /docs to be converted to PDF')
-    parser.add_argument('--config', type=str, help='JSON config file specifying documents and settings')
-    parser.add_argument('--project-dir', type=str, default='/app/mkdocs2pdf/project', help='Name of output directory')
-    parser.add_argument('--assets-dir', type=str, default='/app/mkdocs2pdf/assets', help='Name of assets directory')
+    parser = argparse.ArgumentParser(description="Generate PDF-files from mkdocs sites")
+    parser.add_argument(
+        "--mkdocs-yml",
+        type=str,
+        default="/app/documentation/mkdocs.yml",
+        help="Path to the toplevel mkdocs.yml file",
+    )
+    parser.add_argument(
+        "--document",
+        type=str,
+        help="Name of dir containing /docs to be converted to PDF",
+    )
+    parser.add_argument(
+        "--config", type=str, help="JSON config file specifying documents and settings"
+    )
+    parser.add_argument(
+        "--project-dir",
+        type=str,
+        default="/app/mkdocs2pdf/project",
+        help="Name of output directory",
+    )
+    parser.add_argument(
+        "--assets-dir",
+        type=str,
+        default="/app/mkdocs2pdf/assets",
+        help="Name of assets directory",
+    )
     parser.add_argument("--verbose", action="store_true", help="Enable verbose output")
-    parser.add_argument('--exclude', type=str, help='Name of json file with ToC exclusions')
-    parser.add_argument('--disable-toc', action='store_false', dest='toc', help='Disable print-style table of contents listing')
-    parser.add_argument('--disable-link-rewriting', action='store_false', dest='link_rewrite', help='Disable print-style section numbering of links')
-    parser.add_argument('--disable-syntax-highlighting', action='store_false', dest='syntax_hilite', help='Disable syntax highlighting')
-    parser.add_argument('--disable-section-numbers', action='store_false', dest='enumerate_sections', help='Disable print-style section numbers')
-    parser.add_argument('--screen', action='store_true', help='Make screen-oriented PDF (no ToC, no section numbers)')
-    parser.add_argument('--html-only', action='store_true', help='Generate unified HTML-file, but not PDF-conversion')
+    parser.add_argument(
+        "--exclude", type=str, help="Name of json file with ToC exclusions"
+    )
+    parser.add_argument(
+        "--disable-toc",
+        action="store_false",
+        dest="toc",
+        help="Disable print-style table of contents listing",
+    )
+    parser.add_argument(
+        "--disable-link-rewriting",
+        action="store_false",
+        dest="link_rewrite",
+        help="Disable print-style section numbering of links",
+    )
+    parser.add_argument(
+        "--disable-syntax-highlighting",
+        action="store_false",
+        dest="syntax_hilite",
+        help="Disable syntax highlighting",
+    )
+    parser.add_argument(
+        "--disable-section-numbers",
+        action="store_false",
+        dest="enumerate_sections",
+        help="Disable print-style section numbers",
+    )
+    parser.add_argument(
+        "--screen",
+        action="store_true",
+        help="Make screen-oriented PDF (no ToC, no section numbers)",
+    )
+    parser.add_argument(
+        "--html-only",
+        action="store_true",
+        help="Generate unified HTML-file, but not PDF-conversion",
+    )
 
     args = parser.parse_args()
 
     # Validate that either --document or --config is provided, but not both
     if bool(args.document) == bool(args.config):
-        sys.exit('Error: Exactly one of --document or --config must be specified')
+        sys.exit("Error: Exactly one of --document or --config must be specified")
 
     if args.screen:
         args.toc = False
@@ -975,7 +1115,7 @@ if __name__ == "__main__":
     if not args.enumerate_sections:
         args.link_rewrite = False
 
-    if not args.mkdocs_yml.endswith('mkdocs.yml'):
+    if not args.mkdocs_yml.endswith("mkdocs.yml"):
         sys.exit('--> expected a "mkdocs.yml" file')
 
     if not os.path.isfile(args.mkdocs_yml):
@@ -988,7 +1128,7 @@ if __name__ == "__main__":
     config = {}
     if args.config:
         try:
-            with open(args.config, 'r', encoding='utf-8') as f:
+            with open(args.config, "r", encoding="utf-8") as f:
                 config = json.load(f)
         except json.JSONDecodeError:
             sys.exit(f'--> config file "{args.config}" is not valid JSON')
@@ -996,16 +1136,19 @@ if __name__ == "__main__":
             sys.exit(f'--> config file "{args.config}" not found')
 
         # Override CLI arguments with config settings if present
-        if 'settings' in config:
-            args.toc = not config['settings'].get('disable_toc', not args.toc)
-            args.link_rewrite = not config['settings'].get('disable_link_rewriting', 
-                                                         not args.link_rewrite)
-            args.syntax_hilite = not config['settings'].get('disable_syntax_highlighting', 
-                                                          not args.syntax_hilite)
-            args.enumerate_sections = not config['settings'].get('disable_section_numbers', 
-                                                               not args.enumerate_sections)
-            args.screen = config['settings'].get('screen', args.screen)
-            args.html_only = config['settings'].get('html_only', args.html_only)
+        if "settings" in config:
+            args.toc = not config["settings"].get("disable_toc", not args.toc)
+            args.link_rewrite = not config["settings"].get(
+                "disable_link_rewriting", not args.link_rewrite
+            )
+            args.syntax_hilite = not config["settings"].get(
+                "disable_syntax_highlighting", not args.syntax_hilite
+            )
+            args.enumerate_sections = not config["settings"].get(
+                "disable_section_numbers", not args.enumerate_sections
+            )
+            args.screen = config["settings"].get("screen", args.screen)
+            args.html_only = config["settings"].get("html_only", args.html_only)
 
     git_info = get_git_info(os.path.dirname(args.mkdocs_yml))
     build_date = get_build_date()
@@ -1015,13 +1158,13 @@ if __name__ == "__main__":
 
     version = top_mkdocs_data["extra"].get("version_majmin")
     if not version:
-        sys.exit(f'--> source {args.mkdocs_yml} has no Dyalog version set')
+        sys.exit(f"--> source {args.mkdocs_yml} has no Dyalog version set")
 
-    documents = toplevel_docs(top_mkdocs_data.get('nav', {}))
+    documents = toplevel_docs(top_mkdocs_data.get("nav", {}))
 
     excludes = []
     if args.exclude:
-        with open(args.exclude, 'r', encoding='utf-8') as file:
+        with open(args.exclude, "r", encoding="utf-8") as file:
             excludes = json.load(file)
 
     # Prepare static assets (done once for all documents)
@@ -1030,10 +1173,10 @@ if __name__ == "__main__":
 
     # Process documents
     if args.config:
-        if not isinstance(config.get('documents'), dict):
+        if not isinstance(config.get("documents"), dict):
             sys.exit('--> config file must contain a "documents" dictionary')
-        for doc in config['documents']:
-            print(f'=== building: {doc} ===')
+        for doc in config["documents"]:
+            print(f"=== building: {doc} ===")
             process_document(doc)
     else:
         process_document(args.document)


### PR DESCRIPTION
The 'A-Z' section for system functions isn't very 'A-Z'. This is because the titles don't always match the function name, making the A-Z section largely useless as a navigation tool. 

This PR adds the function name to the beginning of the nav "key", restoring sanity on the MkDocs site.

However, several complex gotchas here:

1. CHM viewers don't support HTML markup in the ToC, and NOR DO THEY SUPPORT UTF-8. Let that sink in. "Solution": strip the `<code>` tag, strip the `⎕`. Better than before, but a bit "meh".
2. The PDF versions generate their ToCs in paged-media CSS. They don't see the YML files, but rely on the documents' own H1. This is a _feature_, not a bug. To get the PDF-toc to reflect the YML toc would be a change too big to contemplate for little gain -- CSS obviously have no access to the YML. Making a PDF-sane ToC not using CSS (when converting HTML to PDF) is hard. In terms of usability, probably matters less for PDF anyway.
3. A mkdocs quirk that is bound to come back to bite: if the ToC contains multiple references to the same file (as the case with all entries bar 4 in the A-Z section), only the first reference's key is respected. No matter what you change the text to in the nav key of subsequent referenecs, they are IGNORED. Mkdocs clearly and proudly enforces the nav as a tree, not a graph.

References: #346 

