### PR TITLE
Correct the font applied during conversion to MKDocs

### DIFF
--- a/language-reference-guide/docs/symbols/ampersand.md
+++ b/language-reference-guide/docs/symbols/ampersand.md
@@ -5,9 +5,9 @@ search:
 
 <h1 class="heading"><span class="name">Ampersand</span> <span class="command">&</span></h1>
 
-## Ampersand is a Monadic operator with an ambivalent operand
+Ampersand is a Monadic operator with an ambivalent operand
 
-## Operator Ampersand means
+Operator Ampersand means
 
 [Spawn](../primitive-operators/spawn.md)
 ```apl

--- a/language-reference-guide/docs/symbols/ampersand.md
+++ b/language-reference-guide/docs/symbols/ampersand.md
@@ -2,13 +2,11 @@
 search:
   exclude: true
 ---
-
 <h1 class="heading"><span class="name">Ampersand</span> <span class="command">&</span></h1>
 
 Ampersand is a Monadic operator with an ambivalent operand
 
 Operator Ampersand means
-
 [Spawn](../primitive-operators/spawn.md)
 ```apl
 
@@ -25,5 +23,4 @@ Delayed:  10.2228
                   ⍝ thread 1 completes:
 Delayed:  10.03183
 ```
-
 [Language Elements](./language-elements.md)

--- a/language-reference-guide/docs/symbols/ampersand.md
+++ b/language-reference-guide/docs/symbols/ampersand.md
@@ -4,7 +4,7 @@ search:
 ---
 <h1 class="heading"><span class="name">Ampersand</span> <span class="command">&</span></h1>
 
-Ampersand is a Monadic operator with an ambivalent operand
+Ampersand is a monadic operator with an ambivalent operand
 
 Operator Ampersand means
 [Spawn](../primitive-operators/spawn.md)

--- a/language-reference-guide/docs/symbols/at.md
+++ b/language-reference-guide/docs/symbols/at.md
@@ -24,5 +24,4 @@ Operator At means
       ⌽@(2∘|) 1 2 3 4 5     ⍝ Reversal of sub-array 1 3 5
 5 2 3 4 1
 ```
-
-
+[Language Elements](./language-elements.md)

--- a/language-reference-guide/docs/symbols/at.md
+++ b/language-reference-guide/docs/symbols/at.md
@@ -2,23 +2,13 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">At</span> <span class="command">@</span></h1>
 
-
-At is a Dyadic operator
+At is a dyadic operator
 
 Operator At means
-
-
 [At](../primitive-operators/at.md)
 ```apl
-
-
       (0@2 4) 1 2 3 4 5
 1 0 3 0 5
 
@@ -33,7 +23,6 @@ Operator At means
 
       ⌽@(2∘|) 1 2 3 4 5     ⍝ Reversal of sub-array 1 3 5
 5 2 3 4 1
-
 ```
 
 

--- a/language-reference-guide/docs/symbols/at.md
+++ b/language-reference-guide/docs/symbols/at.md
@@ -10,9 +10,9 @@ search:
 <h1 class="heading"><span class="name">At</span> <span class="command">@</span></h1>
 
 
-## At is a Dyadic operator
+At is a Dyadic operator
 
-## Operator At means
+Operator At means
 
 
 [At](../primitive-operators/at.md)

--- a/language-reference-guide/docs/symbols/circle-bar.md
+++ b/language-reference-guide/docs/symbols/circle-bar.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Circle Bar</span> <span class="command">⊖</span></h1>
 
 
-## Monadic Circle Bar means
+Monadic Circle Bar means
 
 
 [Reverse First](../primitive-functions/reverse-first.md)
@@ -28,7 +28,7 @@ search:
 
 ```
 
-## Dyadic Circle Bar means
+Dyadic Circle Bar means
 
 
 [Rotate First](../primitive-functions/rotate-first.md)

--- a/language-reference-guide/docs/symbols/circle-bar.md
+++ b/language-reference-guide/docs/symbols/circle-bar.md
@@ -2,20 +2,11 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Circle Bar</span> <span class="command">⊖</span></h1>
 
-
 Monadic Circle Bar means
-
-
 [Reverse First](../primitive-functions/reverse-first.md)
 ```apl
-
       mat
 1  2  3  4
 5  6  7  8
@@ -25,23 +16,16 @@ Monadic Circle Bar means
 9 10 11 12
 5  6  7  8
 1  2  3  4
-
 ```
 
 Dyadic Circle Bar means
-
-
 [Rotate First](../primitive-functions/rotate-first.md)
 ```apl
-
       0 1 2 ¯1 ⊖ mat
 1  6 11 12
 5 10  3  4
 9  2  7  8
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/circle-dieresis.md
+++ b/language-reference-guide/docs/symbols/circle-dieresis.md
@@ -4,7 +4,7 @@ search:
 ---
 <h1 class="heading"><span class="name">Circle Dieresis</span> <span class="command">⍥</span></h1>
 
-Circle Diaeresis is a Dyadic operator with an ambivalent left operand
+Circle Diaeresis is a dyadic operator with an ambivalent left operand
 
 Operator Circle Diaeresis means
 [Over](../primitive-operators/over.md)

--- a/language-reference-guide/docs/symbols/circle-dieresis.md
+++ b/language-reference-guide/docs/symbols/circle-dieresis.md
@@ -10,8 +10,7 @@ search:
 <h1 class="heading"><span class="name">Circle Dieresis</span> <span class="command">⍥</span></h1>
 
 
-Circle Diaeresis is a Dyadic operator with an ambivalent
-      left operand
+Circle Diaeresis is a Dyadic operator with an ambivalent left operand
 
 Operator Circle Diaeresis means
 

--- a/language-reference-guide/docs/symbols/circle-dieresis.md
+++ b/language-reference-guide/docs/symbols/circle-dieresis.md
@@ -2,22 +2,13 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Circle Dieresis</span> <span class="command">⍥</span></h1>
-
 
 Circle Diaeresis is a Dyadic operator with an ambivalent left operand
 
 Operator Circle Diaeresis means
-
-
 [Over](../primitive-operators/over.md)
 ```apl
-
       -⍥⌊ 3.6                 ⍝ Same as ∘ or ⍤ monadically
 ¯3
       5.1 -⍥⌊ 3.6             ⍝ Applies ⌊ to both arguments
@@ -26,10 +17,7 @@ Operator Circle Diaeresis means
 1
       'Dyalog' ≡⍥⎕C 'IBM'
 0
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/circle-dieresis.md
+++ b/language-reference-guide/docs/symbols/circle-dieresis.md
@@ -10,10 +10,10 @@ search:
 <h1 class="heading"><span class="name">Circle Dieresis</span> <span class="command">⍥</span></h1>
 
 
-## Circle Diaeresis is a Dyadic operator with an ambivalent
+Circle Diaeresis is a Dyadic operator with an ambivalent
       left operand
 
-## Operator Circle Diaeresis means
+Operator Circle Diaeresis means
 
 
 [Over](../primitive-operators/over.md)

--- a/language-reference-guide/docs/symbols/circle-stile.md
+++ b/language-reference-guide/docs/symbols/circle-stile.md
@@ -2,20 +2,11 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Circle Stile</span> <span class="command">⌽</span></h1>
 
-
 Monadic Circle Stile means
-
-
 [Reverse](../primitive-functions/reverse.md)
 ```apl
-
       ⌽ 'trams'
 smart
 
@@ -36,11 +27,8 @@ smart
 ```
 
 Dyadic Circle Stile means
-
-
 [Rotate](../primitive-functions/rotate.md)
 ```apl
-
       3 ⌽ 'HatStand'
 StandHat
 
@@ -61,10 +49,7 @@ StandHat
 1  6 11 12
 5 10  3  4
 9  2  7  8
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/circle-stile.md
+++ b/language-reference-guide/docs/symbols/circle-stile.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Circle Stile</span> <span class="command">⌽</span></h1>
 
 
-## Monadic Circle Stile means
+Monadic Circle Stile means
 
 
 [Reverse
@@ -36,7 +36,7 @@ smart
 1  2  3  4
 ```
 
-## Dyadic Circle Stile means
+Dyadic Circle Stile means
 
 
 [Rotate

--- a/language-reference-guide/docs/symbols/circle-stile.md
+++ b/language-reference-guide/docs/symbols/circle-stile.md
@@ -13,8 +13,7 @@ search:
 Monadic Circle Stile means
 
 
-[Reverse
-      ](../primitive-functions/reverse.md)
+[Reverse](../primitive-functions/reverse.md)
 ```apl
 
       ⌽ 'trams'
@@ -39,8 +38,7 @@ smart
 Dyadic Circle Stile means
 
 
-[Rotate
-      ](../primitive-functions/rotate.md)
+[Rotate](../primitive-functions/rotate.md)
 ```apl
 
       3 ⌽ 'HatStand'

--- a/language-reference-guide/docs/symbols/circle.md
+++ b/language-reference-guide/docs/symbols/circle.md
@@ -2,29 +2,17 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Circle</span> <span class="command">○</span></h1>
 
-
 Monadic Circle means
-
-
 [Pi Times](../primitive-functions/pi-times.md)
 ```apl
       ○ 0 1 2
 0 3.14159 6.28319
 ```
-
 Dyadic Circle means
-
-
 [Circular Function (Trig)](../primitive-functions/circular.md)
 ```apl
-
           Note: Angles are in radians 
                 radians ← ○ degrees ÷ 180
 
@@ -47,8 +35,6 @@ Dyadic Circle means
 ¯12  *⍵×0J1       12   phase of ⍵
 
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/circle.md
+++ b/language-reference-guide/docs/symbols/circle.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Circle</span> <span class="command">○</span></h1>
 
 
-## Monadic Circle means
+Monadic Circle means
 
 
 [Pi Times](../primitive-functions/pi-times.md)
@@ -19,7 +19,7 @@ search:
 0 3.14159 6.28319
 ```
 
-## Dyadic Circle means
+Dyadic Circle means
 
 
 [Circular Function (Trig)](../primitive-functions/circular.md)

--- a/language-reference-guide/docs/symbols/comma-bar.md
+++ b/language-reference-guide/docs/symbols/comma-bar.md
@@ -2,20 +2,11 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Comma Bar</span> <span class="command">⍪</span></h1>
 
-
 Monadic Comma Bar means
-
-
 [Table](../primitive-functions/table.md)
 ```apl
-
       ⍪ 2 3 4
 2
 3
@@ -30,13 +21,9 @@ Monadic Comma Bar means
 1 2 3 4
 5 6 7 8
 ```
-
 Dyadic Comma Bar means
-
-
 [Catenate First](../primitive-functions/catenate-first.md)
 ```apl
-
       mat
 1 2 3
 4 5 6
@@ -50,10 +37,7 @@ Dyadic Comma Bar means
 1 2 3
 4 5 6
 7 8 9
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/comma-bar.md
+++ b/language-reference-guide/docs/symbols/comma-bar.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Comma Bar</span> <span class="command">⍪</span></h1>
 
 
-## Monadic Comma Bar means
+Monadic Comma Bar means
 
 
 [Table](../primitive-functions/table.md)
@@ -31,7 +31,7 @@ search:
 5 6 7 8
 ```
 
-## Dyadic Comma Bar means
+Dyadic Comma Bar means
 
 
 [Catenate First](../primitive-functions/catenate-first.md)

--- a/language-reference-guide/docs/symbols/comma.md
+++ b/language-reference-guide/docs/symbols/comma.md
@@ -2,20 +2,11 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Comma</span> <span class="command">,</span></h1>
 
-
 Monadic Comma means
-
-
 [Ravel](../primitive-functions/ravel.md)
 ```apl
-
       cube    ⍝ 3D array
 1 2
 3 4
@@ -29,11 +20,8 @@ Monadic Comma means
 1 2 3 4
 5 6 7 8
 ```
-
-
 [Ravel with Axes](../primitive-functions/ravel-with-axes.md)
 ```apl
-
       ,[1.5]'ABC'
 A
 B
@@ -41,8 +29,6 @@ C
 ```
 
 Dyadic Comma means
-
-
 [Catenate/Laminate (Join)](../primitive-functions/catenate-laminate.md)
 ```apl
       1 2 3 , 4 5 6
@@ -58,10 +44,7 @@ Dyadic Comma means
       1 2 3 ,[0.5] 4 5 6   ⍝ Laminate
 1 2 3
 4 5 6 
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/comma.md
+++ b/language-reference-guide/docs/symbols/comma.md
@@ -13,8 +13,7 @@ search:
 Monadic Comma means
 
 
-[Ravel
-      ](../primitive-functions/ravel.md)
+[Ravel](../primitive-functions/ravel.md)
 ```apl
 
       cube    ⍝ 3D array
@@ -32,8 +31,7 @@ Monadic Comma means
 ```
 
 
-[Ravel with Axes
-			](../primitive-functions/ravel-with-axes.md)
+[Ravel with Axes](../primitive-functions/ravel-with-axes.md)
 ```apl
 
       ,[1.5]'ABC'
@@ -45,8 +43,7 @@ C
 Dyadic Comma means
 
 
-[Catenate/Laminate
-(Join)      ](../primitive-functions/catenate-laminate.md)
+[Catenate/Laminate (Join)](../primitive-functions/catenate-laminate.md)
 ```apl
       1 2 3 , 4 5 6
 1 2 3 4 5 6

--- a/language-reference-guide/docs/symbols/comma.md
+++ b/language-reference-guide/docs/symbols/comma.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Comma</span> <span class="command">,</span></h1>
 
 
-## Monadic Comma means
+Monadic Comma means
 
 
 [Ravel
@@ -42,7 +42,7 @@ B
 C
 ```
 
-## Dyadic Comma means
+Dyadic Comma means
 
 
 [Catenate/Laminate

--- a/language-reference-guide/docs/symbols/decode-symbol.md
+++ b/language-reference-guide/docs/symbols/decode-symbol.md
@@ -2,23 +2,13 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Up Tack</span> <span class="command">⊥</span></h1>
-
-
 
 Monadic Up Tack is not defined
 
 Dyadic Up Tack means
-
-
 [Decode](../primitive-functions/decode.md)
 ```apl
-
       2 ⊥ 1 1 0 1   ⍝ binary decode
 13
 
@@ -27,10 +17,7 @@ Dyadic Up Tack means
 
       24 60 60 ⊥ 2 46 40
 10000
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/decode-symbol.md
+++ b/language-reference-guide/docs/symbols/decode-symbol.md
@@ -13,7 +13,7 @@ search:
 
 Monadic Up Tack is not defined
 
-## Dyadic Up Tack means
+Dyadic Up Tack means
 
 
 [Decode](../primitive-functions/decode.md)

--- a/language-reference-guide/docs/symbols/dieresis-tilde.md
+++ b/language-reference-guide/docs/symbols/dieresis-tilde.md
@@ -10,8 +10,7 @@ search:
 <h1 class="heading"><span class="name">Tilde Diaeresis</span> <span class="command">⍨</span></h1>
 
 
-Tilde Diaeresis is a Monadic operator with a Dyadic
-      operand
+Tilde Diaeresis is a Monadic operator with a Dyadic operand
 
 Operator Tilde Diaeresis means
 

--- a/language-reference-guide/docs/symbols/dieresis-tilde.md
+++ b/language-reference-guide/docs/symbols/dieresis-tilde.md
@@ -4,7 +4,7 @@ search:
 ---
 <h1 class="heading"><span class="name">Tilde Diaeresis</span> <span class="command">⍨</span></h1>
 
-Tilde Diaeresis is a Monadic operator with a Dyadic operand
+Tilde Diaeresis is a monadic operator with a dyadic operand
 
 Operator Tilde Diaeresis means
 [Commute](../primitive-operators/commute.md)

--- a/language-reference-guide/docs/symbols/dieresis-tilde.md
+++ b/language-reference-guide/docs/symbols/dieresis-tilde.md
@@ -2,35 +2,23 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Tilde Diaeresis</span> <span class="command">⍨</span></h1>
-
 
 Tilde Diaeresis is a Monadic operator with a Dyadic operand
 
 Operator Tilde Diaeresis means
-
-
-[Commute     ](../primitive-operators/commute.md)
+[Commute](../primitive-operators/commute.md)
 ```apl
-
       2 ⍴ 3     ⍝ ⍺ ⍴ ⍵
 3 3
       2 ⍴⍨ 3    ⍝ ⍵ ⍴ ⍺
 2 2 2
       ⍴⍨ 3      ⍝ ⍵ ⍴ ⍵
 3 3 3
-
 ```
 
-
-[Constant     ](../primitive-operators/constant.md)
+[Constant](../primitive-operators/constant.md)
 ```apl
-
       'mu'⍨ 'any' ⎕NULL   ⍝ Always returns its operand
 mu
       1E100 ('mu'⍨) 1j1
@@ -39,8 +27,6 @@ mu
 ¯1 ¯1 ¯1
 ¯1 ¯1 ¯1
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/dieresis-tilde.md
+++ b/language-reference-guide/docs/symbols/dieresis-tilde.md
@@ -10,10 +10,10 @@ search:
 <h1 class="heading"><span class="name">Tilde Diaeresis</span> <span class="command">⍨</span></h1>
 
 
-## Tilde Diaeresis is a Monadic operator with a Dyadic
+Tilde Diaeresis is a Monadic operator with a Dyadic
       operand
 
-## Operator Tilde Diaeresis means
+Operator Tilde Diaeresis means
 
 
 [Commute     ](../primitive-operators/commute.md)

--- a/language-reference-guide/docs/symbols/dieresis.md
+++ b/language-reference-guide/docs/symbols/dieresis.md
@@ -10,10 +10,10 @@ search:
 <h1 class="heading"><span class="name">Diaeresis</span> <span class="command">¨</span></h1>
 
 
-## Diaeresis is a Monadic operator with an ambivalent
+Diaeresis is a Monadic operator with an ambivalent
       operand
 
-## Operator Diaeresis means
+Operator Diaeresis means
 
 
 [Each (with monadic operand)](../primitive-operators/each-with-monadic-operand.md) or [Each (with dyadic operand)](../primitive-operators/each-with-dyadic-operand.md)

--- a/language-reference-guide/docs/symbols/dieresis.md
+++ b/language-reference-guide/docs/symbols/dieresis.md
@@ -10,8 +10,7 @@ search:
 <h1 class="heading"><span class="name">Diaeresis</span> <span class="command">¨</span></h1>
 
 
-Diaeresis is a Monadic operator with an ambivalent
-      operand
+Diaeresis is a Monadic operator with an ambivalent operand
 
 Operator Diaeresis means
 

--- a/language-reference-guide/docs/symbols/dieresis.md
+++ b/language-reference-guide/docs/symbols/dieresis.md
@@ -4,7 +4,7 @@ search:
 ---
 <h1 class="heading"><span class="name">Diaeresis</span> <span class="command">¨</span></h1>
 
-Diaeresis is a Monadic operator with an ambivalent operand
+Diaeresis is a monadic operator with an ambivalent operand
 
 Operator Diaeresis means
 [Each (with monadic operand)](../primitive-operators/each-with-monadic-operand.md) or [Each (with dyadic operand)](../primitive-operators/each-with-dyadic-operand.md)

--- a/language-reference-guide/docs/symbols/dieresis.md
+++ b/language-reference-guide/docs/symbols/dieresis.md
@@ -2,22 +2,13 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Diaeresis</span> <span class="command">¨</span></h1>
-
 
 Diaeresis is a Monadic operator with an ambivalent operand
 
 Operator Diaeresis means
-
-
 [Each (with monadic operand)](../primitive-operators/each-with-monadic-operand.md) or [Each (with dyadic operand)](../primitive-operators/each-with-dyadic-operand.md)
 ```apl
-
       ⊃¨ 1 2 3 'ABC' (9 8 7)
 1 2 3 A 9
 
@@ -33,10 +24,7 @@ Operator Diaeresis means
 ┌────┬────┬────┐
 │1 99│2 99│3 99│
 └────┴────┴────┘
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/dieresisstar.md
+++ b/language-reference-guide/docs/symbols/dieresisstar.md
@@ -4,7 +4,7 @@ search:
 ---
 <h1 class="heading"><span class="name">Star Diaeresis</span> <span class="command">⍣</span></h1>
 
-Star Diaeresis is a Dyadic operator with an ambivalent left operand and an integer or dyadic right operand
+Star Diaeresis is a dyadic operator with an ambivalent left operand and an integer or dyadic right operand
 
 Operator Star Diaeresis means
 [Power Operator](../primitive-operators/power-operator.md)

--- a/language-reference-guide/docs/symbols/dieresisstar.md
+++ b/language-reference-guide/docs/symbols/dieresisstar.md
@@ -10,10 +10,9 @@ search:
 <h1 class="heading"><span class="name">Star Diaeresis</span> <span class="command">⍣</span></h1>
 
 
-## Star Diaeresis is a Dyadic operator with an ambivalent
-      left operand and an integer or dyadic right operand
+Star Diaeresis is a Dyadic operator with an ambivalent left operand and an integer or dyadic right operand
 
-## Operator Star Diaeresis means
+Operator Star Diaeresis means
 
 
 [Power Operator  ](../primitive-operators/power-operator.md)

--- a/language-reference-guide/docs/symbols/dieresisstar.md
+++ b/language-reference-guide/docs/symbols/dieresisstar.md
@@ -2,22 +2,13 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Star Diaeresis</span> <span class="command">⍣</span></h1>
-
 
 Star Diaeresis is a Dyadic operator with an ambivalent left operand and an integer or dyadic right operand
 
 Operator Star Diaeresis means
-
-
 [Power Operator](../primitive-operators/power-operator.md)
 ```apl
-
       cube    ⍝ 3D array
 AB
 CD
@@ -50,8 +41,6 @@ GH
       1 +∘÷⍣= 1            ⍝ fixpoint: golden mean
 1.61803
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/dieresisstar.md
+++ b/language-reference-guide/docs/symbols/dieresisstar.md
@@ -15,7 +15,7 @@ Star Diaeresis is a Dyadic operator with an ambivalent left operand and an integ
 Operator Star Diaeresis means
 
 
-[Power Operator  ](../primitive-operators/power-operator.md)
+[Power Operator](../primitive-operators/power-operator.md)
 ```apl
 
       cube    ⍝ 3D array

--- a/language-reference-guide/docs/symbols/divide-sign.md
+++ b/language-reference-guide/docs/symbols/divide-sign.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Divide Sign</span> <span class="command">÷</span></h1>
 
 
-## Monadic Divide Sign means
+Monadic Divide Sign means
 
 
 [Reciprocal](../primitive-functions/reciprocal.md)
@@ -21,7 +21,7 @@ search:
 
 ```
 
-## Dyadic Divide Sign means
+Dyadic Divide Sign means
 
 
 [Divided By](../primitive-functions/divide.md)

--- a/language-reference-guide/docs/symbols/divide-sign.md
+++ b/language-reference-guide/docs/symbols/divide-sign.md
@@ -2,32 +2,19 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Divide Sign</span> <span class="command">÷</span></h1>
 
-
 Monadic Divide Sign means
-
-
 [Reciprocal](../primitive-functions/reciprocal.md)
 ```apl
-
       ÷ 1 2 3
 1 0.5 0.333333
 
 ```
 
 Dyadic Divide Sign means
-
-
 [Divided By](../primitive-functions/divide.md)
 ```apl
-
-
       1 2 3 ÷ 4 5 7
 0.25 0.4 0.428571
 
@@ -35,8 +22,6 @@ Dyadic Divide Sign means
 ¯5 20
 
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/domino.md
+++ b/language-reference-guide/docs/symbols/domino.md
@@ -2,20 +2,11 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Domino;Quad Divide</span> <span class="command">⌹</span></h1>
 
-
 Monadic Domino means
-
-
 [Matrix Inverse Of](../primitive-functions/matrix-inverse.md)
 ```apl
-
       mat
 1 2
 3 4
@@ -25,17 +16,11 @@ Monadic Domino means
 ```
 
 Dyadic Domino means
-
-
 [Matrix Division By](../primitive-functions/matrix-divide.md)
 ```apl
-
       5 6 ⌹ mat
 ¯4 4.5
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/domino.md
+++ b/language-reference-guide/docs/symbols/domino.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Domino;Quad Divide</span> <span class="command">⌹</span></h1>
 
 
-## Monadic Domino means
+Monadic Domino means
 
 
 [Matrix Inverse Of](../primitive-functions/matrix-inverse.md)
@@ -24,7 +24,7 @@ search:
  1.5 ¯0.5
 ```
 
-## Dyadic Domino means
+Dyadic Domino means
 
 
 [Matrix Division By](../primitive-functions/matrix-divide.md)

--- a/language-reference-guide/docs/symbols/domino.md
+++ b/language-reference-guide/docs/symbols/domino.md
@@ -2,9 +2,9 @@
 search:
   exclude: true
 ---
-<h1 class="heading"><span class="name">Domino;Quad Divide</span> <span class="command">⌹</span></h1>
+<h1 class="heading"><span class="name">Quad Divide</span> <span class="command">⌹</span></h1>
 
-Monadic Domino means
+Monadic Quad Divide means
 [Matrix Inverse Of](../primitive-functions/matrix-inverse.md)
 ```apl
       mat
@@ -15,7 +15,7 @@ Monadic Domino means
  1.5 ¯0.5
 ```
 
-Dyadic Domino means
+Dyadic Quad Divide means
 [Matrix Division By](../primitive-functions/matrix-divide.md)
 ```apl
       5 6 ⌹ mat

--- a/language-reference-guide/docs/symbols/dot.md
+++ b/language-reference-guide/docs/symbols/dot.md
@@ -10,9 +10,9 @@ search:
 <h1 class="heading"><span class="name">Dot</span> <span class="command">.</span></h1>
 
 
-## Dot can be used as a Dyadic operator with Dyadic operands
+Dot can be used as a Dyadic operator with Dyadic operands
 
-## Operator Dot means
+Operator Dot means
 
 
 [Inner Product](../primitive-operators/inner-product.md)
@@ -30,7 +30,7 @@ search:
 15 22
 ```
 
-## Used with Jot in place of the left operand Jot Dot means
+Used with Jot in place of the left operand Jot Dot means
 
 
 [Outer Product](../primitive-operators/outer-product.md)

--- a/language-reference-guide/docs/symbols/dot.md
+++ b/language-reference-guide/docs/symbols/dot.md
@@ -3,7 +3,7 @@ search:
   exclude: true
 ---
 <h1 class="heading"><span class="name">Dot</span> <span class="command">.</span></h1>
-Dot can be used as a Dyadic operator with Dyadic operands
+Dot can be used as a dyadic operator with dyadic operands
 
 Operator Dot means
 [Inner Product](../primitive-operators/inner-product.md)

--- a/language-reference-guide/docs/symbols/dot.md
+++ b/language-reference-guide/docs/symbols/dot.md
@@ -2,19 +2,10 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Dot</span> <span class="command">.</span></h1>
-
-
 Dot can be used as a Dyadic operator with Dyadic operands
 
 Operator Dot means
-
-
 [Inner Product](../primitive-operators/inner-product.md)
 
 ```apl
@@ -31,11 +22,8 @@ Operator Dot means
 ```
 
 Used with Jot in place of the left operand Jot Dot means
-
-
 [Outer Product](../primitive-operators/outer-product.md)
 ```apl
-
       1 2 3 ∘.× 4 5 6 7
  4  5  6  7
  8 10 12 14
@@ -43,10 +31,8 @@ Used with Jot in place of the left operand Jot Dot means
 
 ```
 
-
 !!!note
     Dot is also used as a decimal point and as a name separator in namespace reference syntax.
-
 
 [Language Elements](language-elements.md)
 

--- a/language-reference-guide/docs/symbols/down-arrow.md
+++ b/language-reference-guide/docs/symbols/down-arrow.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Down Arrow</span> <span class="command">↓</span></h1>
 
 
-## Monadic Down Arrow means
+Monadic Down Arrow means
 
 
 [Split](../primitive-functions/split.md)
@@ -33,7 +33,7 @@ search:
 
 ```
 
-## Dyadic Down Arrow means
+Dyadic Down Arrow means
 
 
 [Drop](../primitive-functions/drop.md)

--- a/language-reference-guide/docs/symbols/down-arrow.md
+++ b/language-reference-guide/docs/symbols/down-arrow.md
@@ -2,20 +2,11 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Down Arrow</span> <span class="command">↓</span></h1>
 
-
 Monadic Down Arrow means
-
-
 [Split](../primitive-functions/split.md)
 ```apl
-
       mat
 1  2  3  4
 5  6  7  8
@@ -30,12 +21,9 @@ Monadic Down Arrow means
 ┌─────┬──────┬──────┬──────┐
 │1 5 9│2 6 10│3 7 11│4 8 12│
 └─────┴──────┴──────┴──────┘
-
 ```
 
 Dyadic Down Arrow means
-
-
 [Drop](../primitive-functions/drop.md)
 ```apl
       4 ↓ 'Pineapple'
@@ -48,10 +36,7 @@ Pine
       1 ↓ mat
 5  6  7  8
 9 10 11 12
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/downstile.md
+++ b/language-reference-guide/docs/symbols/downstile.md
@@ -3,29 +3,18 @@ search:
   exclude: true
 ---
 
-
-
-
-
 <h1 class="heading"><span class="name">Downstile</span> <span class="command">⌊</span></h1>
 
-
 Monadic Downstile means
-
-
 [Floor](../primitive-functions/floor.md)
 ```apl
-
       ⌊ 3.4 ¯3.4 3 0
 3 ¯4 3 0
 ```
 
 Dyadic Downstile means
-
-
 [Minimum](../primitive-functions/minimum.md)
 ```apl
-
       1.1 ¯2 ⌊ 8.1 ¯3.4
 1.1 ¯3.4
 
@@ -33,8 +22,6 @@ Dyadic Downstile means
 1
 
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/downstile.md
+++ b/language-reference-guide/docs/symbols/downstile.md
@@ -13,8 +13,7 @@ search:
 Monadic Downstile means
 
 
-[Floor
-      ](../primitive-functions/floor.md)
+[Floor](../primitive-functions/floor.md)
 ```apl
 
       ⌊ 3.4 ¯3.4 3 0

--- a/language-reference-guide/docs/symbols/downstile.md
+++ b/language-reference-guide/docs/symbols/downstile.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Downstile</span> <span class="command">⌊</span></h1>
 
 
-## Monadic Downstile means
+Monadic Downstile means
 
 
 [Floor
@@ -21,7 +21,7 @@ search:
 3 ¯4 3 0
 ```
 
-## Dyadic Downstile means
+Dyadic Downstile means
 
 
 [Minimum](../primitive-functions/minimum.md)

--- a/language-reference-guide/docs/symbols/encode-symbol.md
+++ b/language-reference-guide/docs/symbols/encode-symbol.md
@@ -2,23 +2,13 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Down Tack</span> <span class="command">⊤</span></h1>
-
-
 
 Monadic Down Tack is not defined
 
 Dyadic Down Tack means
-
-
 [Encode](../primitive-functions/encode.md)
 ```apl
-
       2 2 2 2 ⊤ 5 7 12   ⍝ binary encode
 0 0 1
 1 1 1
@@ -32,8 +22,6 @@ Dyadic Down Tack means
 2 46 40
 
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/encode-symbol.md
+++ b/language-reference-guide/docs/symbols/encode-symbol.md
@@ -13,7 +13,7 @@ search:
 
 Monadic Down Tack is not defined
 
-## Dyadic Down Tack means
+Dyadic Down Tack means
 
 
 [Encode](../primitive-functions/encode.md)

--- a/language-reference-guide/docs/symbols/epsilon-underbar.md
+++ b/language-reference-guide/docs/symbols/epsilon-underbar.md
@@ -13,7 +13,7 @@ search:
 
 Monadic Epsilon Underbar is not defined
 
-## Dyadic Epsilon Underbar means
+Dyadic Epsilon Underbar means
 
 
 [Find](../primitive-functions/find.md)

--- a/language-reference-guide/docs/symbols/epsilon-underbar.md
+++ b/language-reference-guide/docs/symbols/epsilon-underbar.md
@@ -2,23 +2,13 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Epsilon Underbar</span> <span class="command">⍷</span></h1>
-
-
 
 Monadic Epsilon Underbar is not defined
 
 Dyadic Epsilon Underbar means
-
-
 [Find](../primitive-functions/find.md)
 ```apl
-
       'ana' ⍷ 'Banana'
 0 1 0 1 0 0
 
@@ -37,8 +27,6 @@ Dyadic Epsilon Underbar means
 0 0 0 0
 
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/epsilon.md
+++ b/language-reference-guide/docs/symbols/epsilon.md
@@ -2,16 +2,9 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Epsilon</span> <span class="command">∊</span></h1>
 
-
 Monadic Epsilon means
-
 
 If `⎕ML=0` [Type Of](../primitive-functions/type.md)
 ```apl
@@ -19,10 +12,7 @@ If `⎕ML=0` [Type Of](../primitive-functions/type.md)
    0         0
         0
    0         0
-
 ```
-
-
 If `⎕ML≥1` [Enlist](../primitive-functions/enlist.md)
 ```apl
       mat
@@ -37,20 +27,14 @@ If `⎕ML≥1` [Enlist](../primitive-functions/enlist.md)
 ```
 
 Dyadic Epsilon means
-
-
 [Member Of](../primitive-functions/membership.md)
 ```apl
-
       'abc' 4 ∊ 4 'ab' 'abcd'
 0 1
       mat ∊ 6 2 7 4
 0 1 0
 1 0 1
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/epsilon.md
+++ b/language-reference-guide/docs/symbols/epsilon.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Epsilon</span> <span class="command">∊</span></h1>
 
 
-## Monadic Epsilon means
+Monadic Epsilon means
 
 
 If `⎕ML=0` [Type Of](../primitive-functions/type.md)
@@ -36,7 +36,7 @@ If `⎕ML≥1` [Enlist](../primitive-functions/enlist.md)
 
 ```
 
-## Dyadic Epsilon means
+Dyadic Epsilon means
 
 
 [Member Of](../primitive-functions/membership.md)

--- a/language-reference-guide/docs/symbols/equal-sign.md
+++ b/language-reference-guide/docs/symbols/equal-sign.md
@@ -2,11 +2,11 @@
 search:
   exclude: true
 ---
-<h1 class="heading"><span class="name">Equal Sign</span> <span class="command">=</span></h1>
+<h1 class="heading"><span class="name">Equal</span> <span class="command">=</span></h1>
 
-Monadic Equal Sign is not defined
+Monadic Equal is not defined
 
-Dyadic Equal Sign means
+Dyadic Equal means
 [Equal To](../primitive-functions/equal.md)
 ```apl
       1 2 3 = 4 2 ¯1

--- a/language-reference-guide/docs/symbols/equal-sign.md
+++ b/language-reference-guide/docs/symbols/equal-sign.md
@@ -13,7 +13,7 @@ search:
 
 Monadic Equal Sign is not defined
 
-## Dyadic Equal Sign means
+Dyadic Equal Sign means
 
 
 [Equal To](../primitive-functions/equal.md)

--- a/language-reference-guide/docs/symbols/equal-sign.md
+++ b/language-reference-guide/docs/symbols/equal-sign.md
@@ -2,23 +2,13 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Equal Sign</span> <span class="command">=</span></h1>
-
-
 
 Monadic Equal Sign is not defined
 
 Dyadic Equal Sign means
-
-
 [Equal To](../primitive-functions/equal.md)
 ```apl
-
       1 2 3 = 4 2 ¯1
 0 1 0
 
@@ -30,10 +20,7 @@ Dyadic Equal Sign means
 
       7 = '7'
 0
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/equal-underbar-slash.md
+++ b/language-reference-guide/docs/symbols/equal-underbar-slash.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Equal Underbar Slash</span> <span class="command">≢</span></h1>
 
 
-## Monadic Not Equal Underbar means
+Monadic Not Equal Underbar means
 
 
 [Tally](../primitive-functions/tally.md)
@@ -33,7 +33,7 @@ search:
 2 3
 ```
 
-## Dyadic Not Equal Underbar means
+Dyadic Not Equal Underbar means
 
 
 [Not Match](../primitive-functions/not-match.md)

--- a/language-reference-guide/docs/symbols/equal-underbar-slash.md
+++ b/language-reference-guide/docs/symbols/equal-underbar-slash.md
@@ -2,20 +2,11 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Equal Underbar Slash</span> <span class="command">≢</span></h1>
 
-
 Monadic Not Equal Underbar means
-
-
 [Tally](../primitive-functions/tally.md)
 ```apl
-
       ≢ 'a'
 1
       ≢ 7 4 2
@@ -34,19 +25,13 @@ Monadic Not Equal Underbar means
 ```
 
 Dyadic Not Equal Underbar means
-
-
 [Not Match](../primitive-functions/not-match.md)
 ```apl
-
       'bex' ≢ 'b','e','x' 
 0
       1 ≢ 1 1
 1
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/equal-underbar.md
+++ b/language-reference-guide/docs/symbols/equal-underbar.md
@@ -2,17 +2,9 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Equal Underbar</span> <span class="command">≡</span></h1>
 
-
 Monadic Equal Underbar means
-
-
 [Depth](../primitive-functions/depth.md)
 ```apl
 
@@ -26,12 +18,9 @@ Monadic Equal Underbar means
 ¯2
 ```
 
-
 Note: Result is always positive if `⎕ML` is greater than or equal to 2
 
 Dyadic Equal Underbar means
-
-
 [Match](../primitive-functions/match.md)
 ```apl
 
@@ -39,10 +28,7 @@ Dyadic Equal Underbar means
 1
       1 ≡ 1 1
 0
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/equal-underbar.md
+++ b/language-reference-guide/docs/symbols/equal-underbar.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Equal Underbar</span> <span class="command">≡</span></h1>
 
 
-## Monadic Equal Underbar means
+Monadic Equal Underbar means
 
 
 [Depth](../primitive-functions/depth.md)
@@ -29,7 +29,7 @@ search:
 
 Note: Result is always positive if `⎕ML` is greater than or equal to 2
 
-## Dyadic Equal Underbar means
+Dyadic Equal Underbar means
 
 
 [Match](../primitive-functions/match.md)

--- a/language-reference-guide/docs/symbols/exclamation-mark.md
+++ b/language-reference-guide/docs/symbols/exclamation-mark.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Exclamation Mark;Quote Dot</span> <span class="command">!</span></h1>
 
 
-## Monadic Exclamation Mark means
+Monadic Exclamation Mark means
 
 
 [Factorial](../primitive-functions/factorial.md)
@@ -20,7 +20,7 @@ search:
 6 362880 1.07683
 ```
 
-## Dyadic Exclamation Mark means
+Dyadic Exclamation Mark means
 
 
 [Binomial

--- a/language-reference-guide/docs/symbols/exclamation-mark.md
+++ b/language-reference-guide/docs/symbols/exclamation-mark.md
@@ -23,8 +23,7 @@ Monadic Exclamation Mark means
 Dyadic Exclamation Mark means
 
 
-[Binomial
-      ](../primitive-functions/binomial.md)
+[Binomial](../primitive-functions/binomial.md)
 ```apl
 
       2 1 3 ! 3 10 ¯0.11

--- a/language-reference-guide/docs/symbols/exclamation-mark.md
+++ b/language-reference-guide/docs/symbols/exclamation-mark.md
@@ -2,36 +2,21 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Exclamation Mark;Quote Dot</span> <span class="command">!</span></h1>
 
-
 Monadic Exclamation Mark means
-
-
 [Factorial](../primitive-functions/factorial.md)
 ```apl
-
       ! 3 9 ¯0.11
 6 362880 1.07683
 ```
 
 Dyadic Exclamation Mark means
-
-
 [Binomial](../primitive-functions/binomial.md)
 ```apl
-
       2 1 3 ! 3 10 ¯0.11
 3 10 ¯0.0429385
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/execute-symbol.md
+++ b/language-reference-guide/docs/symbols/execute-symbol.md
@@ -2,20 +2,11 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Hydrant</span> <span class="command">⍎</span></h1>
 
-
 Monadic Hydrant means
-
-
 [Execute expression](../primitive-functions/execute.md)
 ```apl
-
       ⍎ '1+1'
 2
       V ← 1 2 3
@@ -25,8 +16,6 @@ Monadic Hydrant means
 ```
 
 Dyadic Hydrant means
-
-
 [Execute expression in given namespace](../primitive-functions/execute.md)
 ```apl
       '#' ⍎ '⎕PP ⎕CT ⎕RL'
@@ -37,8 +26,6 @@ Dyadic Hydrant means
 └──┴─────┴────┘
 
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/execute-symbol.md
+++ b/language-reference-guide/docs/symbols/execute-symbol.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Hydrant</span> <span class="command">⍎</span></h1>
 
 
-## Monadic Hydrant means
+Monadic Hydrant means
 
 
 [Execute expression](../primitive-functions/execute.md)
@@ -24,7 +24,7 @@ search:
 
 ```
 
-## Dyadic Hydrant means
+Dyadic Hydrant means
 
 
 [Execute expression in given namespace](../primitive-functions/execute.md)

--- a/language-reference-guide/docs/symbols/grade-down.md
+++ b/language-reference-guide/docs/symbols/grade-down.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Grade Down</span> <span class="command">⍒</span></h1>
 
 
-## Monadic Grade Down means
+Monadic Grade Down means
 
 
 [Grade Down](../primitive-functions/grade-down-monadic.md)
@@ -31,7 +31,7 @@ search:
 1 5 4 2 3
 ```
 
-## Dyadic Grade Down means
+Dyadic Grade Down means
 
 
 [Dyadic Grade Down](../primitive-functions/grade-down-dyadic.md)

--- a/language-reference-guide/docs/symbols/grade-down.md
+++ b/language-reference-guide/docs/symbols/grade-down.md
@@ -2,20 +2,11 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Grade Down</span> <span class="command">⍒</span></h1>
 
-
 Monadic Grade Down means
-
-
 [Grade Down](../primitive-functions/grade-down-monadic.md)
 ```apl
-
       ⍒ 33 11 44 66 22
 4 3 1 5 2
 
@@ -32,11 +23,8 @@ Monadic Grade Down means
 ```
 
 Dyadic Grade Down means
-
-
 [Dyadic Grade Down](../primitive-functions/grade-down-dyadic.md)
 ```apl
-
 Provide collating sequence for character data.
 
       ⍒ 'Banana'
@@ -44,10 +32,7 @@ Provide collating sequence for character data.
 
       'an' ⍒ 'Banana'
 1 3 5 2 4 6
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/grade-up.md
+++ b/language-reference-guide/docs/symbols/grade-up.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Grade Up</span> <span class="command">⍋</span></h1>
 
 
-## Monadic Grade Up means
+Monadic Grade Up means
 
 
 [Grade Up](../primitive-functions/grade-up-monadic.md)
@@ -33,7 +33,7 @@ search:
 
 ```
 
-## Dyadic Grade Up means
+Dyadic Grade Up means
 
 
 [Dyadic Grade Up](../primitive-functions/grade-up-dyadic.md)

--- a/language-reference-guide/docs/symbols/grade-up.md
+++ b/language-reference-guide/docs/symbols/grade-up.md
@@ -2,21 +2,11 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Grade Up</span> <span class="command">⍋</span></h1>
 
-
 Monadic Grade Up means
-
-
 [Grade Up](../primitive-functions/grade-up-monadic.md)
 ```apl
-
-
       ⍋ 33 11 44 66 22
 2 5 1 3 4
 
@@ -30,24 +20,17 @@ Monadic Grade Up means
 
       ⍋ 'ABC' ⎕NULL ⍬ ¯3j4 'A'
 3 2 4 5 1
-
 ```
 
 Dyadic Grade Up means
-
-
 [Dyadic Grade Up](../primitive-functions/grade-up-dyadic.md)
 ```apl
-
       ⍋ 'Banana'
 1 2 4 6 3 5
 
       'an' ⍋ 'Banana'
 2 4 6 3 5 1
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/greater-than-or-equal-to-sign.md
+++ b/language-reference-guide/docs/symbols/greater-than-or-equal-to-sign.md
@@ -2,20 +2,11 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Greater Than Or Equal To Sign</span> <span class="command">≥</span></h1>
-
-
 
 Monadic Greater Than or Equal To Sign is not defined
 
 Dyadic Greater Than or Equal To Sign means
-
-
 [Is Greater Or Equal To](../primitive-functions/greater-or-equal.md)
 ```apl
 
@@ -25,8 +16,6 @@ Dyadic Greater Than or Equal To Sign means
 0 1 1
 
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/greater-than-or-equal-to-sign.md
+++ b/language-reference-guide/docs/symbols/greater-than-or-equal-to-sign.md
@@ -2,11 +2,11 @@
 search:
   exclude: true
 ---
-<h1 class="heading"><span class="name">Greater Than Or Equal To Sign</span> <span class="command">≥</span></h1>
+<h1 class="heading"><span class="name">Greater Than Or Equal To</span> <span class="command">≥</span></h1>
 
-Monadic Greater Than or Equal To Sign is not defined
+Monadic Greater Than or Equal To is not defined
 
-Dyadic Greater Than or Equal To Sign means
+Dyadic Greater Than or Equal To means
 [Is Greater Or Equal To](../primitive-functions/greater-or-equal.md)
 ```apl
 

--- a/language-reference-guide/docs/symbols/greater-than-or-equal-to-sign.md
+++ b/language-reference-guide/docs/symbols/greater-than-or-equal-to-sign.md
@@ -13,7 +13,7 @@ search:
 
 Monadic Greater Than or Equal To Sign is not defined
 
-## Dyadic Greater Than or Equal To Sign means
+Dyadic Greater Than or Equal To Sign means
 
 
 [Is Greater Or Equal To](../primitive-functions/greater-or-equal.md)

--- a/language-reference-guide/docs/symbols/greater-than-sign.md
+++ b/language-reference-guide/docs/symbols/greater-than-sign.md
@@ -2,11 +2,11 @@
 search:
   exclude: true
 ---
-<h1 class="heading"><span class="name">Greater Than Sign</span> <span class="command">></span></h1>
+<h1 class="heading"><span class="name">Greater Than</span> <span class="command">></span></h1>
 
-Monadic Greater Than Sign is not defined
+Monadic Greater Than is not defined
 
-Dyadic Greater Than Sign means
+Dyadic Greater Than means
 [Greater Than](../primitive-functions/greater.md)
 ```apl
 

--- a/language-reference-guide/docs/symbols/greater-than-sign.md
+++ b/language-reference-guide/docs/symbols/greater-than-sign.md
@@ -2,20 +2,11 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Greater Than Sign</span> <span class="command">></span></h1>
-
-
 
 Monadic Greater Than Sign is not defined
 
 Dyadic Greater Than Sign means
-
-
 [Greater Than](../primitive-functions/greater.md)
 ```apl
 
@@ -25,8 +16,6 @@ Dyadic Greater Than Sign means
 0 0 1
 
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/greater-than-sign.md
+++ b/language-reference-guide/docs/symbols/greater-than-sign.md
@@ -13,7 +13,7 @@ search:
 
 Monadic Greater Than Sign is not defined
 
-## Dyadic Greater Than Sign means
+Dyadic Greater Than Sign means
 
 
 [Greater Than](../primitive-functions/greater.md)

--- a/language-reference-guide/docs/symbols/ibeam.md
+++ b/language-reference-guide/docs/symbols/ibeam.md
@@ -2,11 +2,6 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">I-Beam</span> <span class="command">⌶</span></h1>
 
 
@@ -14,12 +9,10 @@ I-Beam is a monadic operator that provides a range of system related services.
 
 <h3 class="example">Examples</h3>
 
-
 Monadic operator:  I-Beam
 
 Provides a system-related service
 determined by the left-operand value.
-
 
 [Language Elements](./language-elements.md)
 

--- a/language-reference-guide/docs/symbols/ibeam.md
+++ b/language-reference-guide/docs/symbols/ibeam.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">I-Beam</span> <span class="command">⌶</span></h1>
 
 
-## I-Beam is a monadic operator that provides a range of system related services.
+I-Beam is a monadic operator that provides a range of system related services.
 
 <h3 class="example">Examples</h3>
 

--- a/language-reference-guide/docs/symbols/index-symbol.md
+++ b/language-reference-guide/docs/symbols/index-symbol.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Squad</span> <span class="command">⌷</span></h1>
 
 
-## Squad means
+Squad means
 
 
 [Materialise](../primitive-functions/materialise.md)
@@ -25,7 +25,7 @@ If ⍵ is a COM or .NET collection, returns all elements
 in the collection as an array.
 ```
 
-## Index with Axes means
+Index with Axes means
 
 
 [Index](../primitive-functions/index-with-axes.md)

--- a/language-reference-guide/docs/symbols/index-symbol.md
+++ b/language-reference-guide/docs/symbols/index-symbol.md
@@ -2,20 +2,11 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Squad</span> <span class="command">⌷</span></h1>
 
-
 Squad means
-
-
 [Materialise](../primitive-functions/materialise.md)
 ```apl
-
       ⌷ ⍵
 If ⍵ is an array, returns ⍵.
 If ⍵ is ref to an instance of a Dyalog Class with a 
@@ -26,11 +17,8 @@ in the collection as an array.
 ```
 
 Index with Axes means
-
-
 [Index](../primitive-functions/index-with-axes.md)
 ```apl
-
       mat
 1  2  3  4
 5  6  7  8
@@ -43,10 +31,7 @@ Index with Axes means
 
       2 ⌷[2] mat
 2 6 10
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/iota-underbar.md
+++ b/language-reference-guide/docs/symbols/iota-underbar.md
@@ -2,17 +2,11 @@
 search:
   exclude: true
 ---
-
-
 <h1 class="heading"><span class="name">Iota Underbar</span> <span class="command">⍸</span></h1>
 
-
 Monadic Iota Underbar means
-
-
 [Where](../primitive-functions/where.md)
 ```apl
-
       ⍸ 1 0 0 1 1
 1 4 5
       bmat
@@ -25,11 +19,8 @@ Monadic Iota Underbar means
 ```
 
 Dyadic Iota Underbar means
-
-
 [Interval Index](../primitive-functions/interval-index.md)
 ```apl
-
       'AEIOU' ⍸ 'DYALOG'
 1 5 1 3 4 2
 
@@ -44,8 +35,5 @@ Dyadic Iota Underbar means
 1
       mat ⍸ 3 5
 2
-
 ```
-
-
 [Language Elements](./language-elements.md)

--- a/language-reference-guide/docs/symbols/iota-underbar.md
+++ b/language-reference-guide/docs/symbols/iota-underbar.md
@@ -7,7 +7,7 @@ search:
 <h1 class="heading"><span class="name">Iota Underbar</span> <span class="command">⍸</span></h1>
 
 
-## Monadic Iota Underbar means
+Monadic Iota Underbar means
 
 
 [Where](../primitive-functions/where.md)
@@ -24,7 +24,7 @@ search:
 └───┴───┴───┘
 ```
 
-## Dyadic Iota Underbar means
+Dyadic Iota Underbar means
 
 
 [Interval Index

--- a/language-reference-guide/docs/symbols/iota-underbar.md
+++ b/language-reference-guide/docs/symbols/iota-underbar.md
@@ -27,8 +27,7 @@ Monadic Iota Underbar means
 Dyadic Iota Underbar means
 
 
-[Interval Index
-      ](../primitive-functions/interval-index.md)
+[Interval Index](../primitive-functions/interval-index.md)
 ```apl
 
       'AEIOU' ⍸ 'DYALOG'

--- a/language-reference-guide/docs/symbols/iota.md
+++ b/language-reference-guide/docs/symbols/iota.md
@@ -8,7 +8,7 @@ search:
 <h1 class="heading"><span class="name">Iota</span> <span class="command">⍳</span></h1>
 
 
-## Monadic Iota means
+Monadic Iota means
 
 
 [Index Generator
@@ -26,7 +26,7 @@ search:
 └───┴───┴───┘
 ```
 
-## Dyadic Iota means
+Dyadic Iota means
 
 
 [Index Of

--- a/language-reference-guide/docs/symbols/iota.md
+++ b/language-reference-guide/docs/symbols/iota.md
@@ -2,15 +2,9 @@
 search:
   exclude: true
 ---
-
-
-
 <h1 class="heading"><span class="name">Iota</span> <span class="command">⍳</span></h1>
 
-
 Monadic Iota means
-
-
 [Index Generator
       ](../primitive-functions/index-generator.md)
 ```apl
@@ -44,6 +38,4 @@ Dyadic Iota means
 3
 
 ```
-
-
 [Language Elements](./language-elements.md)

--- a/language-reference-guide/docs/symbols/jot-diaresis.md
+++ b/language-reference-guide/docs/symbols/jot-diaresis.md
@@ -2,23 +2,13 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Jot Diaeresis</span> <span class="command">⍤</span></h1>
-
 
 Jot Diaeresis is a Dyadic operator with an ambivalent left operand
 
 Operator Jot Diaeresis means
-
-
 [Atop](../primitive-operators/atop.md)
 ```apl
-
-
       -⍤÷ 4
 ¯0.25
       12 -⍤÷ 4
@@ -28,11 +18,8 @@ Operator Jot Diaeresis means
       3 1 4 1 5 (~⍤∊ ⊢⍤/ ⊣) ⍳3  ⍝ ⊢⍤/ is always a function
 4 5
 ```
-
-
 [Rank ](../primitive-operators/rank.md)
 ```apl
-
       cube    ⍝ 3D array
  1  2  3
  4  5  6
@@ -59,10 +46,7 @@ zxy
 11 12 13 14 
 25 26 27 28 
 39 40 41 42
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/jot-diaresis.md
+++ b/language-reference-guide/docs/symbols/jot-diaresis.md
@@ -4,7 +4,7 @@ search:
 ---
 <h1 class="heading"><span class="name">Jot Diaeresis</span> <span class="command">⍤</span></h1>
 
-Jot Diaeresis is a Dyadic operator with an ambivalent left operand
+Jot Diaeresis is a dyadic operator with an ambivalent left operand
 
 Operator Jot Diaeresis means
 [Atop](../primitive-operators/atop.md)

--- a/language-reference-guide/docs/symbols/jot-diaresis.md
+++ b/language-reference-guide/docs/symbols/jot-diaresis.md
@@ -10,8 +10,7 @@ search:
 <h1 class="heading"><span class="name">Jot Diaeresis</span> <span class="command">⍤</span></h1>
 
 
-Jot Diaeresis is a Dyadic operator with an ambivalent
-      left operand
+Jot Diaeresis is a Dyadic operator with an ambivalent left operand
 
 Operator Jot Diaeresis means
 

--- a/language-reference-guide/docs/symbols/jot-diaresis.md
+++ b/language-reference-guide/docs/symbols/jot-diaresis.md
@@ -10,10 +10,10 @@ search:
 <h1 class="heading"><span class="name">Jot Diaeresis</span> <span class="command">⍤</span></h1>
 
 
-## Jot Diaeresis is a Dyadic operator with an ambivalent
+Jot Diaeresis is a Dyadic operator with an ambivalent
       left operand
 
-## Operator Jot Diaeresis means
+Operator Jot Diaeresis means
 
 
 [Atop](../primitive-operators/atop.md)

--- a/language-reference-guide/docs/symbols/jot-underbar.md
+++ b/language-reference-guide/docs/symbols/jot-underbar.md
@@ -2,13 +2,11 @@
 search:
   exclude: true
 ---
-
 <h1 class="heading"><span class="name">Jot Underbar</span> <span class="command">⍛</span></h1>
 
 Jot Underbar is a Dyadic Operator
 
 Operator Jot Underbar Means
-
 [Behind](../primitive-operators/behind.md)
 ```apl
       ⍝ Is it a palindrome?
@@ -21,5 +19,4 @@ Operator Jot Underbar Means
       4-⍛↓'Dyalog APL'
 Dyalog
 ```
-
 [Language Elements](./language-elements.md)

--- a/language-reference-guide/docs/symbols/jot-underbar.md
+++ b/language-reference-guide/docs/symbols/jot-underbar.md
@@ -6,7 +6,7 @@ search:
 
 Jot Underbar is a dyadic Operator
 
-Operator Jot Underbar Means
+Operator Jot Underbar means
 [Behind](../primitive-operators/behind.md)
 ```apl
       ⍝ Is it a palindrome?

--- a/language-reference-guide/docs/symbols/jot-underbar.md
+++ b/language-reference-guide/docs/symbols/jot-underbar.md
@@ -4,7 +4,7 @@ search:
 ---
 <h1 class="heading"><span class="name">Jot Underbar</span> <span class="command">⍛</span></h1>
 
-Jot Underbar is a Dyadic Operator
+Jot Underbar is a dyadic Operator
 
 Operator Jot Underbar Means
 [Behind](../primitive-operators/behind.md)

--- a/language-reference-guide/docs/symbols/jot-underbar.md
+++ b/language-reference-guide/docs/symbols/jot-underbar.md
@@ -5,9 +5,9 @@ search:
 
 <h1 class="heading"><span class="name">Jot Underbar</span> <span class="command">⍛</span></h1>
 
-## Jot Underbar is a Dyadic Operator
+Jot Underbar is a Dyadic Operator
 
-## Operator Jot Underbar Means
+Operator Jot Underbar Means
 
 [Behind](../primitive-operators/behind.md)
 ```apl

--- a/language-reference-guide/docs/symbols/jot.md
+++ b/language-reference-guide/docs/symbols/jot.md
@@ -4,7 +4,7 @@ search:
 ---
 <h1 class="heading"><span class="name">Jot</span> <span class="command">∘</span></h1>
 
-Jot is a Dyadic operator
+Jot is a dyadic operator
 
 Operator Jot means Beside or Bind
 

--- a/language-reference-guide/docs/symbols/jot.md
+++ b/language-reference-guide/docs/symbols/jot.md
@@ -2,25 +2,14 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Jot</span> <span class="command">∘</span></h1>
-
 
 Jot is a Dyadic operator
 
-Operator Jot means
-
-
-Beside or Bind
-
+Operator Jot means Beside or Bind
 
 [Beside](../primitive-operators/beside.md) (function composition)
 ```apl
-
       ⌽∘⍳¨ 3 4 5
 ┌─────┬───────┬─────────┐
 │3 2 1│4 3 2 1│5 4 3 2 1│
@@ -33,13 +22,10 @@ Beside or Bind
 
       +∘÷/ 40⍴1    ⍝ continued fraction
 1.61803
-
 ```
-
 
 [Bind](../primitive-operators/bind.md) (left and right argument currying)
 ```apl
-
       next ← 1∘+
       next 23
 24
@@ -47,11 +33,8 @@ Beside or Bind
       prev 23
 22
 ```
-
-
 N.B. Jot is also used in conjunction with Dot to mean
       [Outer Product](../primitive-operators/outer-product.md).
-
 
 [Language Elements](./language-elements.md)
 

--- a/language-reference-guide/docs/symbols/jot.md
+++ b/language-reference-guide/docs/symbols/jot.md
@@ -37,8 +37,7 @@ Beside or Bind
 ```
 
 
-[
-Bind](../primitive-operators/bind.md) (left and right argument currying)
+[Bind](../primitive-operators/bind.md) (left and right argument currying)
 ```apl
 
       next ← 1∘+
@@ -51,8 +50,7 @@ Bind](../primitive-operators/bind.md) (left and right argument currying)
 
 
 N.B. Jot is also used in conjunction with Dot to mean
-      [Outer
-        Product](../primitive-operators/outer-product.md).
+      [Outer Product](../primitive-operators/outer-product.md).
 
 
 [Language Elements](./language-elements.md)

--- a/language-reference-guide/docs/symbols/jot.md
+++ b/language-reference-guide/docs/symbols/jot.md
@@ -10,9 +10,9 @@ search:
 <h1 class="heading"><span class="name">Jot</span> <span class="command">∘</span></h1>
 
 
-## Jot is a Dyadic operator
+Jot is a Dyadic operator
 
-## Operator Jot means
+Operator Jot means
 
 
 Beside or Bind

--- a/language-reference-guide/docs/symbols/language-elements.md
+++ b/language-reference-guide/docs/symbols/language-elements.md
@@ -4,152 +4,90 @@ Primitive Functions
 
 <table class="Normal">
     <tr>
-        <td class="Dyalog"><a href="../plus-sign">+</a>
-        </td>
-        <td class="Dyalog"><a href="../minus-sign">-</a>
-        </td>
-        <td class="Dyalog"><a href="../times-sign">×</a>
-        </td>
-        <td class="Dyalog"><a href="../divide-sign">÷</a>
-        </td>
-        <td class="Dyalog"><a href="../stile">|</a>
-        </td>
-        <td class="Dyalog"><a href="../upstile">⌈</a>
-        </td>
-        <td class="Dyalog"><a href="../downstile">⌊</a>
-        </td>
-        <td class="Dyalog"><a href="../star">*</a>
-        </td>
-        <td class="Dyalog"><a href="../log">⍟</a>
-        </td>
+        <td class="Dyalog"><a href="../plus-sign">+</a> </td>
+        <td class="Dyalog"><a href="../minus-sign">-</a> </td>
+        <td class="Dyalog"><a href="../times-sign">×</a> </td>
+        <td class="Dyalog"><a href="../divide-sign">÷</a> </td>
+        <td class="Dyalog"><a href="../stile">|</a> </td>
+        <td class="Dyalog"><a href="../upstile">⌈</a> </td>
+        <td class="Dyalog"><a href="../downstile">⌊</a> </td>
+        <td class="Dyalog"><a href="../star">*</a> </td>
+        <td class="Dyalog"><a href="../log">⍟</a> </td>
         <td>&#160;</td>
         <td>&#160;</td>
     </tr>
     <tr>
-        <td class="Dyalog"><a href="../circle">○</a>
-        </td>
-        <td class="Dyalog"><a href="../exclamation-mark">!</a>
-        </td>
-        <td class="Dyalog"><a href="../question-mark">?</a>
-        </td>
-        <td class="Dyalog"><a href="../tilde">~</a>
-        </td>
-        <td class="Dyalog"><a href="../logical-and">∧</a>
-        </td>
-        <td class="Dyalog"><a href="../logical-or">∨</a>
-        </td>
-        <td class="Dyalog"><a href="../nand-symbol">⍲</a>
-        </td>
-        <td class="Dyalog"><a href="../nor-symbol">⍱</a>
-        </td>
-        <td class="Dyalog">&#160;
-                    </td>
+        <td class="Dyalog"><a href="../circle">○</a> </td>
+        <td class="Dyalog"><a href="../exclamation-mark">!</a> </td>
+        <td class="Dyalog"><a href="../question-mark">?</a> </td>
+        <td class="Dyalog"><a href="../tilde">~</a> </td>
+        <td class="Dyalog"><a href="../logical-and">∧</a> </td>
+        <td class="Dyalog"><a href="../logical-or">∨</a> </td>
+        <td class="Dyalog"><a href="../nand-symbol">⍲</a> </td>
+        <td class="Dyalog"><a href="../nor-symbol">⍱</a> </td>
+        <td class="Dyalog">&#160; </td>
         <td>&#160;</td>
         <td>&#160;</td>
     </tr>
     <tr>
-        <td class="Dyalog"><a href="../less-than-sign">&lt;</a>
-        </td>
-        <td class="Dyalog"><a href="../less-than-or-equal-to-sign">≤</a>
-        </td>
-        <td class="Dyalog"><a href="../equal-sign">=</a>
-        </td>
-        <td class="Dyalog"><a href="../greater-than-sign">&gt;</a>
-        </td>
-        <td class="Dyalog"><a href="../greater-than-or-equal-to-sign">≥</a>
-        </td>
-        <td class="Dyalog"><a href="../not-equal-to">≠</a>
-        </td>
-        <td class="Dyalog"><a href="../equal-underbar">≡</a>
-        </td>
-        <td class="Dyalog"><a href="../equal-underbar-slash">≢</a>
-        </td>
+        <td class="Dyalog"><a href="../less-than-sign">&lt;</a> </td>
+        <td class="Dyalog"><a href="../less-than-or-equal-to-sign">≤</a> </td>
+        <td class="Dyalog"><a href="../equal-sign">=</a> </td>
+        <td class="Dyalog"><a href="../greater-than-sign">&gt;</a> </td>
+        <td class="Dyalog"><a href="../greater-than-or-equal-to-sign">≥</a> </td>
+        <td class="Dyalog"><a href="../not-equal-to">≠</a> </td>
+        <td class="Dyalog"><a href="../equal-underbar">≡</a> </td>
+        <td class="Dyalog"><a href="../equal-underbar-slash">≢</a> </td>
         <td>&#160;</td>
         <td>&#160;</td>
         <td>&#160;</td>
     </tr>
     <tr>
-        <td class="Dyalog"><a href="../rho">⍴</a>
-        </td>
-        <td class="Dyalog"><a href="../comma">,</a>
-        </td>
-        <td class="Dyalog"><a href="../comma-bar">⍪</a>
-        </td>
-        <td class="Dyalog"><a href="../circle-stile">⌽</a>
-        </td>
-        <td class="Dyalog"><a href="../circle-bar">⊖</a>
-        </td>
-        <td class="Dyalog"><a href="../transpose">⍉</a>
-        </td>
-        <td class="Dyalog"><a href="../up-arrow">↑</a>
-        </td>
-        <td class="Dyalog"><a href="../down-arrow">↓</a>
-        </td>
-        <td class="Dyalog">&#160;
-                    </td>
+        <td class="Dyalog"><a href="../rho">⍴</a> </td>
+        <td class="Dyalog"><a href="../comma">,</a> </td>
+        <td class="Dyalog"><a href="../comma-bar">⍪</a> </td>
+        <td class="Dyalog"><a href="../circle-stile">⌽</a> </td>
+        <td class="Dyalog"><a href="../circle-bar">⊖</a> </td>
+        <td class="Dyalog"><a href="../transpose">⍉</a> </td>
+        <td class="Dyalog"><a href="../up-arrow">↑</a> </td>
+        <td class="Dyalog"><a href="../down-arrow">↓</a> </td>
+        <td class="Dyalog">&#160; </td>
         <td>&#160;</td>
         <td>&#160;</td>
     </tr>
     <tr>
-        <td class="Dyalog"><a href="../left-shoe">⊂</a>
-        </td>
-        <td class="Dyalog"><a href="../left-shoe-underbar">⊆</a>
-        </td>
-        <td class="Dyalog"><a href="../right-shoe">⊃</a>
-        </td>
-        <td class="Dyalog"><a href="../epsilon">∊</a>
-        </td>
-        <td class="Dyalog"><a href="../epsilon-underbar">⍷</a>
-        </td>
-        <td class="Dyalog"><a href="../slash">/</a>
-        </td>
-        <td class="Dyalog"><a href="../slash-bar">⌿</a>
-        </td>
-        <td class="Dyalog"><a href="../slope">\</a>
-        </td>
-        <td class="Dyalog"><a href="../slope-bar">⍀</a>
-        </td>
-        <td class="Dyalog">&#160;
-                    </td>
+        <td class="Dyalog"><a href="../left-shoe">⊂</a> </td>
+        <td class="Dyalog"><a href="../left-shoe-underbar">⊆</a> </td>
+        <td class="Dyalog"><a href="../right-shoe">⊃</a> </td>
+        <td class="Dyalog"><a href="../epsilon">∊</a> </td>
+        <td class="Dyalog"><a href="../epsilon-underbar">⍷</a> </td>
+        <td class="Dyalog"><a href="../slash">/</a> </td>
+        <td class="Dyalog"><a href="../slash-bar">⌿</a> </td>
+        <td class="Dyalog"><a href="../slope">\</a> </td>
+        <td class="Dyalog"><a href="../slope-bar">⍀</a> </td>
+        <td class="Dyalog">&#160; </td>
         <td>&#160;</td>
     </tr>
     <tr>
-        <td class="Dyalog"><a href="../set-intersection">∩</a>
-        </td>
-        <td class="Dyalog"><a href="../set-union">∪</a>
-        </td>
-        <td class="Dyalog"><a href="../iota">⍳</a>
-        </td>
-        <td class="Dyalog"><a href="../iota-underbar">⍸</a>
-        </td>
-        <td class="Dyalog"><a href="../index-symbol">⌷</a>
-        </td>
-        <td class="Dyalog"><a href="../grade-up">⍋</a>
-        </td>
-        <td class="Dyalog"><a href="../grade-down">⍒</a>
-        </td>
-        <td class="Dyalog"><a href="../execute-symbol">⍎</a>
-        </td>
-        <td class="Dyalog"><a href="../thorn-symbol">⍕</a>
-        </td>
-        <td class="Dyalog"><a href="../decode-symbol">⊥</a>
-        </td>
-        <td class="Dyalog"><a href="../encode-symbol">⊤</a>
-        </td>
+        <td class="Dyalog"><a href="../set-intersection">∩</a> </td>
+        <td class="Dyalog"><a href="../set-union">∪</a> </td>
+        <td class="Dyalog"><a href="../iota">⍳</a> </td>
+        <td class="Dyalog"><a href="../iota-underbar">⍸</a> </td>
+        <td class="Dyalog"><a href="../index-symbol">⌷</a> </td>
+        <td class="Dyalog"><a href="../grade-up">⍋</a> </td>
+        <td class="Dyalog"><a href="../grade-down">⍒</a> </td>
+        <td class="Dyalog"><a href="../execute-symbol">⍎</a> </td>
+        <td class="Dyalog"><a href="../thorn-symbol">⍕</a> </td>
+        <td class="Dyalog"><a href="../decode-symbol">⊥</a> </td>
+        <td class="Dyalog"><a href="../encode-symbol">⊤</a> </td>
     </tr>
     <tr>
-        <td class="Dyalog"><a href="../left-tack">⊣</a>
-        </td>
-        <td class="Dyalog"><a href="../right-tack">⊢</a>
-        </td>
-        <td class="Dyalog"><a href="../domino">⌹</a>
-        </td>
-        <td class="Dyalog"><a href="../zilde-symbol">⍬</a>
-        </td>
-        <td class="Dyalog"><a href="../right-arrow">→</a>
-        </td>
-        <td class="Dyalog"><a href="../left-arrow">←</a>
-        </td>
+        <td class="Dyalog"><a href="../left-tack">⊣</a> </td>
+        <td class="Dyalog"><a href="../right-tack">⊢</a> </td>
+        <td class="Dyalog"><a href="../domino">⌹</a> </td>
+        <td class="Dyalog"><a href="../zilde-symbol">⍬</a> </td>
+        <td class="Dyalog"><a href="../right-arrow">→</a> </td>
+        <td class="Dyalog"><a href="../left-arrow">←</a> </td>
         <td>&#160;</td>
         <td>&#160;</td>
         <td>&#160;</td>
@@ -162,46 +100,28 @@ Primitive Operators
 
 <table class="Normal">
     <tr>
-        <td class="Dyalog"><a href="../dieresis">¨</a>
-        </td>
-        <td class="Dyalog"><a href="../dieresis-tilde">⍨</a>
-        </td>
-        <td class="Dyalog"><a href="../jot">∘</a>
-        </td>
-        <td class="Dyalog"><a href="../dot">.</a>
-        </td>
-        <td class="Dyalog"><a href="../../primitive-operators/outer-product">∘.</a>
-        </td>
-        <td class="Dyalog"><a href="../slash">/</a>
-        </td>
+        <td class="Dyalog"><a href="../dieresis">¨</a> </td>
+        <td class="Dyalog"><a href="../dieresis-tilde">⍨</a> </td>
+        <td class="Dyalog"><a href="../jot">∘</a> </td>
+        <td class="Dyalog"><a href="../dot">.</a> </td>
+        <td class="Dyalog"><a href="../../primitive-operators/outer-product">∘.</a> </td>
+        <td class="Dyalog"><a href="../slash">/</a> </td>
     </tr>
     <tr>
-        <td class="Dyalog"><a href="../slash-bar">⌿</a>
-        </td>
-        <td class="Dyalog"><a href="../slope">\</a>
-        </td>
-        <td class="Dyalog"><a href="../slope-bar">⍀</a>
-        </td>
-        <td class="Dyalog"><a href="../dieresisstar">⍣</a>
-        </td>
-        <td class="Dyalog"><a href="../ampersand">&amp;</a>
-        </td>
-        <td class="Dyalog"><a href="../ibeam">⌶</a>
-        </td>
+        <td class="Dyalog"><a href="../slash-bar">⌿</a> </td>
+        <td class="Dyalog"><a href="../slope">\</a> </td>
+        <td class="Dyalog"><a href="../slope-bar">⍀</a> </td>
+        <td class="Dyalog"><a href="../dieresisstar">⍣</a> </td>
+        <td class="Dyalog"><a href="../ampersand">&amp;</a> </td>
+        <td class="Dyalog"><a href="../ibeam">⌶</a> </td>
     </tr>
     <tr>
-        <td class="Dyalog"><a href="../variant">⍠</a>
-        </td>
-        <td class="Dyalog"><a href="../quad-equal">⌸</a>
-        </td>
-        <td class="Dyalog"><a href="../quad-diamond">⌺</a>
-        </td>
-        <td class="Dyalog"><a href="../jot-diaresis">⍤</a>
-        </td>
-        <td class="Dyalog"><a href="../circle-dieresis">⍥</a>
-        </td>
-        <td class="Dyalog"><a href="../jot-underbar">⍛</a>
-        </td>
+        <td class="Dyalog"><a href="../variant">⍠</a> </td>
+        <td class="Dyalog"><a href="../quad-equal">⌸</a> </td>
+        <td class="Dyalog"><a href="../quad-diamond">⌺</a> </td>
+        <td class="Dyalog"><a href="../jot-diaresis">⍤</a> </td>
+        <td class="Dyalog"><a href="../circle-dieresis">⍥</a> </td>
+        <td class="Dyalog"><a href="../jot-underbar">⍛</a> </td>
     </tr>
     <tr>
         <td class="Dyalog"><a href="../at">@</a></td>

--- a/language-reference-guide/docs/symbols/language-elements.md
+++ b/language-reference-guide/docs/symbols/language-elements.md
@@ -1,6 +1,6 @@
 <h1 class="heading"><span class="name">Language Elements</span></h1>
 
-## Primitive Functions
+Primitive Functions
 
 <table class="Normal">
     <tr>
@@ -158,7 +158,7 @@
     </tr>
 </table>
 
-## Primitive Operators
+Primitive Operators
 
 <table class="Normal">
     <tr>
@@ -213,7 +213,7 @@
     </tr>
 </table>
 
-## Other Language Elements
+Other Language Elements
 
 - [Brackets](../brackets)
 - [Special Syntax](../special-symbols)

--- a/language-reference-guide/docs/symbols/left-arrow.md
+++ b/language-reference-guide/docs/symbols/left-arrow.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Left Arrow</span> <span class="command">←</span></h1>
 
 
-## Dyadic Left Arrow means
+Dyadic Left Arrow means
 
 
 [Naming      ](../primitive-functions/assignment.md)
@@ -23,7 +23,7 @@ search:
     inverse ← ⍣¯1
 ```
 
-## Operator Left Arrow means
+Operator Left Arrow means
 
 
 [Modified Assignment](../primitive-functions/assignment.md)

--- a/language-reference-guide/docs/symbols/left-arrow.md
+++ b/language-reference-guide/docs/symbols/left-arrow.md
@@ -2,17 +2,9 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Left Arrow</span> <span class="command">←</span></h1>
 
-
 Dyadic Left Arrow means
-
-
 [Naming      ](../primitive-functions/assignment.md)
 ```apl
 
@@ -24,8 +16,6 @@ Dyadic Left Arrow means
 ```
 
 Operator Left Arrow means
-
-
 [Modified Assignment](../primitive-functions/assignment.md)
 ```apl
 
@@ -34,8 +24,6 @@ Operator Left Arrow means
     (⊃V) ← 2
 
 ```
-
-
 [Language Elements](../primitive-functions/assignment.md)
 
 

--- a/language-reference-guide/docs/symbols/left-shoe-underbar.md
+++ b/language-reference-guide/docs/symbols/left-shoe-underbar.md
@@ -13,8 +13,7 @@ search:
 Monadic Left Shoe Underbar means
 
 
-[Nest
-      ](../primitive-functions/nest.md)
+[Nest](../primitive-functions/nest.md)
 ```apl
 
       ⊆ 'this'

--- a/language-reference-guide/docs/symbols/left-shoe-underbar.md
+++ b/language-reference-guide/docs/symbols/left-shoe-underbar.md
@@ -2,20 +2,12 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Left Shoe Underbar</span> <span class="command">⊆</span></h1>
 
 
 Monadic Left Shoe Underbar means
-
-
 [Nest](../primitive-functions/nest.md)
 ```apl
-
       ⊆ 'this'
 ┌────┐
 │this│
@@ -27,11 +19,8 @@ Monadic Left Shoe Underbar means
 ```
 
 Dyadic Left Shoe Underbar means
-
-
 [Partition](../primitive-functions/partition.md)
 ```apl
-
       1 0 0 1 1 ⊆ 1 2 3 4 5
 ┌─┬───┐
 │1│4 5│
@@ -44,10 +33,7 @@ Dyadic Left Shoe Underbar means
 ┌────┬─┬────┐
 │many│a│time│
 └────┴─┴────┘
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/left-shoe-underbar.md
+++ b/language-reference-guide/docs/symbols/left-shoe-underbar.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Left Shoe Underbar</span> <span class="command">⊆</span></h1>
 
 
-## Monadic Left Shoe Underbar means
+Monadic Left Shoe Underbar means
 
 
 [Nest
@@ -27,7 +27,7 @@ search:
 └────┴────┘
 ```
 
-## Dyadic Left Shoe Underbar means
+Dyadic Left Shoe Underbar means
 
 
 [Partition](../primitive-functions/partition.md)

--- a/language-reference-guide/docs/symbols/left-shoe.md
+++ b/language-reference-guide/docs/symbols/left-shoe.md
@@ -2,20 +2,11 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Left Shoe</span> <span class="command">⊂</span></h1>
 
-
 Monadic Left Shoe means
-
-
 [Enclose](../primitive-functions/enclose.md)
 ```apl
-
       1(2 3)
 ┌─┬───┐
 │1│2 3│
@@ -38,16 +29,13 @@ Monadic Left Shoe means
 
 Dyadic Left Shoe means
 
-
 If `⎕ML<3`[ Partitioned Enclose](../primitive-functions/partitioned-enclose.md)
 ```apl
        0 1 0 1 ⊂ 1 2 3 4
 ┌───┬─┐
 │2 3│4│
 └───┴─┘
-
 ```
-
 
 If `⎕ML≥3`[ Partition](../primitive-functions/partition.md)
 ```apl
@@ -55,10 +43,7 @@ If `⎕ML≥3`[ Partition](../primitive-functions/partition.md)
 ┌─┬─┐
 │2│4│
 └─┴─┘
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/left-shoe.md
+++ b/language-reference-guide/docs/symbols/left-shoe.md
@@ -13,8 +13,7 @@ search:
 Monadic Left Shoe means
 
 
-[Enclose
-      ](../primitive-functions/enclose.md)
+[Enclose](../primitive-functions/enclose.md)
 ```apl
 
       1(2 3)

--- a/language-reference-guide/docs/symbols/left-shoe.md
+++ b/language-reference-guide/docs/symbols/left-shoe.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Left Shoe</span> <span class="command">⊂</span></h1>
 
 
-## Monadic Left Shoe means
+Monadic Left Shoe means
 
 
 [Enclose
@@ -37,7 +37,7 @@ search:
 └─────────┘
 ```
 
-## Dyadic Left Shoe means
+Dyadic Left Shoe means
 
 
 If `⎕ML<3`[ Partitioned Enclose](../primitive-functions/partitioned-enclose.md)

--- a/language-reference-guide/docs/symbols/left-tack.md
+++ b/language-reference-guide/docs/symbols/left-tack.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Left Tack</span> <span class="command">⊣</span></h1>
 
 
-## Monadic Left Tack means
+Monadic Left Tack means
 
 
 [Same](../primitive-functions/same.md)
@@ -20,7 +20,7 @@ search:
 1 2 3
 ```
 
-## Dyadic Left Tack means
+Dyadic Left Tack means
 
 
 [Left](../primitive-functions/left.md)

--- a/language-reference-guide/docs/symbols/left-tack.md
+++ b/language-reference-guide/docs/symbols/left-tack.md
@@ -2,38 +2,23 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Left Tack</span> <span class="command">⊣</span></h1>
 
-
 Monadic Left Tack means
-
-
 [Same](../primitive-functions/same.md)
 ```apl
-
       ⊣  1 2 3
 1 2 3
 ```
 
 Dyadic Left Tack means
-
-
 [Left](../primitive-functions/left.md)
 ```apl
-
       'L' ⊣ 'R'
 L
       ⊣/ 1 2 3
 1
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/less-than-or-equal-to-sign.md
+++ b/language-reference-guide/docs/symbols/less-than-or-equal-to-sign.md
@@ -2,11 +2,11 @@
 search:
   exclude: true
 ---
-<h1 class="heading"><span class="name">Less Than Or Equal To Sign</span> <span class="command">≤</span></h1>
+<h1 class="heading"><span class="name">Less Than Or Equal To</span> <span class="command">≤</span></h1>
 
-Monadic Less Than Or Equal To Sign is not defined
+Monadic Less Than Or Equal To is not defined
 
-Dyadic Less Than or Equal To Sign means
+Dyadic Less Than or Equal To means
 [Is Less Or Equal To](../primitive-functions/less-or-equal.md)
 ```apl
       1 2 3 ≤ 4 2 ¯1

--- a/language-reference-guide/docs/symbols/less-than-or-equal-to-sign.md
+++ b/language-reference-guide/docs/symbols/less-than-or-equal-to-sign.md
@@ -2,31 +2,18 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Less Than Or Equal To Sign</span> <span class="command">≤</span></h1>
-
-
 
 Monadic Less Than Or Equal To Sign is not defined
 
 Dyadic Less Than or Equal To Sign means
-
-
 [Is Less Or Equal To](../primitive-functions/less-or-equal.md)
 ```apl
-
       1 2 3 ≤ 4 2 ¯1
 1 1 0
       1 2 3 ≤ 2
 1 1 0
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/less-than-or-equal-to-sign.md
+++ b/language-reference-guide/docs/symbols/less-than-or-equal-to-sign.md
@@ -13,7 +13,7 @@ search:
 
 Monadic Less Than Or Equal To Sign is not defined
 
-## Dyadic Less Than or Equal To Sign means
+Dyadic Less Than or Equal To Sign means
 
 
 [Is Less Or Equal To](../primitive-functions/less-or-equal.md)

--- a/language-reference-guide/docs/symbols/less-than-sign.md
+++ b/language-reference-guide/docs/symbols/less-than-sign.md
@@ -2,31 +2,18 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Less Than Sign</span> <span class="command"><</span></h1>
-
-
 
 Monadic Less Than Sign is not defined
 
 Dyadic Less Than Sign means
-
-
 [Less Than](../primitive-functions/less.md)
 ```apl
-
       1 2 3 < 4 2 ¯1
 1 0 0
       1 2 3 < 2
 1 0 0
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/less-than-sign.md
+++ b/language-reference-guide/docs/symbols/less-than-sign.md
@@ -2,11 +2,11 @@
 search:
   exclude: true
 ---
-<h1 class="heading"><span class="name">Less Than Sign</span> <span class="command"><</span></h1>
+<h1 class="heading"><span class="name">Less Than</span> <span class="command"><</span></h1>
 
-Monadic Less Than Sign is not defined
+Monadic Less Than is not defined
 
-Dyadic Less Than Sign means
+Dyadic Less Than means
 [Less Than](../primitive-functions/less.md)
 ```apl
       1 2 3 < 4 2 ¯1

--- a/language-reference-guide/docs/symbols/less-than-sign.md
+++ b/language-reference-guide/docs/symbols/less-than-sign.md
@@ -13,7 +13,7 @@ search:
 
 Monadic Less Than Sign is not defined
 
-## Dyadic Less Than Sign means
+Dyadic Less Than Sign means
 
 
 [Less Than](../primitive-functions/less.md)

--- a/language-reference-guide/docs/symbols/log.md
+++ b/language-reference-guide/docs/symbols/log.md
@@ -2,36 +2,21 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Log;Circle Star</span> <span class="command">⍟</span></h1>
 
-
 Monadic Log means
-
-
 [Natural Logarithm](../primitive-functions/natural-logarithm.md)
 ```apl
-
       ⍟ 1 2 3 2.7182818285
 0 0.693147 1.09861 1
 ```
 
 Dyadic Log means
-
-
 [Logarithm](../primitive-functions/logarithm.md)
 ```apl
-
       2 10 ⍟ 32 1000
 5 3
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/log.md
+++ b/language-reference-guide/docs/symbols/log.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Log;Circle Star</span> <span class="command">⍟</span></h1>
 
 
-## Monadic Log means
+Monadic Log means
 
 
 [Natural Logarithm](../primitive-functions/natural-logarithm.md)
@@ -20,7 +20,7 @@ search:
 0 0.693147 1.09861 1
 ```
 
-## Dyadic Log means
+Dyadic Log means
 
 
 [Logarithm](../primitive-functions/logarithm.md)

--- a/language-reference-guide/docs/symbols/log.md
+++ b/language-reference-guide/docs/symbols/log.md
@@ -2,7 +2,7 @@
 search:
   exclude: true
 ---
-<h1 class="heading"><span class="name">Log;Circle Star</span> <span class="command">⍟</span></h1>
+<h1 class="heading"><span class="name">Log</span> <span class="command">⍟</span></h1>
 
 Monadic Log means
 [Natural Logarithm](../primitive-functions/natural-logarithm.md)

--- a/language-reference-guide/docs/symbols/logical-and.md
+++ b/language-reference-guide/docs/symbols/logical-and.md
@@ -2,20 +2,11 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Logical AND</span> <span class="command">∧</span></h1>
-
-
 
 Monadic Logical AND is not defined.
 
 Dyadic Logical AND means
-
-
 [Lowest Common Multiple (AND)](../primitive-functions/and-lowest-common-multiple.md)
 ```apl
       0 1 0 1 ∧ 0 0 1 1
@@ -25,8 +16,6 @@ Dyadic Logical AND means
 105 1 4 0
 
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/logical-and.md
+++ b/language-reference-guide/docs/symbols/logical-and.md
@@ -13,7 +13,7 @@ search:
 
 Monadic Logical AND is not defined.
 
-## Dyadic Logical AND means
+Dyadic Logical AND means
 
 
 [Lowest Common Multiple (AND)](../primitive-functions/and-lowest-common-multiple.md)

--- a/language-reference-guide/docs/symbols/logical-or.md
+++ b/language-reference-guide/docs/symbols/logical-or.md
@@ -13,7 +13,7 @@ search:
 
 Monadic Logical Or is not defined.
 
-## Dyadic Logical Or means
+Dyadic Logical Or means
 
 
 [Greatest Common Divisor (Or)](../primitive-functions/or-greatest-common-divisor.md)

--- a/language-reference-guide/docs/symbols/logical-or.md
+++ b/language-reference-guide/docs/symbols/logical-or.md
@@ -2,20 +2,11 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Logical Or</span> <span class="command">∨</span></h1>
-
-
 
 Monadic Logical Or is not defined.
 
 Dyadic Logical Or means
-
-
 [Greatest Common Divisor (Or)](../primitive-functions/or-greatest-common-divisor.md)
 ```apl
 
@@ -24,10 +15,7 @@ Dyadic Logical Or means
 
       15 1 2 7 ∨ 35 1 4 0
 5 1 2 7
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/logical-or.md
+++ b/language-reference-guide/docs/symbols/logical-or.md
@@ -2,11 +2,11 @@
 search:
   exclude: true
 ---
-<h1 class="heading"><span class="name">Logical Or</span> <span class="command">∨</span></h1>
+<h1 class="heading"><span class="name">Logical OR</span> <span class="command">∨</span></h1>
 
-Monadic Logical Or is not defined.
+Monadic Logical OR is not defined.
 
-Dyadic Logical Or means
+Dyadic Logical OR means
 [Greatest Common Divisor (Or)](../primitive-functions/or-greatest-common-divisor.md)
 ```apl
 

--- a/language-reference-guide/docs/symbols/minus-sign.md
+++ b/language-reference-guide/docs/symbols/minus-sign.md
@@ -2,41 +2,24 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Minus Sign;Bar</span> <span class="command">-</span></h1>
 
-
 Monadic Minus Sign means
-
-
 [Negate](../primitive-functions/negative.md)
 ```apl
-
-
       - 3.2 ¯7 0
 ¯3.2 7 0
 ```
 
 Dyadic Minus Sign means
-
-
 [Minus;Subtract](../primitive-functions/subtract.md)
 ```apl
-
-
       3 7 9 - 5
 ¯2 2 4
 
       5 1 4 - 2 3 4
 3 ¯2 0
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/minus-sign.md
+++ b/language-reference-guide/docs/symbols/minus-sign.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Minus Sign;Bar</span> <span class="command">-</span></h1>
 
 
-## Monadic Minus Sign means
+Monadic Minus Sign means
 
 
 [Negate
@@ -22,7 +22,7 @@ search:
 ¯3.2 7 0
 ```
 
-## Dyadic Minus Sign means
+Dyadic Minus Sign means
 
 
 [Minus;Subtract](../primitive-functions/subtract.md)

--- a/language-reference-guide/docs/symbols/minus-sign.md
+++ b/language-reference-guide/docs/symbols/minus-sign.md
@@ -13,8 +13,7 @@ search:
 Monadic Minus Sign means
 
 
-[Negate
-      ](../primitive-functions/negative.md)
+[Negate](../primitive-functions/negative.md)
 ```apl
 
 

--- a/language-reference-guide/docs/symbols/minus-sign.md
+++ b/language-reference-guide/docs/symbols/minus-sign.md
@@ -2,16 +2,16 @@
 search:
   exclude: true
 ---
-<h1 class="heading"><span class="name">Minus Sign;Bar</span> <span class="command">-</span></h1>
+<h1 class="heading"><span class="name">Minus</span> <span class="command">-</span></h1>
 
-Monadic Minus Sign means
+Monadic Minus means
 [Negate](../primitive-functions/negative.md)
 ```apl
       - 3.2 ¯7 0
 ¯3.2 7 0
 ```
 
-Dyadic Minus Sign means
+Dyadic Minus means
 [Minus;Subtract](../primitive-functions/subtract.md)
 ```apl
       3 7 9 - 5

--- a/language-reference-guide/docs/symbols/nand-symbol.md
+++ b/language-reference-guide/docs/symbols/nand-symbol.md
@@ -16,8 +16,7 @@ Monadic Logical NAND is not defined
 Dyadic Logical NAND means
 
 
-[NAND
-      ](../primitive-functions/nand.md)
+[NAND](../primitive-functions/nand.md)
 ```apl
       0 1 0 1 ⍲ 0 0 1 1
 1 1 1 0

--- a/language-reference-guide/docs/symbols/nand-symbol.md
+++ b/language-reference-guide/docs/symbols/nand-symbol.md
@@ -2,28 +2,16 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Logical NAND</span> <span class="command">⍲</span></h1>
-
-
 
 Monadic Logical NAND is not defined
 
 Dyadic Logical NAND means
-
-
 [NAND](../primitive-functions/nand.md)
 ```apl
       0 1 0 1 ⍲ 0 0 1 1
 1 1 1 0
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/nand-symbol.md
+++ b/language-reference-guide/docs/symbols/nand-symbol.md
@@ -13,7 +13,7 @@ search:
 
 Monadic Logical NAND is not defined
 
-## Dyadic Logical NAND means
+Dyadic Logical NAND means
 
 
 [NAND

--- a/language-reference-guide/docs/symbols/nor-symbol.md
+++ b/language-reference-guide/docs/symbols/nor-symbol.md
@@ -13,7 +13,7 @@ search:
 
 Monadic Logical NOR is not defined
 
-## Dyadic Logical NOR means
+Dyadic Logical NOR means
 
 
 [NOR](../primitive-functions/nor.md)

--- a/language-reference-guide/docs/symbols/nor-symbol.md
+++ b/language-reference-guide/docs/symbols/nor-symbol.md
@@ -2,29 +2,16 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Logical NOR</span> <span class="command">⍱</span></h1>
-
-
 
 Monadic Logical NOR is not defined
 
 Dyadic Logical NOR means
-
-
 [NOR](../primitive-functions/nor.md)
 ```apl
-
       0 1 0 1 ⍱ 0 0 1 1
 1 0 0 0
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/not-equal-to.md
+++ b/language-reference-guide/docs/symbols/not-equal-to.md
@@ -2,20 +2,11 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Not Equal</span> <span class="command">≠</span></h1>
 
-
 Monadic Not Equal means
-
-
 [Unique Mask](../primitive-functions/unique-mask.md)
 ```apl
-
       ≠ 'Banana'
 1 1 1 0 0 0
 
@@ -24,11 +15,8 @@ Monadic Not Equal means
 ```
 
 Dyadic Not Equal means
-
-
 [Not Equal To](../primitive-functions/not-equal.md)
 ```apl
-
       1 2 3 ≠ 4 2 ¯1
 1 0 1
 
@@ -40,10 +28,7 @@ Dyadic Not Equal means
 
       7 ≠ '7'
 1
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/not-equal-to.md
+++ b/language-reference-guide/docs/symbols/not-equal-to.md
@@ -26,8 +26,7 @@ Monadic Not Equal means
 Dyadic Not Equal means
 
 
-[Not Equal To
-      ](../primitive-functions/not-equal.md)
+[Not Equal To](../primitive-functions/not-equal.md)
 ```apl
 
       1 2 3 ≠ 4 2 ¯1

--- a/language-reference-guide/docs/symbols/not-equal-to.md
+++ b/language-reference-guide/docs/symbols/not-equal-to.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Not Equal</span> <span class="command">≠</span></h1>
 
 
-## Monadic Not Equal means
+Monadic Not Equal means
 
 
 [Unique Mask](../primitive-functions/unique-mask.md)
@@ -23,7 +23,7 @@ search:
 1 1 1 0 0 0 0 0 1 0 0
 ```
 
-## Dyadic Not Equal means
+Dyadic Not Equal means
 
 
 [Not Equal To

--- a/language-reference-guide/docs/symbols/plus-sign.md
+++ b/language-reference-guide/docs/symbols/plus-sign.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Plus Sign</span> <span class="command">+</span></h1>
 
 
-## Monadic Plus Sign means
+Monadic Plus Sign means
 
 
 [Conjugate
@@ -22,7 +22,7 @@ search:
 
 ```
 
-## Dyadic Plus Sign means
+Dyadic Plus Sign means
 
 
 [Plus](../primitive-functions/add.md)

--- a/language-reference-guide/docs/symbols/plus-sign.md
+++ b/language-reference-guide/docs/symbols/plus-sign.md
@@ -2,32 +2,18 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Plus Sign</span> <span class="command">+</span></h1>
 
-
 Monadic Plus Sign means
-
-
 [Conjugate](../primitive-functions/conjugate.md)
 ```apl
-
       + 1.2 0j4 ¯5j¯6
 1.2 0J¯4 ¯5J6
-
 ```
 
 Dyadic Plus Sign means
-
-
 [Plus](../primitive-functions/add.md)
 ```apl
-
-
       1 2 3 4 + 10
 11 12 13 14
 
@@ -36,10 +22,7 @@ Dyadic Plus Sign means
 
       +/ 1 2 3
 6
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/plus-sign.md
+++ b/language-reference-guide/docs/symbols/plus-sign.md
@@ -2,16 +2,16 @@
 search:
   exclude: true
 ---
-<h1 class="heading"><span class="name">Plus Sign</span> <span class="command">+</span></h1>
+<h1 class="heading"><span class="name">Plus</span> <span class="command">+</span></h1>
 
-Monadic Plus Sign means
+Monadic Plus means
 [Conjugate](../primitive-functions/conjugate.md)
 ```apl
       + 1.2 0j4 ¯5j¯6
 1.2 0J¯4 ¯5J6
 ```
 
-Dyadic Plus Sign means
+Dyadic Plus means
 [Plus](../primitive-functions/add.md)
 ```apl
       1 2 3 4 + 10

--- a/language-reference-guide/docs/symbols/plus-sign.md
+++ b/language-reference-guide/docs/symbols/plus-sign.md
@@ -13,8 +13,7 @@ search:
 Monadic Plus Sign means
 
 
-[Conjugate
-      ](../primitive-functions/conjugate.md)
+[Conjugate](../primitive-functions/conjugate.md)
 ```apl
 
       + 1.2 0j4 ¯5j¯6

--- a/language-reference-guide/docs/symbols/quad-diamond.md
+++ b/language-reference-guide/docs/symbols/quad-diamond.md
@@ -2,19 +2,12 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Quad Diamond</span> <span class="command">⌺</span></h1>
 
 
 Quad Diamond is a Dyadic operator
 
 Operator Quad Diamond means
-
-
 [Stencil](../primitive-operators/stencil.md)
 ```apl
 Dyadic operator:  Stencil
@@ -49,10 +42,7 @@ Dyadic operator:  Stencil
 33 54 63 45
 57 90 99 69
 46 72 78 54
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/quad-diamond.md
+++ b/language-reference-guide/docs/symbols/quad-diamond.md
@@ -10,7 +10,6 @@ Quad Diamond is a Dyadic operator
 Operator Quad Diamond means
 [Stencil](../primitive-operators/stencil.md)
 ```apl
-Dyadic operator:  Stencil
 
       mat
  1  2  3  4

--- a/language-reference-guide/docs/symbols/quad-diamond.md
+++ b/language-reference-guide/docs/symbols/quad-diamond.md
@@ -10,9 +10,9 @@ search:
 <h1 class="heading"><span class="name">Quad Diamond</span> <span class="command">⌺</span></h1>
 
 
-## Quad Diamond is a Dyadic operator
+Quad Diamond is a Dyadic operator
 
-## Operator Quad Diamond means
+Operator Quad Diamond means
 
 
 [Stencil](../primitive-operators/stencil.md)

--- a/language-reference-guide/docs/symbols/quad-equal.md
+++ b/language-reference-guide/docs/symbols/quad-equal.md
@@ -10,10 +10,10 @@ search:
 <h1 class="heading"><span class="name">Quad Equal</span> <span class="command">⌸</span></h1>
 
 
-## Quad Equal is a Monadic operator with an ambivalent
+Quad Equal is a Monadic operator with an ambivalent
       operand
 
-## Operator Quad Equal means
+Operator Quad Equal means
 
 
 [Key](../primitive-operators/key.md)

--- a/language-reference-guide/docs/symbols/quad-equal.md
+++ b/language-reference-guide/docs/symbols/quad-equal.md
@@ -2,22 +2,14 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Quad Equal</span> <span class="command">⌸</span></h1>
 
 
 Quad Equal is a Monadic operator with an ambivalent operand
 
 Operator Quad Equal means
-
-
 [Key](../primitive-operators/key.md)
 ```apl
-
       'Banana' {⍺ ⍵}⌸ 3 1 4 1 5 9
 ┌─┬─────┐
 │B│3    │
@@ -46,10 +38,7 @@ n  9
 ├─┼─────┤
 │n│3 5  │
 └─┴─────┘
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/quad-equal.md
+++ b/language-reference-guide/docs/symbols/quad-equal.md
@@ -10,8 +10,7 @@ search:
 <h1 class="heading"><span class="name">Quad Equal</span> <span class="command">⌸</span></h1>
 
 
-Quad Equal is a Monadic operator with an ambivalent
-      operand
+Quad Equal is a Monadic operator with an ambivalent operand
 
 Operator Quad Equal means
 

--- a/language-reference-guide/docs/symbols/quad-equal.md
+++ b/language-reference-guide/docs/symbols/quad-equal.md
@@ -5,7 +5,7 @@ search:
 <h1 class="heading"><span class="name">Quad Equal</span> <span class="command">⌸</span></h1>
 
 
-Quad Equal is a Monadic operator with an ambivalent operand
+Quad Equal is a monadic operator with an ambivalent operand
 
 Operator Quad Equal means
 [Key](../primitive-operators/key.md)

--- a/language-reference-guide/docs/symbols/question-mark.md
+++ b/language-reference-guide/docs/symbols/question-mark.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Question Mark;Query</span> <span class="command">?</span></h1>
 
 
-## Monadic Question Mark means
+Monadic Question Mark means
 
 
 [Roll](../primitive-functions/roll.md)
@@ -23,7 +23,7 @@ search:
 0.260561 0.929928
 ```
 
-## Dyadic Question Mark means
+Dyadic Question Mark means
 
 
 [Deal](../primitive-functions/deal.md)

--- a/language-reference-guide/docs/symbols/question-mark.md
+++ b/language-reference-guide/docs/symbols/question-mark.md
@@ -2,20 +2,11 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Question Mark;Query</span> <span class="command">?</span></h1>
 
-
 Monadic Question Mark means
-
-
 [Roll](../primitive-functions/roll.md)
 ```apl
-
       ? 6 6 6 6 6
 4 3 6 3 5
 
@@ -24,17 +15,11 @@ Monadic Question Mark means
 ```
 
 Dyadic Question Mark means
-
-
 [Deal](../primitive-functions/deal.md)
 ```apl
-
       13 ? 52
 36 31 44 11 27 42 13 8 2 33 19 34 6
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/question-mark.md
+++ b/language-reference-guide/docs/symbols/question-mark.md
@@ -2,7 +2,7 @@
 search:
   exclude: true
 ---
-<h1 class="heading"><span class="name">Question Mark;Query</span> <span class="command">?</span></h1>
+<h1 class="heading"><span class="name">Question Mark</span> <span class="command">?</span></h1>
 
 Monadic Question Mark means
 [Roll](../primitive-functions/roll.md)

--- a/language-reference-guide/docs/symbols/rho.md
+++ b/language-reference-guide/docs/symbols/rho.md
@@ -5,7 +5,7 @@ search:
 <h1 class="heading"><span class="name">Rho</span> <span class="command">⍴</span></h1>
 
 Monadic Rho means
-[Shape Of](../primitive-functions/shape.md)
+[Shape](../primitive-functions/shape.md)
 ```apl
       mat
 1  2  3  4

--- a/language-reference-guide/docs/symbols/rho.md
+++ b/language-reference-guide/docs/symbols/rho.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Rho</span> <span class="command">⍴</span></h1>
 
 
-## Monadic Rho means
+Monadic Rho means
 
 
 [Shape Of
@@ -34,7 +34,7 @@ search:
 0
 ```
 
-## Dyadic Rho means
+Dyadic Rho means
 
 
 [Reshape

--- a/language-reference-guide/docs/symbols/rho.md
+++ b/language-reference-guide/docs/symbols/rho.md
@@ -13,8 +13,7 @@ search:
 Monadic Rho means
 
 
-[Shape Of
-      ](../primitive-functions/shape.md)
+[Shape Of](../primitive-functions/shape.md)
 ```apl
 
       mat
@@ -37,8 +36,7 @@ Monadic Rho means
 Dyadic Rho means
 
 
-[Reshape
-      ](../primitive-functions/reshape.md)
+[Reshape](../primitive-functions/reshape.md)
 ```apl
       2 3 4 ⍴ 1 2 3 4 5 6 7
 1 2 3 4

--- a/language-reference-guide/docs/symbols/rho.md
+++ b/language-reference-guide/docs/symbols/rho.md
@@ -2,20 +2,11 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Rho</span> <span class="command">⍴</span></h1>
 
-
 Monadic Rho means
-
-
 [Shape Of](../primitive-functions/shape.md)
 ```apl
-
       mat
 1  2  3  4
 5  6  7  8
@@ -34,8 +25,6 @@ Monadic Rho means
 ```
 
 Dyadic Rho means
-
-
 [Reshape](../primitive-functions/reshape.md)
 ```apl
       2 3 4 ⍴ 1 2 3 4 5 6 7
@@ -46,10 +35,7 @@ Dyadic Rho means
 6 7 1 2
 3 4 5 6
 7 1 2 3
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/right-arrow.md
+++ b/language-reference-guide/docs/symbols/right-arrow.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Right Arrow</span> <span class="command">→</span></h1>
 
 
-## Monadic Right Arrow means
+Monadic Right Arrow means
 
 
 [Branch](../primitive-functions/branch.md)

--- a/language-reference-guide/docs/symbols/right-arrow.md
+++ b/language-reference-guide/docs/symbols/right-arrow.md
@@ -2,17 +2,9 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Right Arrow</span> <span class="command">→</span></h1>
 
-
 Monadic Right Arrow means
-
-
 [Branch](../primitive-functions/branch.md)
 ```apl
 Syntax:  Branch (Clear suspension)
@@ -24,10 +16,7 @@ Syntax:  Branch (Clear suspension)
 
 Branching is superseded by the more modern
 control structures such as :If ... :EndIf
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/right-shoe.md
+++ b/language-reference-guide/docs/symbols/right-shoe.md
@@ -34,8 +34,7 @@ If `⎕ML≥2`[Mix](../primitive-functions/mix.md)
 Dyadic Right Shoe means
 
 
-[Pick
-      ](../primitive-functions/pick.md)
+[Pick](../primitive-functions/pick.md)
 ```apl
 
       3 ⊃ 'Word'

--- a/language-reference-guide/docs/symbols/right-shoe.md
+++ b/language-reference-guide/docs/symbols/right-shoe.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Right Shoe</span> <span class="command">⊃</span></h1>
 
 
-## Monadic Right Shoe means
+Monadic Right Shoe means
 
 
 If `⎕ML<2`[Disclose;First](../primitive-functions/disclose.md)
@@ -31,7 +31,7 @@ If `⎕ML≥2`[Mix](../primitive-functions/mix.md)
 
 ```
 
-## Dyadic Right Shoe means
+Dyadic Right Shoe means
 
 
 [Pick

--- a/language-reference-guide/docs/symbols/right-shoe.md
+++ b/language-reference-guide/docs/symbols/right-shoe.md
@@ -2,41 +2,28 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Right Shoe</span> <span class="command">⊃</span></h1>
-
 
 Monadic Right Shoe means
 
-
 If `⎕ML<2`[Disclose;First](../primitive-functions/disclose.md)
 ```apl
-
       ⊃ 'Word'
 W
       ⊃ (1 2)(3 4 5)
 1 2
 ```
 
-
 If `⎕ML≥2`[Mix](../primitive-functions/mix.md)
 ```apl
       ⊃ (2 2)(3 3 3)
 2 2 0
 3 3 3
-
 ```
 
 Dyadic Right Shoe means
-
-
 [Pick](../primitive-functions/pick.md)
 ```apl
-
       3 ⊃ 'Word'
 r
       2 ⊃ (1 2)(3 4 5)
@@ -44,10 +31,7 @@ r
 
       2 1 ⊃ (1 2)(3 4 5)
 3
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/right-tack.md
+++ b/language-reference-guide/docs/symbols/right-tack.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Right Tack</span> <span class="command">⊢</span></h1>
 
 
-## Monadic Right Tack means
+Monadic Right Tack means
 
 
 [Same](../primitive-functions/same.md)
@@ -20,7 +20,7 @@ search:
 1 2 3
 ```
 
-## Dyadic Right Tack means
+Dyadic Right Tack means
 
 
 [Right](../primitive-functions/right.md)

--- a/language-reference-guide/docs/symbols/right-tack.md
+++ b/language-reference-guide/docs/symbols/right-tack.md
@@ -2,38 +2,23 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Right Tack</span> <span class="command">⊢</span></h1>
 
-
 Monadic Right Tack means
-
-
 [Same](../primitive-functions/same.md)
 ```apl
-
       ⊢  1 2 3
 1 2 3
 ```
 
 Dyadic Right Tack means
-
-
 [Right](../primitive-functions/right.md)
 ```apl
-
       'L' ⊢ 'R'
 R
       ⊢/ 1 2 3
 3
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/set-intersection.md
+++ b/language-reference-guide/docs/symbols/set-intersection.md
@@ -4,9 +4,9 @@ search:
 ---
 <h1 class="heading"><span class="name">Up Shoe</span> <span class="command">∩</span></h1>
 
-Monadic Set Intersection is not defined
+Monadic Up Shoe is not defined
 
-Dyadic Set Intersection means
+Dyadic Up Shoe means
 [Intersection](../primitive-functions/intersection.md)
 ```apl
       22 'ab' 'fg' ∩ 'a' 'ab' 22

--- a/language-reference-guide/docs/symbols/set-intersection.md
+++ b/language-reference-guide/docs/symbols/set-intersection.md
@@ -13,7 +13,7 @@ search:
 
 Monadic Set Intersection is not defined
 
-## Dyadic Set Intersection means
+Dyadic Set Intersection means
 
 
 [Intersection](../primitive-functions/intersection.md)

--- a/language-reference-guide/docs/symbols/set-intersection.md
+++ b/language-reference-guide/docs/symbols/set-intersection.md
@@ -2,31 +2,18 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Up Shoe</span> <span class="command">∩</span></h1>
-
-
 
 Monadic Set Intersection is not defined
 
 Dyadic Set Intersection means
-
-
 [Intersection](../primitive-functions/intersection.md)
 ```apl
-
       22 'ab' 'fg' ∩ 'a' 'ab' 22
 ┌──┬──┐
 │22│ab│
 └──┴──┘
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/set-union.md
+++ b/language-reference-guide/docs/symbols/set-union.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Down Shoe</span> <span class="command">∪</span></h1>
 
 
-## Monadic Set Union means
+Monadic Set Union means
 
 
 [Unique](../primitive-functions/unique.md)
@@ -31,7 +31,7 @@ flywheel
 shyster 
 ```
 
-## Dyadic Set Union means
+Dyadic Set Union means
 
 
 [Union](../primitive-functions/union.md)

--- a/language-reference-guide/docs/symbols/set-union.md
+++ b/language-reference-guide/docs/symbols/set-union.md
@@ -4,7 +4,7 @@ search:
 ---
 <h1 class="heading"><span class="name">Down Shoe</span> <span class="command">∪</span></h1>
 
-Monadic Set Union means
+Monadic Down Shoe means
 [Unique](../primitive-functions/unique.md)
 ```apl
       ∪ 'ab' 'ba' 'ab' 1 1 2
@@ -22,7 +22,7 @@ flywheel
 shyster 
 ```
 
-Dyadic Set Union means
+Dyadic Down Shoe means
 [Union](../primitive-functions/union.md)
 ```apl
       'ab' 'cde' 'fg' ∪ 'a' 'ab'

--- a/language-reference-guide/docs/symbols/set-union.md
+++ b/language-reference-guide/docs/symbols/set-union.md
@@ -2,20 +2,11 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Down Shoe</span> <span class="command">∪</span></h1>
 
-
 Monadic Set Union means
-
-
 [Unique](../primitive-functions/unique.md)
 ```apl
-
       ∪ 'ab' 'ba' 'ab' 1 1 2
 ┌──┬──┬─┬─┐
 │ab│ba│1│2│
@@ -32,18 +23,13 @@ shyster
 ```
 
 Dyadic Set Union means
-
-
 [Union](../primitive-functions/union.md)
 ```apl
       'ab' 'cde' 'fg' ∪ 'a' 'ab'
 ┌──┬───┬──┬─┐
 │ab│cde│fg│a│
 └──┴───┴──┴─┘
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/shared-variable-offer-symbol.md
+++ b/language-reference-guide/docs/symbols/shared-variable-offer-symbol.md
@@ -2,31 +2,20 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Shared Variable Offer</span> <span class="command">⎕SVO</span></h1>
 
 
 Dyadic ⎕SVO means
-
-
 [Shared Variable Offer](../system-functions/svo.md)
 ```apl
 DATA←⍳9 'DDE:' ⎕SVO 'DATA' 1
 ```
 
 Monadic ⎕SVO means
-
-
 [Query Degree of Coupling](../system-functions/svo.md)
 ```apl
 ⎕SVO 'DATA' 1
 ```
-
-
 [Language Elements](../system-functions/svo.md)
 
 

--- a/language-reference-guide/docs/symbols/shared-variable-offer-symbol.md
+++ b/language-reference-guide/docs/symbols/shared-variable-offer-symbol.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Shared Variable Offer</span> <span class="command">⎕SVO</span></h1>
 
 
-## Dyadic ⎕SVO means
+Dyadic ⎕SVO means
 
 
 [Shared
@@ -20,7 +20,7 @@ search:
 DATA←⍳9 'DDE:' ⎕SVO 'DATA' 1
 ```
 
-## Monadic ⎕SVO means
+Monadic ⎕SVO means
 
 
 [Query

--- a/language-reference-guide/docs/symbols/shared-variable-offer-symbol.md
+++ b/language-reference-guide/docs/symbols/shared-variable-offer-symbol.md
@@ -13,9 +13,7 @@ search:
 Dyadic ⎕SVO means
 
 
-[Shared
-        Variable Offer
-      ](../system-functions/svo.md)
+[Shared Variable Offer](../system-functions/svo.md)
 ```apl
 DATA←⍳9 'DDE:' ⎕SVO 'DATA' 1
 ```
@@ -23,16 +21,12 @@ DATA←⍳9 'DDE:' ⎕SVO 'DATA' 1
 Monadic ⎕SVO means
 
 
-[Query
-        Degree of Coupling
-      ](../system-functions/svo.md)
+[Query Degree of Coupling](../system-functions/svo.md)
 ```apl
 ⎕SVO 'DATA' 1
 ```
 
 
-[Language
-        Elements
-      ](../system-functions/svo.md)
+[Language Elements](../system-functions/svo.md)
 
 

--- a/language-reference-guide/docs/symbols/slash-bar.md
+++ b/language-reference-guide/docs/symbols/slash-bar.md
@@ -2,25 +2,15 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Slash Bar</span> <span class="command">⌿</span></h1>
 
-
 Used as a Function
-
 
 Monadic Slash Bar is not defined
 
 ### Dyadic Slash Bar means
-
-
 [Replicate First (Compress First)](../primitive-functions/replicate.md)
 ```apl
-
       mat
 1  2  3  4
 5  6  7  8
@@ -34,25 +24,18 @@ Monadic Slash Bar is not defined
 
 Used as an Operator
 
-
 Slash Bar is a Monadic operator with a Dyadic operand
 
 #### Operator Slash Bar means
-
-
 [Reduce First,  Reduce First N-Wise ](../primitive-operators/reduce-first.md)
 ```apl
-
       +⌿ mat
 15 18 21 24
 
       2 +⌿ mat     ⍝ pair-wise
  6  8 10 12
 14 16 18 20
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/slash-bar.md
+++ b/language-reference-guide/docs/symbols/slash-bar.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Slash Bar</span> <span class="command">⌿</span></h1>
 
 
-## Used as a Function
+Used as a Function
 
 
 Monadic Slash Bar is not defined
@@ -32,7 +32,7 @@ Monadic Slash Bar is not defined
 9 10 11 12
 ```
 
-## Used as an Operator
+Used as an Operator
 
 
 Slash Bar is a Monadic operator with a Dyadic operand

--- a/language-reference-guide/docs/symbols/slash-bar.md
+++ b/language-reference-guide/docs/symbols/slash-bar.md
@@ -24,7 +24,7 @@ Dyadic Slash Bar means
 
 # Used as an Operator
 
-Slash Bar is a Monadic operator with a Dyadic operand
+Slash Bar is a monadic operator with a dyadic operand
 
 Operator Slash Bar means
 [Reduce First,  Reduce First N-Wise ](../primitive-operators/reduce-first.md)

--- a/language-reference-guide/docs/symbols/slash-bar.md
+++ b/language-reference-guide/docs/symbols/slash-bar.md
@@ -4,11 +4,11 @@ search:
 ---
 <h1 class="heading"><span class="name">Slash Bar</span> <span class="command">⌿</span></h1>
 
-Used as a Function
+# Used as a Function
 
 Monadic Slash Bar is not defined
 
-### Dyadic Slash Bar means
+Dyadic Slash Bar means
 [Replicate First (Compress First)](../primitive-functions/replicate.md)
 ```apl
       mat
@@ -22,11 +22,11 @@ Monadic Slash Bar is not defined
 9 10 11 12
 ```
 
-Used as an Operator
+# Used as an Operator
 
 Slash Bar is a Monadic operator with a Dyadic operand
 
-#### Operator Slash Bar means
+Operator Slash Bar means
 [Reduce First,  Reduce First N-Wise ](../primitive-operators/reduce-first.md)
 ```apl
       +⌿ mat

--- a/language-reference-guide/docs/symbols/slash.md
+++ b/language-reference-guide/docs/symbols/slash.md
@@ -20,7 +20,7 @@ Hat
 
 # Used as an Operator
 
-Slash is a Monadic operator with a Dyadic operand
+Slash is a monadic operator with a dyadic operand
 
 Operator Slash means
 [Reduce](../primitive-operators/reduce.md), [N-Wise Reduce](../primitive-operators/reduce-n-wise.md)

--- a/language-reference-guide/docs/symbols/slash.md
+++ b/language-reference-guide/docs/symbols/slash.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Slash</span> <span class="command">/</span></h1>
 
 
-## Used as a Function
+Used as a Function
 
 
 Monadic Slash is not defined
@@ -28,7 +28,7 @@ Monadic Slash is not defined
 Hat
 ```
 
-## Used as an Operator
+Used as an Operator
 
 
 Slash is a Monadic operator with a Dyadic operand

--- a/language-reference-guide/docs/symbols/slash.md
+++ b/language-reference-guide/docs/symbols/slash.md
@@ -2,25 +2,15 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Slash</span> <span class="command">/</span></h1>
 
-
 Used as a Function
-
 
 Monadic Slash is not defined
 
 ### Dyadic Slash means
-
-
 [Replicate](../primitive-functions/replicate.md)
 ```apl
-
       3 1 ¯2 2 / 6 7 8 9
 6 6 6 7 0 0 9 9
 
@@ -30,15 +20,11 @@ Hat
 
 Used as an Operator
 
-
 Slash is a Monadic operator with a Dyadic operand
 
 #### Operator Slash means
-
-
 [Reduce](../primitive-operators/reduce.md), [N-Wise Reduce](../primitive-operators/reduce-n-wise.md)
 ```apl
-
       +/ 1 2 3 4 5
 15
       2 +/ 1 2 3 4 5   ⍝ pair-wise sum
@@ -67,8 +53,6 @@ Slash is a Monadic operator with a Dyadic operand
 51 54 57 60
 
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/slash.md
+++ b/language-reference-guide/docs/symbols/slash.md
@@ -4,11 +4,11 @@ search:
 ---
 <h1 class="heading"><span class="name">Slash</span> <span class="command">/</span></h1>
 
-Used as a Function
+# Used as a Function
 
 Monadic Slash is not defined
 
-### Dyadic Slash means
+Dyadic Slash means
 [Replicate](../primitive-functions/replicate.md)
 ```apl
       3 1 ¯2 2 / 6 7 8 9
@@ -18,11 +18,11 @@ Monadic Slash is not defined
 Hat
 ```
 
-Used as an Operator
+# Used as an Operator
 
 Slash is a Monadic operator with a Dyadic operand
 
-#### Operator Slash means
+Operator Slash means
 [Reduce](../primitive-operators/reduce.md), [N-Wise Reduce](../primitive-operators/reduce-n-wise.md)
 ```apl
       +/ 1 2 3 4 5

--- a/language-reference-guide/docs/symbols/slope-bar.md
+++ b/language-reference-guide/docs/symbols/slope-bar.md
@@ -2,14 +2,14 @@
 search:
   exclude: true
 ---
-<h1 class="heading"><span class="name">Back Slash Bar</span> <span class="command">⍀</span></h1>
+<h1 class="heading"><span class="name">Backslash Bar</span> <span class="command">⍀</span></h1>
 
 
 # Used as a Function
 
-Monadic Back Slash Bar is not defined
+Monadic Backslash Bar is not defined
 
-Dyadic Back Slash Bar means
+Dyadic Backslash Bar means
 [Expand  First](../primitive-functions/expand.md)
 ```apl
 
@@ -28,9 +28,9 @@ Dyadic Back Slash Bar means
 
 # Used as an Operator
 
-Back Slash Bar is a monadic operator with a dyadic operand
+Backslash Bar is a monadic operator with a dyadic operand
 
-Operator Slope Bar means
+Operator Backslash Bar means
 [Scan First](../primitive-operators/scan-first.md)
 ```apl
       +⍀ mat

--- a/language-reference-guide/docs/symbols/slope-bar.md
+++ b/language-reference-guide/docs/symbols/slope-bar.md
@@ -2,22 +2,14 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Back Slash Bar</span> <span class="command">⍀</span></h1>
 
 
-Used as a Function
-
+# Used as a Function
 
 Monadic Back Slash Bar is not defined
 
-### Dyadic Back Slash Bar means
-
-
+Dyadic Back Slash Bar means
 [Expand  First](../primitive-functions/expand.md)
 ```apl
 
@@ -34,25 +26,18 @@ Monadic Back Slash Bar is not defined
 9 10 11 12
 ```
 
-Used as an Operator
-
+# Used as an Operator
 
 Back Slash Bar is a Monadic operator with a Dyadic operand
 
-#### Operator Slope Bar means
-
-
+Operator Slope Bar means
 [Scan First](../primitive-operators/scan-first.md)
 ```apl
-
       +⍀ mat
  1  2  3  4
  6  8 10 12
 15 18 21 24 
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/slope-bar.md
+++ b/language-reference-guide/docs/symbols/slope-bar.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Back Slash Bar</span> <span class="command">⍀</span></h1>
 
 
-## Used as a Function
+Used as a Function
 
 
 Monadic Back Slash Bar is not defined
@@ -34,7 +34,7 @@ Monadic Back Slash Bar is not defined
 9 10 11 12
 ```
 
-## Used as an Operator
+Used as an Operator
 
 
 Back Slash Bar is a Monadic operator with a Dyadic operand

--- a/language-reference-guide/docs/symbols/slope-bar.md
+++ b/language-reference-guide/docs/symbols/slope-bar.md
@@ -28,7 +28,7 @@ Dyadic Back Slash Bar means
 
 # Used as an Operator
 
-Back Slash Bar is a Monadic operator with a Dyadic operand
+Back Slash Bar is a monadic operator with a dyadic operand
 
 Operator Slope Bar means
 [Scan First](../primitive-operators/scan-first.md)

--- a/language-reference-guide/docs/symbols/slope.md
+++ b/language-reference-guide/docs/symbols/slope.md
@@ -2,13 +2,13 @@
 search:
   exclude: true
 ---
-<h1 class="heading"><span class="name">Back Slash</span> <span class="command">\</span></h1>
+<h1 class="heading"><span class="name">Backslash</span> <span class="command">\</span></h1>
 
 # Used as a Function
 
-Monadic Back Slash is not defined
+Monadic Backslash is not defined
 
-Dyadic Back Slash means
+Dyadic Backslash means
 [Expand](../primitive-functions/expand.md)
 ```apl
       3 ¯2 4 \ 7 8
@@ -20,9 +20,9 @@ H a t
 
 # Used as an Operator
 
-Back Slash is a monadic operator with a dyadic operand
+Backslash is a monadic operator with a dyadic operand
 
-Operator Back Slash means
+Operator Backslash means
 [Scan](../primitive-operators/scan.md)
 ```apl
       +\ 1 2 3 4 5

--- a/language-reference-guide/docs/symbols/slope.md
+++ b/language-reference-guide/docs/symbols/slope.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Back Slash</span> <span class="command">\</span></h1>
 
 
-## Used as a Function
+Used as a Function
 
 
 Monadic Back Slash is not defined
@@ -28,7 +28,7 @@ Monadic Back Slash is not defined
 H a t
 ```
 
-## Used as an Operator
+Used as an Operator
 
 
 Back Slash is a Monadic operator with a Dyadic operand

--- a/language-reference-guide/docs/symbols/slope.md
+++ b/language-reference-guide/docs/symbols/slope.md
@@ -2,25 +2,15 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Back Slash</span> <span class="command">\</span></h1>
 
-
-Used as a Function
-
+# Used as a Function
 
 Monadic Back Slash is not defined
 
-### Dyadic Back Slash means
-
-
+Dyadic Back Slash means
 [Expand](../primitive-functions/expand.md)
 ```apl
-
       3 ¯2 4 \ 7 8
 7 7 7 0 0 8 8 8 8
 
@@ -28,17 +18,13 @@ Monadic Back Slash is not defined
 H a t
 ```
 
-Used as an Operator
-
+# Used as an Operator
 
 Back Slash is a Monadic operator with a Dyadic operand
 
-#### Operator Back Slash means
-
-
+Operator Back Slash means
 [Scan](../primitive-operators/scan.md)
 ```apl
-
       +\ 1 2 3 4 5
 1 3 6 10 15
 
@@ -56,10 +42,7 @@ Back Slash is a Monadic operator with a Dyadic operand
  1  2  3  4
  6  8 10 12
 15 18 21 24
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/slope.md
+++ b/language-reference-guide/docs/symbols/slope.md
@@ -20,7 +20,7 @@ H a t
 
 # Used as an Operator
 
-Back Slash is a Monadic operator with a Dyadic operand
+Back Slash is a monadic operator with a dyadic operand
 
 Operator Back Slash means
 [Scan](../primitive-operators/scan.md)

--- a/language-reference-guide/docs/symbols/star.md
+++ b/language-reference-guide/docs/symbols/star.md
@@ -2,36 +2,22 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Star</span> <span class="command">*</span></h1>
 
 
 Monadic Star means
-
-
 [Exponential](../primitive-functions/exponential.md)
 ```apl
-
       * 0 1 2
 1 2.71828 7.38906
 ```
 
 Dyadic Star means
-
-
 [Power](../primitive-functions/power.md)
 ```apl
-
       49 5 ¯4 * 0.5 2 0.5
 7 25 0J2
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/star.md
+++ b/language-reference-guide/docs/symbols/star.md
@@ -23,8 +23,7 @@ Monadic Star means
 Dyadic Star means
 
 
-[Power
-      ](../primitive-functions/power.md)
+[Power](../primitive-functions/power.md)
 ```apl
 
       49 5 ¯4 * 0.5 2 0.5

--- a/language-reference-guide/docs/symbols/star.md
+++ b/language-reference-guide/docs/symbols/star.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Star</span> <span class="command">*</span></h1>
 
 
-## Monadic Star means
+Monadic Star means
 
 
 [Exponential](../primitive-functions/exponential.md)
@@ -20,7 +20,7 @@ search:
 1 2.71828 7.38906
 ```
 
-## Dyadic Star means
+Dyadic Star means
 
 
 [Power

--- a/language-reference-guide/docs/symbols/stile.md
+++ b/language-reference-guide/docs/symbols/stile.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Stile;Vertical Bar</span> <span class="command">|</span></h1>
 
 
-## Monadic Stile means
+Monadic Stile means
 
 
 [Magnitude](../primitive-functions/magnitude.md)
@@ -22,7 +22,7 @@ search:
 
 ```
 
-## Dyadic Stile means
+Dyadic Stile means
 
 
 [Residue;Modulus](../primitive-functions/residue.md)

--- a/language-reference-guide/docs/symbols/stile.md
+++ b/language-reference-guide/docs/symbols/stile.md
@@ -2,38 +2,22 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Stile;Vertical Bar</span> <span class="command">|</span></h1>
 
 
 Monadic Stile means
-
-
 [Magnitude](../primitive-functions/magnitude.md)
 ```apl
-
-
       | 2.3 ¯4 0 3j4
 2.3 4 0 5
-
 ```
 
 Dyadic Stile means
-
-
 [Residue;Modulus](../primitive-functions/residue.md)
 ```apl
-
       2 10 ¯2.5 | 7 ¯13 8
 1 7 ¯2
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/thorn-symbol.md
+++ b/language-reference-guide/docs/symbols/thorn-symbol.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Thorn</span> <span class="command">⍕</span></h1>
 
 
-Monadic Format means
+Monadic Thorn means
 
 
 [Format](../primitive-functions/format-monadic.md)
@@ -36,7 +36,7 @@ NB: In the following examples space characters
 
 N.B. depends on `⎕PP`
 
-Dyadic Format means
+Dyadic Thorn means
 
 
 [Format By Specification](../primitive-functions/format-dyadic.md)
@@ -55,8 +55,6 @@ Field-width and number of decimal places:
 ******
 
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/thorn-symbol.md
+++ b/language-reference-guide/docs/symbols/thorn-symbol.md
@@ -39,8 +39,7 @@ N.B. depends on `⎕PP`
 Dyadic Format means
 
 
-[Format By Specification
-      ](../primitive-functions/format-dyadic.md)
+[Format By Specification](../primitive-functions/format-dyadic.md)
 ```apl
 
 Field-width and number of decimal places:

--- a/language-reference-guide/docs/symbols/thorn-symbol.md
+++ b/language-reference-guide/docs/symbols/thorn-symbol.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Thorn</span> <span class="command">⍕</span></h1>
 
 
-## Monadic Format means
+Monadic Format means
 
 
 [Format](../primitive-functions/format-monadic.md)
@@ -36,7 +36,7 @@ NB: In the following examples space characters
 
 N.B. depends on `⎕PP`
 
-## Dyadic Format means
+Dyadic Format means
 
 
 [Format By Specification

--- a/language-reference-guide/docs/symbols/tilde.md
+++ b/language-reference-guide/docs/symbols/tilde.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Tilde</span> <span class="command">~</span></h1>
 
 
-## Monadic Tilde means
+Monadic Tilde means
 
 
 [Not
@@ -21,7 +21,7 @@ search:
 1 0 1 0
 ```
 
-## Dyadic Tilde means
+Dyadic Tilde means
 
 
 [Without;Excluding](../primitive-functions/excluding.md)

--- a/language-reference-guide/docs/symbols/tilde.md
+++ b/language-reference-guide/docs/symbols/tilde.md
@@ -13,8 +13,7 @@ search:
 Monadic Tilde means
 
 
-[Not
-      ](../primitive-functions/not.md)
+[Not](../primitive-functions/not.md)
 ```apl
 
       ~ 0 1 0 1

--- a/language-reference-guide/docs/symbols/tilde.md
+++ b/language-reference-guide/docs/symbols/tilde.md
@@ -2,30 +2,18 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Tilde</span> <span class="command">~</span></h1>
 
-
 Monadic Tilde means
-
-
 [Not](../primitive-functions/not.md)
 ```apl
-
       ~ 0 1 0 1
 1 0 1 0
 ```
 
 Dyadic Tilde means
-
-
 [Without;Excluding](../primitive-functions/excluding.md)
 ```apl
-
       3 1 4 1 5 ~ 5 1
 3 4
 
@@ -33,10 +21,7 @@ Dyadic Tilde means
 ┌──┬──┐
 │aa│cc│
 └──┴──┘
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/times-sign.md
+++ b/language-reference-guide/docs/symbols/times-sign.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Times Sign</span> <span class="command">×</span></h1>
 
 
-## Monadic Times Sign means
+Monadic Times Sign means
 
 
 [Direction](../primitive-functions/direction.md)
@@ -22,7 +22,7 @@ search:
 
 ```
 
-## Dyadic Times Sign means
+Dyadic Times Sign means
 
 
 [Times](../primitive-functions/multiply.md)

--- a/language-reference-guide/docs/symbols/times-sign.md
+++ b/language-reference-guide/docs/symbols/times-sign.md
@@ -2,32 +2,18 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Times Sign</span> <span class="command">×</span></h1>
 
-
 Monadic Times Sign means
-
-
 [Direction](../primitive-functions/direction.md)
 ```apl
-
-
       × 3.1 ¯2 0 3j4
 1 ¯1 0 0.6J0.8
-
 ```
 
 Dyadic Times Sign means
-
-
 [Times](../primitive-functions/multiply.md)
 ```apl
-
       2 ¯3 4.5 × ¯3 ¯4 2
 ¯6 12 9
 
@@ -36,10 +22,7 @@ Dyadic Times Sign means
 
       ×/ 2 3 4
 24
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/transpose.md
+++ b/language-reference-guide/docs/symbols/transpose.md
@@ -2,20 +2,11 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Circle Backslash</span> <span class="command">⍉</span></h1>
 
-
 Monadic Transpose means
-
-
 [Transpose](../primitive-functions/transpose-monadic.md)
 ```apl
-
       mat
 1 2 3
 4 5 6
@@ -24,25 +15,18 @@ Monadic Transpose means
 1 4
 2 5
 3 6
-
 ```
 
 Dyadic Transpose means
-
-
 [Dyadic Transpose](../primitive-functions/transpose-dyadic.md)
 ```apl
-
       2 1 ⍉ mat
 1 4
 2 5
 3 6
       1 1 ⍉ mat     ⍝ leading diagonal
 1 5
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/transpose.md
+++ b/language-reference-guide/docs/symbols/transpose.md
@@ -4,7 +4,7 @@ search:
 ---
 <h1 class="heading"><span class="name">Circle Backslash</span> <span class="command">⍉</span></h1>
 
-Monadic Transpose means
+Monadic Circle Backslash means
 [Transpose](../primitive-functions/transpose-monadic.md)
 ```apl
       mat
@@ -17,7 +17,7 @@ Monadic Transpose means
 3 6
 ```
 
-Dyadic Transpose means
+Dyadic Circle Backslash means
 [Dyadic Transpose](../primitive-functions/transpose-dyadic.md)
 ```apl
       2 1 ⍉ mat

--- a/language-reference-guide/docs/symbols/transpose.md
+++ b/language-reference-guide/docs/symbols/transpose.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Circle Backslash</span> <span class="command">⍉</span></h1>
 
 
-## Monadic Transpose means
+Monadic Transpose means
 
 
 [Transpose](../primitive-functions/transpose-monadic.md)
@@ -27,7 +27,7 @@ search:
 
 ```
 
-## Dyadic Transpose means
+Dyadic Transpose means
 
 
 [Dyadic Transpose](../primitive-functions/transpose-dyadic.md)

--- a/language-reference-guide/docs/symbols/up-arrow.md
+++ b/language-reference-guide/docs/symbols/up-arrow.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Up Arrow</span> <span class="command">↑</span></h1>
 
 
-## Monadic Up Arrow means
+Monadic Up Arrow means
 
 
 If `⎕ML<2` [Mix](../primitive-functions/mix.md)
@@ -38,7 +38,7 @@ If `⎕ML≥2` [First](../primitive-functions/disclose.md)
 
 ```
 
-## Dyadic Up Arrow means
+Dyadic Up Arrow means
 
 
 [Take

--- a/language-reference-guide/docs/symbols/up-arrow.md
+++ b/language-reference-guide/docs/symbols/up-arrow.md
@@ -41,8 +41,7 @@ If `⎕ML≥2` [First](../primitive-functions/disclose.md)
 Dyadic Up Arrow means
 
 
-[Take
-      ](../primitive-functions/take.md)
+[Take](../primitive-functions/take.md)
 ```apl
 
       4 ↑ 'Pineapple'

--- a/language-reference-guide/docs/symbols/up-arrow.md
+++ b/language-reference-guide/docs/symbols/up-arrow.md
@@ -2,21 +2,12 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Up Arrow</span> <span class="command">↑</span></h1>
-
 
 Monadic Up Arrow means
 
-
 If `⎕ML<2` [Mix](../primitive-functions/mix.md)
 ```apl
-
-
       ↑ 'Hip' 'Hop'
 Hip
 Hop
@@ -30,20 +21,15 @@ io
 pp
 ```
 
-
 If `⎕ML≥2` [First](../primitive-functions/disclose.md)
 ```apl
       ↑ (6 4) 5 3
 6 4
-
 ```
 
 Dyadic Up Arrow means
-
-
 [Take](../primitive-functions/take.md)
 ```apl
-
       4 ↑ 'Pineapple'
 Pine
       ¯5 ↑ 'Pineapple'
@@ -65,10 +51,5 @@ apple
       ¯2 3 ↑ 7
 0 0 0
 7 0 0
-
 ```
-
-
 [Language Elements](./language-elements.md)
-
-

--- a/language-reference-guide/docs/symbols/upstile.md
+++ b/language-reference-guide/docs/symbols/upstile.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Upstile</span> <span class="command">⌈</span></h1>
 
 
-## Monadic Upstile means
+Monadic Upstile means
 
 
 [Ceiling](../primitive-functions/ceiling.md)
@@ -20,7 +20,7 @@ search:
 4 ¯3 3 0
 ```
 
-## Dyadic Upstile means
+Dyadic Upstile means
 
 
 [Maximum

--- a/language-reference-guide/docs/symbols/upstile.md
+++ b/language-reference-guide/docs/symbols/upstile.md
@@ -2,39 +2,24 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Upstile</span> <span class="command">⌈</span></h1>
 
-
 Monadic Upstile means
-
-
 [Ceiling](../primitive-functions/ceiling.md)
 ```apl
-
       ⌈ 3.4 ¯3.4 3 0
 4 ¯3 3 0
 ```
 
 Dyadic Upstile means
-
-
 [Maximum](../primitive-functions/maximum.md)
 ```apl
-
       1.1 ¯2 ⌈ 8.1 ¯3.4
 8.1 ¯2
 
       ⌈/ 3 1 4 1
 4
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/upstile.md
+++ b/language-reference-guide/docs/symbols/upstile.md
@@ -23,8 +23,7 @@ Monadic Upstile means
 Dyadic Upstile means
 
 
-[Maximum
-      ](../primitive-functions/maximum.md)
+[Maximum](../primitive-functions/maximum.md)
 ```apl
 
       1.1 ¯2 ⌈ 8.1 ¯3.4

--- a/language-reference-guide/docs/symbols/variant.md
+++ b/language-reference-guide/docs/symbols/variant.md
@@ -2,19 +2,12 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Variant</span> <span class="command">⍠</span></h1>
-
 
 The Variant operator  specifies the value of an option to be used by its left operand function.
 
 <h2 class="example">Examples</h2>
 ```apl
-
       ('a' ⎕R 'x') 'ABC'           ⍝ 'a' replaced with 'x'
 ABC
 
@@ -25,9 +18,7 @@ xBC
       
       'a' ⎕R 'x' IgnCase 'ABC'
 xBC 
-
 ```
-
 
 The following derived function returns the location of the word `'variant'` within its right argument using default values for all the options.
 ```apl
@@ -36,13 +27,11 @@ The following derived function returns the location of the word `'variant'` with
 4
 ```
 
-
 It may be modified to perform a case-insensitive search:
 ```apl
       (f1 ⍠ 1) 'The variant Variant operator'
 4 12
 ```
-
 
 This modified function may be named:
 ```apl
@@ -50,7 +39,6 @@ This modified function may be named:
       f2 'The variant Variant operator'
 4 12
 ```
-
 
 The modified function may itself be modified, in this case to revert to a case sensitive search:
 ```apl
@@ -65,8 +53,6 @@ This is equivalent to:
       (f1 ⍠ 1 ⍠ 0) 'The variant Variant operator'
 4
 ```
-
-
 [Language Elements](./language-elements.md)
 
 

--- a/language-reference-guide/docs/symbols/variant.md
+++ b/language-reference-guide/docs/symbols/variant.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Variant</span> <span class="command">⍠</span></h1>
 
 
-## The Variant operator  specifies the value of an option to be used by its left operand function.
+The Variant operator  specifies the value of an option to be used by its left operand function.
 
 <h2 class="example">Examples</h2>
 ```apl

--- a/language-reference-guide/docs/symbols/zilde-symbol.md
+++ b/language-reference-guide/docs/symbols/zilde-symbol.md
@@ -10,7 +10,7 @@ search:
 <h1 class="heading"><span class="name">Zilde;</span> <span class="command">⍬</span></h1>
 
 
-## Niladic Zilde is
+Niladic Zilde is
 
 
 [Zilde](../primitive-functions/zilde.md)

--- a/language-reference-guide/docs/symbols/zilde-symbol.md
+++ b/language-reference-guide/docs/symbols/zilde-symbol.md
@@ -2,20 +2,11 @@
 search:
   exclude: true
 ---
-
-
-
-
-
 <h1 class="heading"><span class="name">Zilde;</span> <span class="command">⍬</span></h1>
 
-
 Niladic Zilde is
-
-
 [Zilde](../primitive-functions/zilde.md)
 ```apl
-
       ⍬≡⍳0
 1
       ⍬≡0⍴0
@@ -24,10 +15,7 @@ Niladic Zilde is
 0
       ⍬≡''
 0
-
 ```
-
-
 [Language Elements](./language-elements.md)
 
 


### PR DESCRIPTION
As #362 states, the various Dyalog APL Language Reference Guide > Symbols sub-pages have heading fonts where body text was expected.

Correct these