### PR TITLE
Correct :Hold table rendering

### DIFF
--- a/programming-reference-guide/docs/defined-functions-and-operators/traditional-functions-and-operators/control-structures/hold.md
+++ b/programming-reference-guide/docs/defined-functions-and-operators/traditional-functions-and-operators/control-structures/hold.md
@@ -66,7 +66,6 @@ In the following example, a thread updates a critical structure in a child names
 
 However, with the nesting of holds comes the possibility of a "deadlock". For example, consider the two threads:
 
-
 <table>
 <tr>
 <td>Thread 1</td>
@@ -76,9 +75,9 @@ However, with the nesting of holds comes the possibility of a "deadlock". For ex
 <td><pre>
 :Hold 'red'
     ...
-   :Hold 'green'
+    :Hold 'green'
         ...
-   :EndHold
+    :EndHold
 :EndHold
 </pre></td>
 <td><pre>
@@ -111,10 +110,30 @@ You can avoid deadlock by ensuring that threads always attempt to acquire tokens
 
 Note that token acquisition for any particular `:Hold` is atomic, that is, either *all* of the tokens or *none* of them are acquired. The following example *cannot* deadlock:
 
+<table>
+<tr>
+<td>Thread 1</td>
+<td>Thread 2</td>
+</tr>
+<tr>
+<td><pre>
+:Hold 'red'
+    ...
+    :Hold 'green'
+        ...
+    :EndHold
+:EndHold
+</pre></td>
+<td><pre>
 
-|Thread 1                                                                           |Thread 2                                              |
-|-----------------------------------------------------------------------------------|------------------------------------------------------|
-|```apl :Hold 'red'     ...     :Hold 'green'         ...     :EndHold :EndHold  ```|```apl  :Hold 'green' 'red'     ...     :EndHold   ```|
+:Hold 'green' 'red'
+        ...
+:EndHold
+
+</pre></td>
+	</tr>
+</table>
+
 
 <h2 class="example">Examples</h2>
 

--- a/programming-reference-guide/docs/defined-functions-and-operators/traditional-functions-and-operators/control-structures/hold.md
+++ b/programming-reference-guide/docs/defined-functions-and-operators/traditional-functions-and-operators/control-structures/hold.md
@@ -72,22 +72,22 @@ However, with the nesting of holds comes the possibility of a "deadlock". For ex
 <td>Thread 2</td>
 </tr>
 <tr>
-<td><pre>
+<td><pre><code>
 :Hold 'red'
     ...
     :Hold 'green'
         ...
     :EndHold
 :EndHold
-</pre></td>
-<td><pre>
+</code></pre></td>
+<td><pre><code>
 :Hold 'green'
     ...
     :Hold 'red'
         ...
     :EndHold
 :EndHold
-</pre></td>
+</code></pre></td>
 	</tr>
 </table>
 
@@ -116,21 +116,22 @@ Note that token acquisition for any particular `:Hold` is atomic, that is, eithe
 <td>Thread 2</td>
 </tr>
 <tr>
-<td><pre>
+<td>
+<pre><code>
 :Hold 'red'
     ...
     :Hold 'green'
         ...
     :EndHold
 :EndHold
-</pre></td>
-<td><pre>
+</code></pre></td>
+<td><pre><code>
 
 :Hold 'green' 'red'
         ...
 :EndHold
 
-</pre></td>
+</code></pre></td>
 	</tr>
 </table>
 

--- a/programming-reference-guide/docs/defined-functions-and-operators/traditional-functions-and-operators/control-structures/hold.md
+++ b/programming-reference-guide/docs/defined-functions-and-operators/traditional-functions-and-operators/control-structures/hold.md
@@ -67,28 +67,32 @@ In the following example, a thread updates a critical structure in a child names
 However, with the nesting of holds comes the possibility of a "deadlock". For example, consider the two threads:
 
 <table>
-<tr>
-<td>Thread 1</td>
-<td>Thread 2</td>
-</tr>
-<tr>
-<td><pre><code>
-:Hold 'red'
-    ...
-    :Hold 'green'
-        ...
-    :EndHold
-:EndHold
-</code></pre></td>
-<td><pre><code>
-:Hold 'green'
-    ...
-    :Hold 'red'
-        ...
-    :EndHold
-:EndHold
-</code></pre></td>
-	</tr>
+    <tr>
+        <td>Thread 1</td>
+        <td>Thread 2</td>
+    </tr>
+    <tr>
+        <td>
+            <pre><code>
+            :Hold 'red'
+                ...
+                :Hold 'green'
+                    ...
+                :EndHold
+            :EndHold
+            </code></pre>
+        </td>
+        <td>
+            <pre><code>
+            :Hold 'green'
+                ...
+                :Hold 'red'
+                    ...
+                :EndHold
+            :EndHold
+            </code></pre>
+        </td>
+    </tr>
 </table>
 
 
@@ -111,28 +115,31 @@ You can avoid deadlock by ensuring that threads always attempt to acquire tokens
 Note that token acquisition for any particular `:Hold` is atomic, that is, either *all* of the tokens or *none* of them are acquired. The following example *cannot* deadlock:
 
 <table>
-<tr>
-<td>Thread 1</td>
-<td>Thread 2</td>
-</tr>
-<tr>
-<td>
-<pre><code>
-:Hold 'red'
-    ...
-    :Hold 'green'
-        ...
-    :EndHold
-:EndHold
-</code></pre></td>
-<td><pre><code>
-
-:Hold 'green' 'red'
-        ...
-:EndHold
-
-</code></pre></td>
-	</tr>
+    <tr>
+        <td>Thread 1</td>
+        <td>Thread 2</td>
+    </tr>
+    <tr>
+        <td>
+            <pre><code>
+            :Hold 'red'
+                ...
+                :Hold 'green'
+                    ...
+                :EndHold
+            :EndHold
+            </code></pre>
+        </td>
+        <td>
+            <pre><code>
+            
+            :Hold 'green' 'red'
+                    ...
+            :EndHold
+            
+            </code></pre>
+        </td>
+    </tr>
 </table>
 
 

--- a/programming-reference-guide/docs/defined-functions-and-operators/traditional-functions-and-operators/control-structures/hold.md
+++ b/programming-reference-guide/docs/defined-functions-and-operators/traditional-functions-and-operators/control-structures/hold.md
@@ -67,9 +67,34 @@ In the following example, a thread updates a critical structure in a child names
 However, with the nesting of holds comes the possibility of a "deadlock". For example, consider the two threads:
 
 
-|Thread 1                                                                           |Thread 2                                                                           |
-|-----------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
-|```apl :Hold 'red'     ...     :Hold 'green'         ...     :EndHold :EndHold  ```|```apl :Hold 'green'     ...     :Hold 'red'          ...     :EndHold :EndHold ```|
+<table>
+<tr>
+<td>Thread 1</td>
+<td>Thread 2</td>
+</tr>
+<tr>
+<td><pre>
+:Hold 'red'
+    ...
+   :Hold 'green'
+        ...
+   :EndHold
+:EndHold
+</pre></td>
+<td><pre>
+:Hold 'green'
+    ...
+    :Hold 'red'
+        ...
+    :EndHold
+:EndHold
+</pre></td>
+	</tr>
+</table>
+
+
+
+
 
 
 In this case if both threads succeed in acquiring their first hold, they will both block waiting for the other to release its token.


### PR DESCRIPTION
As #385 states, `:Hold`'s uses tables to show code blocks adjacent to each other. 
Unfortunately the table and code blocks seem to not work together well.