### PR TITLE
Remove emoji extensions globally.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,9 +54,6 @@ markdown_extensions:
   - pymdownx.highlight:
       pygments_lang_class: true
   - attr_list
-  - pymdownx.emoji:
-      emoji_index: !!python/name:material.extensions.emoji.twemoji
-      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - abbr
   - footnotes
   - md_in_html


### PR DESCRIPTION
Datetime components were "flagged" by mistake.

References: #376 