### PR TITLE
Enable minify plugin to shrink HTML build assets

### DIFF
--- a/.github/workflows/mkdocs-publish.yml
+++ b/.github/workflows/mkdocs-publish.yml
@@ -51,7 +51,8 @@ jobs:
           mkdocs-monorepo-plugin \
           mkdocs-site-urls \
           mkdocs-caption \
-          markdown-tables-extended
+          markdown-tables-extended \
+          mkdocs-minify-plugin
 
     - name: Get Git Info
       id: git-info

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,8 @@ plugins:
   - search
   - macros
   - monorepo
+  - minify:
+      minify_html: true
   - caption:
       table: 
         enable: true

--- a/tools/mkdocs/Dockerfile
+++ b/tools/mkdocs/Dockerfile
@@ -10,7 +10,8 @@ RUN pip install \
     mkdocs-monorepo-plugin \
     mkdocs-site-urls \
     mkdocs-caption \
-    markdown-tables-extended
+    markdown-tables-extended \
+    mkdocs-minify-plugin
 
 # Set the working directory
 WORKDIR /docs


### PR DESCRIPTION
Install and enable the minify plugin.

References: #396 