### PR TITLE
Fix reference to svn checkout script in the workflow

### DIFF
--- a/.github/workflows/mkdocs-publish.yml
+++ b/.github/workflows/mkdocs-publish.yml
@@ -104,11 +104,11 @@ jobs:
         mv tools/jenkins/Jenkinsfile .
         mv tools/jenkins/service.yml .
         mv tools/jenkins/.rsync-exclude .
-        mv tools/jenkins/get_svn_docs .
+        mv tools/jenkins/get_svn_docbin .
         
         # Remove from staging in old location and add to staging in new location
         git rm -r tools
-        git add Jenkinsfile service.yml .rsync-exclude get_svn_docs
+        git add Jenkinsfile service.yml .rsync-exclude get_svn_docbin
         
         # Commit if there are changes
         if git diff --staged --quiet; then


### PR DESCRIPTION
Typo in the workflow meant that it fails.