### PR TITLE
Fix empty pages on search results for section introductions

### DIFF
--- a/chm/mkdocs2chm.py
+++ b/chm/mkdocs2chm.py
@@ -121,10 +121,15 @@ def _process_nav_item(item: dict | str, parent: Node, project="project") -> None
         value = item  # item is the filename -- swap to .htm to parse
         if item.endswith(".md"):
             html_file = os.path.join(project, item.replace(".md", ".htm"))
-            with open(html_file, "r", encoding="utf-8") as f:
-                data = f.read()
-            if h1 := extract_h1(data):
-                key = h1
+            # Check if the HTML file exists (it might have been excluded)
+            if os.path.exists(html_file):
+                with open(html_file, "r", encoding="utf-8") as f:
+                    data = f.read()
+                if h1 := extract_h1(data):
+                    key = h1
+            else:
+                # File was excluded, skip this nav item
+                return
 
             # Special case for welcome.md - override the H1 title
             if item == "welcome.md":
@@ -141,7 +146,21 @@ def _process_nav_item(item: dict | str, parent: Node, project="project") -> None
 def _traverse(node: Node, toc: IO[str]) -> None:
     # Just clean up quotes and backticks (HTML tags and quad already removed during parsing)
     title = node.name.replace("`", "").replace('"', "")
-    toc.write(DIR_ENTRY.format(name=title))
+    
+    # Check if this directory has an "Introduction" child that should be used as its link
+    intro_file = None
+    if node.children:
+        for child in node.children:
+            if child.name == "Introduction" and not child.isdir() and child.html_name:
+                intro_file = child.html_name
+                break
+    
+    # Write the entry with or without a Local parameter
+    if intro_file:
+        toc.write(FILE_ENTRY.format(name=title, file=intro_file))
+    else:
+        toc.write(DIR_ENTRY.format(name=title))
+    
     if node.children:  # Only write <ul> if there are children
         toc.write("<ul>\n")
         for child in node.children:
@@ -285,6 +304,7 @@ def find_source_files(topdir: str, subdirs: List[str]) -> Tuple[List[str], List[
     """
     markdown_files = []
     image_files = []
+    excluded_print_files = []
 
     for subdir in subdirs:
         incldir = os.path.join(topdir, re.sub(r"^[./]+", "", os.path.dirname(subdir)))
@@ -299,9 +319,18 @@ def find_source_files(topdir: str, subdirs: List[str]) -> Tuple[List[str], List[
                     continue
                 extension = os.path.splitext(full_path)[-1]
                 if extension == ".md":
-                    markdown_files.append(full_path)
+                    # Skip -print.md files completely
+                    if file.endswith("-print.md"):
+                        excluded_print_files.append(full_path)
+                    else:
+                        markdown_files.append(full_path)
                 elif extension in {".png", ".gif", ".jpg", ".bmp", ".jpeg"}:
                     image_files.append(full_path)
+
+    if excluded_print_files:
+        print(f"\nExcluded {len(excluded_print_files)} -print.md files from all processing:")
+        for f in sorted(excluded_print_files):
+            print(f"  - {os.path.basename(f)}")
 
     return markdown_files, image_files
 
@@ -437,6 +466,27 @@ def purge_css(css: str, html_content: str) -> str:
     return new_stylesheet.cssText.decode("utf-8")
 
 
+def parse_frontmatter(content: str) -> Tuple[dict, str]:
+    """
+    Parse YAML frontmatter from markdown content.
+    Returns (frontmatter_dict, content_without_frontmatter)
+    """
+    frontmatter_pattern = r'^\s*---\n(.*?)\n---\n+'
+    match = re.match(frontmatter_pattern, content, flags=re.DOTALL)
+    
+    if match:
+        yaml = YAML()
+        try:
+            frontmatter = yaml.load(match.group(1))
+            if frontmatter is None:
+                frontmatter = {}
+        except:
+            frontmatter = {}
+        content_without = re.sub(frontmatter_pattern, '', content, count=1, flags=re.DOTALL)
+        return frontmatter, content_without
+    return {}, content
+
+
 def convert_to_html(
     filenames: List[str],
     css: str,
@@ -444,7 +494,7 @@ def convert_to_html(
     transforms: List[Callable[[str], str]],
     project: str,
     top_level_files: List[str],
-) -> List[str]:
+) -> Tuple[List[str], List[str]]:
     """
     Convert each Markdown file and convert to HTML, using the same rendering library as
     mkdocs, with the same set of extensions. We expand the mkdocs-macro {{ templates }}
@@ -453,8 +503,11 @@ def convert_to_html(
     viewer does not understand <link ...>.
 
     As a mitigation, take steps to only add the actually used CSS bits.
+    
+    Returns: (converted_files, excluded_files)
     """
     converted: List[str] = []
+    excluded: List[str] = []
 
     head_template = """
 <!DOCTYPE html>
@@ -465,8 +518,6 @@ def convert_to_html(
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{title}</title>
 """
-
-    converted: List[str] = []
 
     for file in filenames:
         if file in top_level_files:
@@ -487,10 +538,10 @@ def convert_to_html(
         with open(file, "r", encoding="utf-8") as f:
             md = f.read()
 
-        # Remove YAML frontmatter if present (may have leading whitespace)
-        # Pattern matches optional whitespace, ---, content, ---, and following newlines
-        frontmatter_pattern = r'^\s*---\n.*?\n---\n+'
-        md = re.sub(frontmatter_pattern, '', md, count=1, flags=re.DOTALL)
+        # Parse frontmatter and check for search exclusion
+        frontmatter, md = parse_frontmatter(md)
+        if frontmatter.get('search', {}).get('exclude', False):
+            excluded.append(file)
 
         # Macros are defined in the "extra:" section in the mkdocs.yml file. In the Markdown
         # source, they are templates of the type
@@ -564,7 +615,7 @@ def convert_to_html(
             f.write(final_html)
 
         converted.append(str(newname))
-    return converted
+    return converted, excluded
 
 
 def copy_images(filenames: List[str], project="project") -> List[str]:
@@ -724,7 +775,7 @@ def find_nav_files_and_dirs(
             if isinstance(value, str):
                 if m := re.match(r'!include\s+([^"]+)', value):
                     included_dirs.append(m.group(1))  # Path from !include
-                elif value.endswith(".md"):
+                elif value.endswith(".md") and not value.endswith("-print.md"):
                     standalone_files.append(
                         os.path.join("docs", value)
                     )  # Direct .md file reference
@@ -1266,6 +1317,16 @@ if __name__ == "__main__":
         os.path.abspath(os.path.join(os.path.dirname(args.mkdocs_yml), f))
         for f in standalone_files
     ]
+    
+    # Filter out -print.md files from standalone files
+    excluded_print_standalone = [f for f in standalone_files_abs if f.endswith("-print.md")]
+    standalone_files_abs = [f for f in standalone_files_abs if not f.endswith("-print.md")]
+    
+    if excluded_print_standalone:
+        print(f"\nExcluded {len(excluded_print_standalone)} -print.md standalone files:")
+        for f in sorted(excluded_print_standalone):
+            print(f"  - {os.path.basename(f)}")
+    
     md_files = md_files_from_dirs + standalone_files_abs
 
     # Add welcome.md to the start of the files list
@@ -1289,7 +1350,7 @@ if __name__ == "__main__":
         macros["build_date"] = args.build_date
 
     # Convert to HTML
-    html_files = convert_to_html(
+    html_files, excluded_files = convert_to_html(
         md_files,
         css,
         macros=macros,
@@ -1297,6 +1358,14 @@ if __name__ == "__main__":
         project=args.project_dir,
         top_level_files=standalone_files_abs,
     )
+    
+    # Remove excluded files from md_files for indexing
+    md_files = [f for f in md_files if f not in excluded_files]
+    
+    if excluded_files:
+        print(f"\nExcluded {len(excluded_files)} files from search index due to 'search: exclude: true':")
+        for f in excluded_files:
+            print(f"  - {os.path.basename(f)}")
 
     # Generate the CHM ToC
     generate_toc(yml_data, project=args.project_dir)


### PR DESCRIPTION
Multiple fixes for CHM:

1. Fix empty pages for search results on section intros
2. Respect search index exclusions
3. Ensure we skip pages marked as "for print only"

References: #254 