### PR TITLE
Remove irrelevant example

### DIFF
--- a/language-reference-guide/docs/primitive-operators/operator-syntax.md
+++ b/language-reference-guide/docs/primitive-operators/operator-syntax.md
@@ -18,12 +18,6 @@ An operator with its operand(s) forms a derived function. The derived function 
       PLUS ← + ⋄ TIMES ← ×
       1 PLUS.TIMES 2
 2
- 
-      ⎕NL 2
-A
-X
-      ⎕EX¨↓⎕NL 2
-      ⎕NL 2
 ```
 
 ## Monadic Operators


### PR DESCRIPTION
Remove irrelevant example from https://docs.dyalog.com/20.0/language-reference-guide/primitive-operators/operator-syntax as #429 shows