### PR TITLE
Reformat Cmd and CMD keystroke definitions

### DIFF
--- a/unix-user-guide/docs/appendix-a-table-of-keycodes-te.md
+++ b/unix-user-guide/docs/appendix-a-table-of-keycodes-te.md
@@ -5,8 +5,8 @@ Keycodes, their common keystrokes, and the keystrokes specific to terminal emula
 ## Notes
 
 1. APL represents the metakey used as the APL character and command shift
-2. Cmd represents the keystroke <Ctrl-x>
-3. CMD represents the keystrokes <Ctrl-x><Ctrl-x>
+2. Cmd represents the keystroke <kbd>Ctrl</kbd>+<kbd>x</kbd>
+3. CMD represents the keystrokes <kbd>Ctrl</kbd>+<kbd>x</kbd> <kbd>Ctrl</kbd>+<kbd>x</kbd>
 4. The file $DYALOG/aplkeys/xterm is certain to be up to date and should be treated as the definitive source of the keycode-keystroke translations
 
 |Keycode|Command                 |Common keystrokes    |Terminal Emulator  |

--- a/unix-user-guide/docs/appendix-b-table-of-keycodes-putty.md
+++ b/unix-user-guide/docs/appendix-b-table-of-keycodes-putty.md
@@ -5,8 +5,8 @@ Keycodes, their common keystrokes, and the keystrokes specific to the PuTTY term
 ## Notes
 
 1. APL represents the metakey used as the APL character and command shift
-2. Cmd represents the keystroke <Ctrl-x>
-3. CMD represents the keystrokes <Ctrl-x><Ctrl-x>
+2. Cmd represents the keystroke <kbd>Ctrl</kbd>+<kbd>x</kbd>
+3. CMD represents the keystrokes <kbd>Ctrl</kbd>+<kbd>x</kbd> <kbd>Ctrl</kbd>+<kbd>x</kbd>
 4. The file $DYALOG\aplkeys\xterm is certain to be uptodate and should be treated as the definitive source of the keycode-keystroke translations
 
 |Keycode|Command            |Common keystrokes    |PuTTY               |


### PR DESCRIPTION
With the move to markdown/html formating, reformat the Cmd and CMD keystroke definitions to reveal them
References #415