### PR TITLE
Float "right" class in headings

### DIFF
--- a/chm/assets/main.css
+++ b/chm/assets/main.css
@@ -87,7 +87,10 @@ td {
 }
 
 .right {
-    text-align: right;
+    float: right;
+    /* Float right to position at the end */
+    padding-right: 5pt;
+    /* Match the left padding for symmetry */
     color: black;
 }
 


### PR DESCRIPTION
CSS buglet -- need float right, not just align the text right.

References: #462 