### PR TITLE
Remove reference to removed Native Look and Feel option

### DIFF
--- a/windows-ui-guide/docs/editor.md
+++ b/windows-ui-guide/docs/editor.md
@@ -85,8 +85,6 @@ Function or operator<br>![](img/editor-toolbar-function.png)
 
 Class or namespace script<br>![](img/editor-toolbar-script.png)
 
-In the table below, the first image shows the appearance of the toolbutton with Native Look and Feel enabled; the second with it disabled.
-
 |Button|Description|
 |---|---|
 |![](img/trace-theme-14-00.png) ![](img/editor-line-numbers-icon.png) Toggle line numbers|Toggles Line numbers on/off|


### PR DESCRIPTION
As #421 shows, we should remove the reference to the removed "Native Look and Feel" option