### PR TITLE
Apply minor corrections for incorrectly-formatted links

### DIFF
--- a/language-reference-guide/docs/primitive-functions/primitive-functions-table.md
+++ b/language-reference-guide/docs/primitive-functions/primitive-functions-table.md
@@ -12,7 +12,7 @@
 |`×`|Times|[Direction](direction.md)|[Times](times.md)|
 |`÷`|Divide|[Reciprocal](reciprocal.md)|[Divide](divide.md)|
 |`↓`|Down Arrow|[split](split.md)|[Drop](drop.md)|
-|`⊂`|Left Shoe|[Enclose](enclose.md)|Partitioned Enclose](partitioned-enclose.md)|
+|`⊂`|Left Shoe|[Enclose](enclose.md)|[Partitioned Enclose](partitioned-enclose.md)|
 |`⊤`|Down Tack|&nbsp;|[Encode](encode.md)|
 |`=`|Equal|&nbsp;|[Equal To](equal-to.md)|
 |`~`|Tilde|[NOT](not.md)|[Without](without.md)|
@@ -45,7 +45,7 @@
 |`≢`|Equal Underbar Slash|[Tally](tally.md)|[Not Match](not-match.md)|
 |`∨`|Logical OR|&nbsp;|[Greatest Common Divisor/OR](greatest-common-divisor-or.md)|
 |`⊃`|Right Shoe|[First](first.md)|[Pick](pick.md)|
-|`,`|Comma|[Ravel](ravel.md)|[Catenate/Laminate](catenate-laminate.md)]
+|`,`|Comma|[Ravel](ravel.md)|[Catenate/Laminate](catenate-laminate.md)|
 |`⍴`|Rho|[Shape](shape.md)|[Reshape](reshape.md)|
 |`⍪`|Comma Bar|[Table](table.md)|[Catenate First/Laminate](catenate-first.md)|
 |`↑`|Up Arrow|[Mix](mix.md)|[Take](take.md)|

--- a/language-reference-guide/docs/primitive-functions/scalar-functions.md
+++ b/language-reference-guide/docs/primitive-functions/scalar-functions.md
@@ -23,7 +23,7 @@ Table: Scalar Primitive Functions {: #ScalarPrimitiveFunctions }
 |`^`|&nbsp;|[AND](lowest-common-multiple-and.md)|
 |`∨`|&nbsp;|[OR](greatest-common-divisor-or.md)|
 |`⍲`|&nbsp;|[NAND](nand.md)|
-|`⍱`|&nbsp;|[NOR(nor.md)|
+|`⍱`|&nbsp;|[NOR](nor.md)|
 |`<`|&nbsp;|[Less Than](less-than.md)|
 |`≤`|&nbsp;|[Less Than Or Equal To](less-than-or-equal-to.md)|
 |`=`|&nbsp;|[Equal To](equal-to.md)|


### PR DESCRIPTION
Correct markdown link typos. See #507 