### PR TITLE
Make chm tolerant to markdown links with trailing slash.

### DIFF
--- a/chm/mkdocs2chm.py
+++ b/chm/mkdocs2chm.py
@@ -983,6 +983,10 @@ def fix_links_html(html: str) -> str:
         if href.startswith("http"):  # Off-site link: leave unchanged
             return href
 
+        # Remove trailing slash if present
+        if href.endswith("/"):
+            href = href[:-1]
+
         path, name = os.path.split(href)
         base, ext = os.path.splitext(name)
 


### PR DESCRIPTION
When converting links, remove trailing slashes before adding .htm extension.

References: #527