### PR TITLE
Generate ids for headings to enable page-internal links

### DIFF
--- a/chm/mkdocs2chm.py
+++ b/chm/mkdocs2chm.py
@@ -588,6 +588,7 @@ def convert_to_html(
                 "markdown_tables_extended",  # https://github.com/fumbles/tables_extended
                 "pymdownx.details",  # https://facelessuser.github.io/pymdown-extensions/extensions/details/
                 "pymdownx.superfences",  # https://facelessuser.github.io/pymdown-extensions/extensions/superfences/
+                "toc",  # https://python-markdown.github.io/extensions/toc/ - adds id attributes to headings
                 TableCaptionExtension(),  # https://github.com/flywire/caption
             ],
         )


### PR DESCRIPTION
- Use the [toc](https://python-markdown.github.io/extensions/toc/) extension for pymdownx to generate ids for headings
- Part of the standard set for pymdownx, so no changes to CI or other tooling.

References: #575 