### PR TITLE
workaround for #589

### DIFF
--- a/tools/mkdocs/Dockerfile
+++ b/tools/mkdocs/Dockerfile
@@ -13,6 +13,9 @@ RUN pip install \
     markdown-tables-extended \
     mkdocs-minify-plugin
 
+RUN pip install --force-reinstall click==8.2.1
+
+
 # Set the working directory
 WORKDIR /docs
 


### PR DESCRIPTION
Users should 

```sh
docker compose up --build --force-recreate mkdocs-server
```

the next time they preview docs.

Won't close issue #589 until the upstream problem is fixed.