### PR TITLE
Complete sentence in Session doc

### DIFF
--- a/windows-ui-guide/docs/the-session-object/session-object.md
+++ b/windows-ui-guide/docs/the-session-object/session-object.md
@@ -13,7 +13,7 @@ There is one (and only one) object of type Session and it is called `⎕SE`. You
 
 `⎕SE` is loaded from a session file when APL starts. The name of the session file is specified by the **session_file** parameter. If no session file is defined, `⎕SE` will have no children and the session will be devoid of menu bar, tool bar and status bar components.
 
-An additional feature is provided to establish code in the Session. See the [DyalogStartupSE](../../../windows-installation-and-configuration-guide/configuration-parameters/dyalogstartupse) parameter.
+An additional feature is provided to establish code in the Session; for more information, see the [DyalogStartupSE](../../../windows-installation-and-configuration-guide/configuration-parameters/dyalogstartupse) configuration parameter.
 
 You may use all of the standard GUI system functions to build or configure the components of the Session to your own requirements. You may also control the Session by changing certain of its properties.
 


### PR DESCRIPTION
As #434 says, [Session Object](https://dyalog.github.io/documentation/20.0/windows-ui-guide/the-session-object/session-object) is missing the end of a sentence.

Add the missing words