### PR TITLE
PDF fixes

### DIFF
--- a/pdf/config.json
+++ b/pdf/config.json
@@ -5,7 +5,7 @@
             "subtitle": "Reference Guide",
             "filename": "Dyalog_APL_Language_Reference_Guide.pdf"
         },
-        "dotnet-framework-interface": {
+        "net-framework-interface-guide": {
             "title": "Dyalog for Microsoft Windows",
             "subtitle": ".NET Framework Interface Guide",
             "filename": "Dyalog_for_Microsoft_Windows_dotNET_Framework_Interface_Guide.pdf"


### PR DESCRIPTION
Try to keep up with the structural changes of the documentation

- Skip frontmatter
- Better detection of cross-doc vs internal links 
- Detect references to .../files/... which should be converted to actual https://... links as they only exist post-build

References: #611 