### PR TITLE
Slash and slash-bar disambig pages broken links

### DIFF
--- a/language-reference-guide/docs/symbols/slash-bar.md
+++ b/language-reference-guide/docs/symbols/slash-bar.md
@@ -27,7 +27,7 @@ Dyadic Slash Bar means
 Slash Bar is a monadic operator with a dyadic operand
 
 Operator Slash Bar means
-[Reduce First,  Reduce First N-Wise ](../primitive-operators/reduce-first.md)
+[Reduce First,  Reduce First N-Wise ](../primitive-operators/reduce-first/index.md)
 ```apl
       +⌿ mat
 15 18 21 24

--- a/language-reference-guide/docs/symbols/slash.md
+++ b/language-reference-guide/docs/symbols/slash.md
@@ -23,7 +23,7 @@ Hat
 Slash is a monadic operator with a dyadic operand
 
 Operator Slash means
-[Reduce](../primitive-operators/reduce.md), [N-Wise Reduce](../primitive-operators/reduce/reduce-n-wise.md)
+[Reduce](../primitive-operators/reduce/index.md), [N-Wise Reduce](../primitive-operators/reduce/reduce-n-wise.md)
 ```apl
       +/ 1 2 3 4 5
 15


### PR DESCRIPTION
The diambiguation pages for slash and slash-bar had broken links following a recent re-org.