### PR TITLE
Update hint box formatting in release notes announcements

### DIFF
--- a/release-notes/docs/announcements/index.md
+++ b/release-notes/docs/announcements/index.md
@@ -41,8 +41,8 @@ Images of docker containers that host Dyalog running on ARM64 Linux are availabl
 
 The rules around whether a function can be fixed have been tightened to prevent dfns with unmatched parentheses and brackets from being fixed. This is to accommodate array notation, which changes the meaning of parentheses and brackets that span more than one statement. TradFns will continue to fix as before, but subtle differences in how the code behaves might not be backwards-compatible and could have unexpected results.
 
-    !!! Hint "Hints and Recommendations"
-        If the enhanced restrictions cause problems for you, please contact [support@dyalog.com](mailto:support@dyalog.com) to discuss tools and techniques for mitigation.
+!!! Hint "Hints and Recommendations"
+    If the enhanced restrictions cause problems for you, please contact [support@dyalog.com](mailto:support@dyalog.com) to discuss tools and techniques for mitigation.
 
 ## Removals (Previously Announced)
 


### PR DESCRIPTION
A tab on the line caused it to show up as a codebox, rather than a hint box/panel.

Fixes #639 