### PR TITLE
#Fix 645 by mentioning triggers under ⎕EX

### DIFF
--- a/language-reference-guide/docs/system-functions/ex.md
+++ b/language-reference-guide/docs/system-functions/ex.md
@@ -84,4 +84,4 @@ If the named object is the last remaining external function of an auxiliary proc
 If the named object is the last reference into a dynamic link library, the DLL is freed.
 
 
-If the named object is a [Trigger](../../../programming-reference-guide/triggers/triggers.md), the name is disconnected from the Trigger Function and the Trigger Function will not be invoked when the Trigger is reassigned. The connection may be re-established by re-fixing the Trigger Function.
+If the named object is a [Trigger](../../../programming-reference-guide/triggers/triggers.md), the name is disconnected from the Trigger Function and the Trigger Function will not be invoked when the Trigger is reassigned. The connection can be re-established by re-fixing the Trigger Function.


### PR DESCRIPTION
Note that this behaviour already [documented for Triggers](https://docs.dyalog.com/20.0/programming-reference-guide/triggers/triggers/#:~:text=Expunging,Function):

> Expunging a Trigger disconnects the name from the Trigger Function

This PR only adds mention under `⎕EX`. `)ED` references already links to `⎕EX` for side-effects like this one.