### PR TITLE
Stop implying that bracket axis/indexing is operator/function

### DIFF
--- a/language-reference-guide/docs/other-syntax/axis/axis-with-dyadic-operand.md
+++ b/language-reference-guide/docs/other-syntax/axis/axis-with-dyadic-operand.md
@@ -2,9 +2,9 @@
 <h1 class="heading"><span class="name">Axis (with Dyadic Operand)</span> <span class="command">R←Xf[B]Y</span></h1>
 
 
-`f` must be a dyadic primitive scalar function, or a dyadic primitive mixed function taken from [](#DyadicMixed) below. `B` must be a numeric scalar or vector. `X` and `Y` may be any arrays whose items are appropriate to function `f`. Axis does not follow the normal syntax of an operator.
+`f` must be a dyadic primitive scalar function, or a dyadic primitive mixed function taken from [](#DyadicMixed) below. `B` must be a numeric scalar or vector. `X` and `Y` may be any arrays whose items are appropriate to function `f`.
 
-
+For an alternative method of applying any function to a subset of axes, see [Rank](../primitive-operators/rank.md).
 
 Table: Primitive dyadic mixed functions with optional axis. {: #DyadicMixed }
 
@@ -31,6 +31,7 @@ Exceptionally, `B` must be a fractional value for the Laminate function (`,`) wh
 `⎕IO` is an implicit argument of the derived function which determines the meaning of `B`.
 
 <h2 class="example">Examples</h2>
+
 ```apl
       1 4 5 =[1] 3 2⍴⍳6
 1 0
@@ -60,7 +61,7 @@ ABC
 ## Axis with Scalar Dyadic Functions
 
 
-The axis operator `[X]` can take a scalar dyadic function as operand. This has the effect of "stretching" a lower rank array to fit a higher rank one. The arguments must be conformable along the specified axis (or axes) with elements of the lower rank array being replicated along the other axes.
+Axis `[X]` can take a scalar dyadic function as operand. This has the effect of "stretching" a lower rank array to fit a higher rank one. The arguments must be conformable along the specified axis (or axes) with elements of the lower rank array being replicated along the other axes.
 
 
 For example, if `H` is the higher rank array, `L` the lower rank one, `X` is an axis specification, and `f` a scalar dyadic function, then the expressions `Hf[X]L` and `Lf[X]H` are conformable if `(⍴L)←→(⍴H)[X]`. Each element of L is replicated along the remaining `(⍴H)~X` axes of `H`.
@@ -109,9 +110,8 @@ In the special case where both arguments have the same rank, the right one will 
               
  710  820  930
 1040 1150 1260
- 
-
 ```
+
 ```apl
       cube+[1 3]mat
  110  220  330

--- a/language-reference-guide/docs/other-syntax/axis/axis-with-monadic-operand.md
+++ b/language-reference-guide/docs/other-syntax/axis/axis-with-monadic-operand.md
@@ -2,9 +2,9 @@
 <h1 class="heading"><span class="name">Axis (with Monadic Operand)</span> <span class="command">R←f[B]Y</span></h1>
 
 
-`f` must be a monadic primitive mixed function taken from those shown in [](#MonadicMixed) below, or a function derived from the operators Reduction (`/`) or Scan (`\`). `B` must be a numeric scalar or vector. `Y` may be any array whose items are appropriate to function `f`. Axis does not follow the normal syntax of an operator.
+`f` must be a monadic primitive mixed function taken from those shown in [](#MonadicMixed) below, or a function derived from the operators Reduction (`/`) or Scan (`\`). `B` must be a numeric scalar or vector. `Y` may be any array whose items are appropriate to function `f`.
 
-
+For an alternative method of applying any function to a subset of axes, see [Rank](../primitive-operators/rank.md).
 
 Table: Primitive monadic mixed functions with optional axis. {: #MonadicMixed }
 
@@ -18,7 +18,7 @@ Table: Primitive monadic mixed functions with optional axis. {: #MonadicMixed }
 |`⊂`|Enclose|`(B≡⍳0)∨(^/B∊⍳⍴⍴Y)`|
 
 
-In most cases, `B` must be an integer which identifies a specific axis of `Y`. However, when  `f` is the Mix function (`↑`),   `B` is a fractional value whose lower and upper integer bounds select an adjacent pair of axes of `Y` or an extreme axis of `Y`.
+In most cases, `B` must be an integer which identifies a specific axis of `Y`. However, when  `f` is the Mix function (`↑`),   `B` can be a fractional value whose lower and upper integer bounds select an adjacent pair of axes of `Y` or an extreme axis of `Y`.
 
 
 For Ravel (`,`) and Enclose (`⊂`), `B` can be a **vector** of two or more axes.
@@ -32,7 +32,7 @@ For Ravel (`,`) and Enclose (`⊂`), `B` can be a **vector** of two or more axes
 4 5 6
 1 2 3
  
-      ↑[.1]'ONE' 'TWO'
+      ↑[0.1]'ONE' 'TWO'
 OT
 NW
 EO

--- a/language-reference-guide/docs/other-syntax/indexing.md
+++ b/language-reference-guide/docs/other-syntax/indexing.md
@@ -7,7 +7,7 @@ search:
 
 `X` may be  any array. `Y` must be a valid index specification. `R` is an array composed of elements indexed from `X` and the shape of `R` is determined by the index specification.
 
-This form of Indexing, using brackets, does not follow the normal syntax of a dyadic function. For an alternative method of indexing, see [Index](../primitive-functions/index-function/index.md).
+For an alternative method of indexing, see [Index](../primitive-functions/index-function/index.md).
 
 `⎕IO` is an implicit argument of Indexing.
 


### PR DESCRIPTION
Also adds references to `⍤` in the same vein as bracket indexing currently has a reference to `⌷`.