### PR TITLE
Fix table refs by making minify plugin run last (#630)

### DIFF
--- a/earlier-release-notes/mkdocs.yml
+++ b/earlier-release-notes/mkdocs.yml
@@ -27,6 +27,8 @@ plugins:
         start_index: 1
         increment_index: 1
         position: bottom
+        reference_text: 'Table {index}'
+        caption_prefix: 'Table {index}:' 
 extra:
   version_maj: 20
   version_majmin: 20.0

--- a/interface-guide/mkdocs.yml
+++ b/interface-guide/mkdocs.yml
@@ -28,6 +28,8 @@ plugins:
         start_index: 1
         increment_index: 1
         position: bottom
+        reference_text: 'Table {index}'
+        caption_prefix: 'Table {index}:' 
 extra:
   version_maj: 20
   version_majmin: 20.0

--- a/language-reference-guide/docs/primitive-operators/operators-summarised.md
+++ b/language-reference-guide/docs/primitive-operators/operators-summarised.md
@@ -5,11 +5,11 @@ search:
 
 <h1 class="heading"><span class="name"> Operators Summarised</span></h1>
 
-[](#MonadicOperators) and [](#DyadicOperators) below summarise the Monadic and Dyadic primitive operators whose detailed descriptions  follow in alphabetical order in this section.
+[](#monadic-operators) and [](#dyadic-operators) below summarise the Monadic and Dyadic primitive operators whose detailed descriptions  follow in alphabetical order in this section.
 
 Some operators may include an axis specification (indicated `[]`in the tables). Note that in these case `⎕IO` is an implicit argument of the derived function.
 
-Table: Monadic Primitive Operators {: #MonadicOperators }
+Table: Monadic Primitive Operators { #monadic-operators }
 
 |Name                           |Producing Monadic derived function|Producing Dyadic derived function|
 |-------------------------------|----------------------------------|---------------------------------|
@@ -26,7 +26,7 @@ Table: Monadic Primitive Operators {: #MonadicOperators }
 |Scan First                     |`f⍀Y  [ ]`                        |&nbsp;                           |
 |Spawn                          |`f&Y`                             |`Xf&Y`                           |
 
-Table: Dyadic Primitive Operators {: #DyadicOperators }
+Table: Dyadic Primitive Operators { #dyadic-operators }
 
 | Name         |Producing Monadic derived function| Producing Dyadic derived function |
 |--------------|----------------------------------|-----------------------------------|

--- a/language-reference-guide/mkdocs.yml
+++ b/language-reference-guide/mkdocs.yml
@@ -28,6 +28,8 @@ plugins:
         start_index: 1
         increment_index: 1
         position: bottom
+        reference_text: 'Table {index}'
+        caption_prefix: 'Table {index}:'
 extra:
   version_maj: 20
   version_majmin: 20.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,14 +30,16 @@ plugins:
   - search
   - macros
   - monorepo
-  - minify:
-      minify_html: true
   - caption:
-      table: 
+      table:
         enable: true
         start_index: 1
         increment_index: 1
         position: bottom
+        reference_text: 'Table {index}'
+        caption_prefix: 'Table {index}:'
+  - minify:
+      minify_html: true
 
 extra:
   version_maj: 20

--- a/net-framework-interface-guide/mkdocs.yml
+++ b/net-framework-interface-guide/mkdocs.yml
@@ -28,6 +28,8 @@ plugins:
         start_index: 1
         increment_index: 1
         position: bottom
+        reference_text: 'Table {index}'
+        caption_prefix: 'Table {index}:' 
 extra:
   version_maj: 20
   version_majmin: 20.0

--- a/object-reference/mkdocs.yml
+++ b/object-reference/mkdocs.yml
@@ -27,6 +27,8 @@ plugins:
         start_index: 1
         increment_index: 1
         position: bottom
+        reference_text: 'Table {index}'
+        caption_prefix: 'Table {index}:' 
 extra:
   version_maj: 20
   version_majmin: 20.0

--- a/programming-reference-guide/mkdocs.yml
+++ b/programming-reference-guide/mkdocs.yml
@@ -27,6 +27,8 @@ plugins:
         start_index: 1
         increment_index: 1
         position: bottom
+        reference_text: 'Table {index}'
+        caption_prefix: 'Table {index}:' 
 extra:
   version_maj: 20
   version_majmin: 20.0

--- a/release-notes/mkdocs.yml
+++ b/release-notes/mkdocs.yml
@@ -27,6 +27,8 @@ plugins:
         start_index: 1
         increment_index: 1
         position: bottom
+        reference_text: 'Table {index}'
+        caption_prefix: 'Table {index}:' 
 extra:
   version_maj: 20
   version_majmin: 20.0

--- a/unix-installation-and-configuration-guide/mkdocs.yml
+++ b/unix-installation-and-configuration-guide/mkdocs.yml
@@ -27,6 +27,8 @@ plugins:
         start_index: 1
         increment_index: 1
         position: bottom
+        reference_text: 'Table {index}'
+        caption_prefix: 'Table {index}:' 
 extra:
   version_maj: 20
   version_majmin: 20.0

--- a/unix-user-guide/mkdocs.yml
+++ b/unix-user-guide/mkdocs.yml
@@ -27,6 +27,8 @@ plugins:
         start_index: 1
         increment_index: 1
         position: bottom
+        reference_text: 'Table {index}'
+        caption_prefix: 'Table {index}:' 
 extra:
   version_maj: 20
   version_majmin: 20.0

--- a/windows-installation-and-configuration-guide/mkdocs.yml
+++ b/windows-installation-and-configuration-guide/mkdocs.yml
@@ -27,6 +27,8 @@ plugins:
         start_index: 1
         increment_index: 1
         position: bottom
+        reference_text: 'Table {index}'
+        caption_prefix: 'Table {index}:' 
 extra:
   version_maj: 20
   version_majmin: 20.0

--- a/windows-ui-guide/mkdocs.yml
+++ b/windows-ui-guide/mkdocs.yml
@@ -28,6 +28,8 @@ plugins:
         start_index: 1
         increment_index: 1
         position: bottom
+        reference_text: 'Table {index}'
+        caption_prefix: 'Table {index}:' 
 extra:
   version_maj: 20
   version_majmin: 20.0


### PR DESCRIPTION
- Minify plugin removes quotes around ids, which the table captioning regexes rely on to do forward references. 
- Solution: reorder plugins to minify after captioning
- Add explicit table captioning texts to all configs