### PR TITLE
Correct Hydrant row in primitive functions table

### DIFF
--- a/language-reference-guide/docs/primitive-functions/index.md
+++ b/language-reference-guide/docs/primitive-functions/index.md
@@ -56,7 +56,7 @@ search:
 |`⌹`|Domino|[Matrix Inverse](matrix-inverse.md)|[Matrix Divide](matrix-divide.md)|
 |`⊢`|Right Tack|[Same](same.md)|[Right](right.md)|
 |`⊣`|Left Tack|[Same](same.md)|[Left](left.md)|
-|`⍕`|Hydrant|[Format](format.md)|[Format by Specification](format-by-specification.md)
+|`⍎`|Hydrant|[Execute](execute.md)|[Dyadic Execute](dyadic-execute.md)
 |`⍕`|Thorn|[Format](format.md)|[Format by Specification](format-by-specification.md)|
 |`/`|Slash|&nbsp;|[Replicate](replicate.md)
 |`⌿`|Slash Bar|&nbsp;|[Replicate First](replicate-first.md)


### PR DESCRIPTION
As #673 describes, the Hydrant row is incorrect