### PR TITLE
Be specific when deleting .git-hash

### DIFF
--- a/tools/jenkins/Jenkinsfile
+++ b/tools/jenkins/Jenkinsfile
@@ -256,7 +256,7 @@ pipeline {
                             ## Force docs/20.0 so we don't overwrite older versions
                             if [ -d "${WEB_ROOT}" ]; then
                                 rm -rf "${WEB_ROOT}"/20.0/*
-                                rm "${WEB_ROOT}"/.git-hash
+                                rm -f "${WEB_ROOT}"/.git-hash
                             else
                                 mkdir -p "${WEB_ROOT}/20.0"
                             fi


### PR DESCRIPTION
The line

```
rm -rf "${WEB_ROOT}"/.[^.]*  2>/dev/null || true
```

had unintended consequences. Changed to 

```
rm "${WEB_ROOT}"/.git-hash
```