### PR TITLE
Remove footnote in at documentation

### DIFF
--- a/language-reference-guide/docs/primitive-operators/at.md
+++ b/language-reference-guide/docs/primitive-operators/at.md
@@ -26,7 +26,7 @@ Replace the 2nd and 4th items of `⍳5`:
 1 10 3 20 5
 ```
 
-Note that in the previous example, no parentheses are required as the array `2 4` binds to the `@` operator rather than the `⍳` function as [operator-array binding is stronger than function-array binding](programming-reference-guide/introduction/binding-strength).
+The parentheses in the previous example are included to aid comprehension but are not required as the array `2 4` binds to the `@` operator rather than the `⍳` function due to [operator-array binding being stronger than function-array binding](programming-reference-guide/introduction/binding-strength):
 ```apl
       10 20@2 4⍳5
 1 10 3 20 5


### PR DESCRIPTION
As #439 discusses, remove the footnote in codeblocks