### PR TITLE
Reduce First N-Wise links to Reduce First rather than Reduce N-Wise

### DIFF
--- a/language-reference-guide/docs/primitive-operators/reduce-first/reduce-first-n-wise.md
+++ b/language-reference-guide/docs/primitive-operators/reduce-first/reduce-first-n-wise.md
@@ -9,4 +9,4 @@ search:
 
 <h1 class="heading"><span class="name">Reduce First N-Wise</span> <span class="command">R←Xf⌿[K]Y</span></h1>
 
-The form `R←Xf⌿Y` implies N-Wise reduction along the first axis of `Y`. See [Reduce N-Wise](index.md).
+The form `R←Xf⌿Y` implies N-Wise reduction along the first axis of `Y`. See [Reduce N-Wise](../reduce/reduce-n-wise.md).


### PR DESCRIPTION
As #689 states, Reduce First N-Wise incorrectly links to Reduce First rather than Reduce N-Wise