### PR TITLE
Remove dead link to "Language Elements"

### DIFF
--- a/language-reference-guide/docs/system-functions/dr.md
+++ b/language-reference-guide/docs/system-functions/dr.md
@@ -31,8 +31,3 @@ search:
 0 0 0 0 1 0 1 0
 
 ```
-
-
-[Language Elements](../symbols/language-elements.md)
-
-

--- a/language-reference-guide/docs/system-functions/fmt.md
+++ b/language-reference-guide/docs/system-functions/fmt.md
@@ -30,8 +30,3 @@ search:
   1 2.00  3 4.00
   5 6.00  7 8.00
 ```
-
-
-[Language Elements](../symbols/language-elements.md)
-
-

--- a/language-reference-guide/docs/system-functions/monitor.md
+++ b/language-reference-guide/docs/system-functions/monitor.md
@@ -33,8 +33,3 @@ search:
 4 1  467 1000 0
 5 1  100    0 0
 ```
-
-
-[Language Elements](../symbols/language-elements.md)
-
-

--- a/language-reference-guide/docs/system-functions/sh.md
+++ b/language-reference-guide/docs/system-functions/sh.md
@@ -31,8 +31,3 @@ clear ws
 avx     box     dbr     getenv  hex     ltom    ltov    mtol    ss      vtol
 
 ```
-
-
-[Language Elements](../symbols/language-elements.md)
-
-

--- a/language-reference-guide/docs/system-functions/stop.md
+++ b/language-reference-guide/docs/system-functions/stop.md
@@ -27,8 +27,3 @@ search:
       ⎕STOP 'FOO'
 0 1
 ```
-
-
-[Language Elements](../symbols/language-elements.md)
-
-

--- a/language-reference-guide/docs/system-functions/svc.md
+++ b/language-reference-guide/docs/system-functions/svc.md
@@ -28,8 +28,3 @@ search:
       ⎕SVC 'X'
 1 1 1 1
 ```
-
-
-[Language Elements](../symbols/language-elements.md)
-
-

--- a/language-reference-guide/docs/system-functions/svo.md
+++ b/language-reference-guide/docs/system-functions/svo.md
@@ -32,8 +32,3 @@ search:
       ⎕SVO 'DATA'
 1
 ```
-
-
-[Language Elements](../symbols/language-elements.md)
-
-

--- a/language-reference-guide/docs/system-functions/trace.md
+++ b/language-reference-guide/docs/system-functions/trace.md
@@ -27,8 +27,3 @@ search:
       ⎕TRACE 'foo'
 0 1 2 3 4 5
 ```
-
-
-[Language Elements](../symbols/language-elements.md)
-
-

--- a/language-reference-guide/docs/system-functions/xt.md
+++ b/language-reference-guide/docs/system-functions/xt.md
@@ -26,8 +26,3 @@ search:
       ⎕XT'V'
 EXT\ARRAY
 ```
-
-
-[Language Elements](../symbols/language-elements.md)
-
-


### PR DESCRIPTION
As #655 states, remove the dead links to the "Language Elements" page