### PR TITLE
Remove stray JSON reference in Format Date-Time I-Beam

### DIFF
--- a/language-reference-guide/docs/primitive-operators/i-beam/format-datetime.md
+++ b/language-reference-guide/docs/primitive-operators/i-beam/format-datetime.md
@@ -378,7 +378,7 @@ few elements) an error is signalled only if the missing content would actually b
 
 ## Example dictionary
 
-The following creates a dictionary defined by the namespace `dict` using JSON text. See the formatting examples below
+The following creates a dictionary defined by the namespace `dict`. See the formatting examples below
 for uses of this dictionary.
 
 ```apl


### PR DESCRIPTION
Remove the stray JSON reference left from #226 as #738 describes.
