### PR TITLE
Add Full Release workflow (assets + site in one run)

### DIFF
--- a/.github/workflows/full-release.yml
+++ b/.github/workflows/full-release.yml
@@ -1,0 +1,30 @@
+name: Full Release (Assets + Site)
+
+on:
+  workflow_dispatch:
+    inputs:
+      set_as_latest:
+        description: 'Set this version as the default/latest (tick when releasing v21 to production)'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  pages: write
+
+jobs:
+  build-assets:
+    uses: ./.github/workflows/mkdocs-pdf.yml
+    with:
+      generate_pdf: true
+      generate_chm: true
+      publish_release: true
+    secrets: inherit
+
+  publish-site:
+    needs: build-assets
+    uses: ./.github/workflows/mkdocs-publish.yml
+    with:
+      set_as_latest: ${{ inputs.set_as_latest }}
+    secrets: inherit

--- a/.github/workflows/mkdocs-pdf.yml
+++ b/.github/workflows/mkdocs-pdf.yml
@@ -11,6 +11,18 @@ on:
         description: 'Generate CHM help file'
         type: boolean
         default: true
+  workflow_call:
+    inputs:
+      generate_pdf:
+        type: boolean
+        default: true
+      generate_chm:
+        type: boolean
+        default: true
+      publish_release:
+        description: 'Publish release immediately instead of as a draft'
+        type: boolean
+        default: false
 
 jobs:
   convert-docs:
@@ -224,12 +236,20 @@ jobs:
         PARTS=$(echo $PARTS | xargs)
         RELEASE_NAME="Documentation ${PARTS} $RELEASE_TAG"
         NOTES="Documentation ${PARTS} generated from ${{ steps.git-info.outputs.GIT_INFO }}"
-        
-        echo "Creating new draft release: $RELEASE_TAG"
-        
-        # Create a draft release with current syntax
+
+        # When called from the Full Release workflow, publish_release=true
+        # and we skip the draft step so Jenkins can immediately pick up the assets.
+        DRAFT_FLAG="--draft"
+        RELEASE_TYPE="draft"
+        if [ "${{ inputs.publish_release }}" = "true" ]; then
+          DRAFT_FLAG=""
+          RELEASE_TYPE="published"
+        fi
+
+        echo "Creating new ${RELEASE_TYPE} release: $RELEASE_TAG"
+
         gh release create "$RELEASE_TAG" \
           $ASSETS \
-          --draft \
+          $DRAFT_FLAG \
           --title "$RELEASE_NAME" \
           --notes "$NOTES"

--- a/.github/workflows/mkdocs-publish.yml
+++ b/.github/workflows/mkdocs-publish.yml
@@ -13,6 +13,14 @@ on:
         required: false
         default: false
         type: boolean
+  workflow_call:
+    inputs:
+      version_override:
+        type: string
+        default: ''
+      set_as_latest:
+        type: boolean
+        default: false
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Adds a new \`full-release.yml\` workflow that chains the existing PDF/CHM asset build and the site publish into a single Actions run, so an author doesn't have to manually sequence: run asset workflow → un-draft the release → run publish workflow.

The two existing workflows gain \`workflow_call\` triggers alongside their existing \`workflow_dispatch\`, so they continue to work standalone with no behaviour change. \`mkdocs-pdf.yml\` also gains a \`publish_release\` input (default \`false\`, so standalone behaviour is unchanged — still creates a draft); when \`true\` (only set by the Full Release workflow), the release is created published rather than as a draft.

## How it runs

- **Actions → Full Release (Assets + Site)** → select branch (\`main\` or \`v20.0\`) → run.
- Optional \`set_as_latest\` input, same meaning as in \`mkdocs-publish.yml\` — tick only when releasing v21 to production.
- Builds PDF + CHM, publishes the release (not draft), runs \`mike deploy\`. Jenkins picks up gh-pages on its next poll and uses the just-published release assets.

## What's unchanged

- \`mkdocs-pdf.yml\` standalone still creates a draft; no forced workflow change for authors.
- \`mkdocs-publish.yml\` standalone behaves identically.
- No version input on Full Release — it's auto-detected from \`mkdocs.yml\` via the called workflows, same as today.

## Follow-up

After merge, apply the same three-file change to \`v20.0\` (cherry-pick this commit) so the Full Release button exists there too. Happy to do that in a follow-up PR.

## Test plan

- [ ] Merge this PR
- [ ] Run "Full Release" from \`main\` — expect a new published release \`v21.0.N\` and \`/21.0/\` updated on staging; production unaffected
- [ ] Verify \`mkdocs-pdf.yml\` standalone still produces drafts
- [ ] Verify \`mkdocs-publish.yml\` standalone still works
- [ ] Cherry-pick to \`v20.0\` and smoke-test a v20 full release