### PR TITLE
Backport Full Release workflow to v20.0

### DIFF
--- a/.github/workflows/full-release.yml
+++ b/.github/workflows/full-release.yml
@@ -1,0 +1,30 @@
+name: Full Release (Assets + Site)
+
+on:
+  workflow_dispatch:
+    inputs:
+      set_as_latest:
+        description: 'Set this version as the default/latest (tick when releasing v21 to production)'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  pages: write
+
+jobs:
+  build-assets:
+    uses: ./.github/workflows/mkdocs-pdf.yml
+    with:
+      generate_pdf: true
+      generate_chm: true
+      publish_release: true
+    secrets: inherit
+
+  publish-site:
+    needs: build-assets
+    uses: ./.github/workflows/mkdocs-publish.yml
+    with:
+      set_as_latest: ${{ inputs.set_as_latest }}
+    secrets: inherit

--- a/.github/workflows/mkdocs-pdf.yml
+++ b/.github/workflows/mkdocs-pdf.yml
@@ -11,6 +11,18 @@ on:
         description: 'Generate CHM help file'
         type: boolean
         default: true
+  workflow_call:
+    inputs:
+      generate_pdf:
+        type: boolean
+        default: true
+      generate_chm:
+        type: boolean
+        default: true
+      publish_release:
+        description: 'Publish release immediately instead of as a draft'
+        type: boolean
+        default: false
 
 jobs:
   convert-docs:
@@ -224,12 +236,20 @@ jobs:
         PARTS=$(echo $PARTS | xargs)
         RELEASE_NAME="Documentation ${PARTS} $RELEASE_TAG"
         NOTES="Documentation ${PARTS} generated from ${{ steps.git-info.outputs.GIT_INFO }}"
-        
-        echo "Creating new draft release: $RELEASE_TAG"
-        
-        # Create a draft release with current syntax
+
+        # When called from the Full Release workflow, publish_release=true
+        # and we skip the draft step so Jenkins can immediately pick up the assets.
+        DRAFT_FLAG="--draft"
+        RELEASE_TYPE="draft"
+        if [ "${{ inputs.publish_release }}" = "true" ]; then
+          DRAFT_FLAG=""
+          RELEASE_TYPE="published"
+        fi
+
+        echo "Creating new ${RELEASE_TYPE} release: $RELEASE_TAG"
+
         gh release create "$RELEASE_TAG" \
           $ASSETS \
-          --draft \
+          $DRAFT_FLAG \
           --title "$RELEASE_NAME" \
           --notes "$NOTES"

--- a/.github/workflows/mkdocs-publish.yml
+++ b/.github/workflows/mkdocs-publish.yml
@@ -13,6 +13,14 @@ on:
         required: false
         default: false
         type: boolean
+  workflow_call:
+    inputs:
+      version_override:
+        type: string
+        default: ''
+      set_as_latest:
+        type: boolean
+        default: false
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Cherry-pick of the Full Release workflow from #764 onto \`v20.0\` so the chained asset+site release button exists on the maintenance branch too.

Same three files as #764 (new \`full-release.yml\`, \`workflow_call\` triggers added to \`mkdocs-pdf.yml\` and \`mkdocs-publish.yml\`). The \`--init\` submodule flag on this branch was preserved through the auto-merge.

## Test plan

- [ ] Merge this PR
- [ ] Run "Full Release" from \`v20.0\` — expect new published release \`v20.0.N\` (CHM + PDFs), \`/20.0/\` updated on staging, and Jenkins picks up the new assets on its next poll