### PR TITLE
Add CONTRIBUTING.md for v20/v21 branch workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,94 @@
+# Contributing to the Dyalog documentation
+
+The documentation repo has two active branches:
+
+- **`main`** — v21 (new content, in development)
+- **`v20.0`** — v20 (maintenance)
+
+Your PRs need to target the right one. Pick the scenario that matches your change.
+
+## (1) Fixing something v20-specific
+
+Examples: typo in a v20 release note, broken link in existing v20 content, clarifying a v20-only quirk.
+
+**Shape:** branch from `v20.0`, commit your fix, PR against `v20.0`.
+
+**Via GitHub UI (easiest for small edits):**
+
+1. Before editing, make sure you're viewing the file on the `v20.0` branch (the URL will contain `/blob/v20.0/`, not `/blob/main/`). Use the branch dropdown at the top-left of the file tree to switch.
+2. Click the pencil icon, edit, commit to a new branch.
+3. The PR form opens. **Check the base branch dropdown — it must be `v20.0`, not `main`.** Submit.
+
+**Via command line:**
+
+```
+git checkout v20.0
+git pull
+git checkout -b fix-typo-v20
+# edit files
+git add -u && git commit -m "Fix typo in foo.md"
+git push -u origin fix-typo-v20
+```
+
+On the PR form on GitHub, change the base branch dropdown from `main` to `v20.0` before submitting.
+
+## (2) Fixing something relevant to both v20 and v21
+
+Examples: typo in shared content, fix to an API description that both versions document.
+
+**Shape:** fix it on `v20.0` first (lower risk, hits production soonest), then forward-port to `main`. Two PRs.
+
+**Step 1:** fix on `v20.0` exactly as in scenario (1). Merge it.
+
+**Step 2:** once step 1 is merged, bring the same change to `main`:
+
+```
+git checkout main
+git pull
+git checkout -b fix-typo-v21
+git cherry-pick <hash-of-the-v20-merge-commit>
+git push -u origin fix-typo-v21
+```
+
+To find the hash: on the merged v20 PR, copy the merge-commit SHA shown in the conversation view. Or run `git log --oneline origin/v20.0 -5`.
+
+Then PR against `main`.
+
+**If the cherry-pick conflicts** (because v21 content has drifted from v20), either resolve the conflict and continue (`git cherry-pick --continue`), or abort (`git cherry-pick --abort`) and just apply the change manually on a fresh branch from `main`.
+
+**Shortcut for simple, obviously-clean fixes:** skip the cherry-pick and do both PRs in parallel — one branch from `v20.0` targeting `v20.0`, another from `main` targeting `main`, same edits.
+
+## (3) Writing something only for v21
+
+Examples: new feature documentation, new language reference content, anything not relevant to v20.
+
+**Shape:** branch from `main`, PR against `main`. This is the workflow you already know.
+
+```
+git checkout main
+git pull
+git checkout -b feature-xyz
+# write content
+git add -u && git commit -m "Document feature xyz"
+git push -u origin feature-xyz
+```
+
+PR base defaults to `main`, so nothing special to set.
+
+## Quick reference
+
+| What you're changing | Branch from | PR base |
+|---|---|---|
+| v20 only | `v20.0` | `v20.0` |
+| Both v20 and v21 | `v20.0` then `main` | two PRs: one against each |
+| v21 only | `main` | `main` |
+
+## Common mistakes to watch for
+
+- **PRing the wrong base.** GitHub's PR form defaults the base to `main`. For a v20 fix you must change it to `v20.0` before submitting — there's no warning if you get it wrong, it'll just merge into the wrong version.
+- **Branching from the wrong base.** `git checkout -b my-fix` branches off whatever you're currently on. Always `git checkout <base> && git pull` first.
+- **Editing a file on `main` when you meant `v20.0` (or vice versa).** When using the GitHub UI to edit, verify the branch in the file URL before clicking the pencil.
+
+## If in doubt
+
+Raise the PR against whatever seems closest, and say in the PR description that you're unsure whether the change should also go to the other branch. We can sort it out in review.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,27 +36,25 @@ On the PR form on GitHub, change the base branch dropdown from `main` to `v20.0`
 
 Examples: typo in shared content, fix to an API description that both versions document.
 
-**Shape:** fix it on `v20.0` first (lower risk, hits production soonest), then forward-port to `main`. Two PRs.
+**Shape:** make the change commit on `main` (where v21 development lives), then apply the same commit to `v20.0` via a cherry-pick. Two PRs — one against each branch — and the v20 PR contains the exact commit that was merged to `main`.
 
-**Step 1:** fix on `v20.0` exactly as in scenario (1). Merge it.
+**Step 1:** make the change on `main` as in scenario (3). Merge it.
 
-**Step 2:** once step 1 is merged, bring the same change to `main`:
+**Step 2:** once step 1 is merged, apply the same commit to `v20.0`:
 
 ```
-git checkout main
+git checkout v20.0
 git pull
-git checkout -b fix-typo-v21
-git cherry-pick <hash-of-the-v20-merge-commit>
-git push -u origin fix-typo-v21
+git checkout -b fix-typo-v20
+git cherry-pick <hash-of-the-main-merge-commit>
+git push -u origin fix-typo-v20
 ```
 
-To find the hash: on the merged v20 PR, copy the merge-commit SHA shown in the conversation view. Or run `git log --oneline origin/v20.0 -5`.
+To find the hash: on the merged `main` PR, copy the merge-commit SHA shown in the conversation view. Or run `git log --oneline origin/main -5`.
 
-Then PR against `main`.
+Then open a PR **against `v20.0`** (remember to change the base branch dropdown).
 
-**If the cherry-pick conflicts** (because v21 content has drifted from v20), either resolve the conflict and continue (`git cherry-pick --continue`), or abort (`git cherry-pick --abort`) and just apply the change manually on a fresh branch from `main`.
-
-**Shortcut for simple, obviously-clean fixes:** skip the cherry-pick and do both PRs in parallel — one branch from `v20.0` targeting `v20.0`, another from `main` targeting `main`, same edits.
+**If the cherry-pick conflicts** (because v20 content has drifted from v21), either resolve the conflict and continue (`git cherry-pick --continue`), or abort (`git cherry-pick --abort`) and just apply the change manually on a fresh branch from `v20.0`.
 
 ## (3) Writing something only for v21
 
@@ -80,7 +78,7 @@ PR base defaults to `main`, so nothing special to set.
 | What you're changing | Branch from | PR base |
 |---|---|---|
 | v20 only | `v20.0` | `v20.0` |
-| Both v20 and v21 | `v20.0` then `main` | two PRs: one against each |
+| Both v20 and v21 | `main` then cherry-pick to `v20.0` | two PRs: one against each |
 | v21 only | `main` | `main` |
 
 ## Common mistakes to watch for


### PR DESCRIPTION
## Summary

Adds a CONTRIBUTING.md at the repo root explaining how technical authors should work with the two active branches now that v20 maintenance and v21 development run in parallel.

Covers three scenarios: v20-specific fix, fix relevant to both versions, v21-only content. Aimed at authors who know basic git (branch, commit, PR) but haven't worked with multiple base branches before — shows both GitHub-UI and CLI workflows, with a quick-reference table and common mistakes.

## Follow-up

After merge, cherry-pick to \`v20.0\` so the file exists on both branches (same pattern as the Full Release workflow). Happy to do that in a follow-up PR.