### PR TITLE
Pin mkdocs build dependencies (v20 cherry-pick)

### DIFF
--- a/.github/workflows/mkdocs-pdf.yml
+++ b/.github/workflows/mkdocs-pdf.yml
@@ -63,25 +63,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install \
-          mkdocs \
-          mkdocs-material \
-          weasyprint \
-          beautifulsoup4 \
-          markdown \
-          ruamel.yaml \
-          pygments \
-          pymdown-extensions \
-          markdown-tables-extended \
-          git+https://github.com/flywire/caption \
-          htmlmin \
-          csscompressor \
-          cssutils \
-          mkdocs-macros-plugin \
-          mkdocs-monorepo-plugin \
-          mkdocs-site-urls \
-          mkdocs-caption \
-          mkdocs-minify-plugin
+        pip install -r tools/requirements-docs.txt
 
     - name: Prepare directories
       run: |

--- a/.github/workflows/mkdocs-publish.yml
+++ b/.github/workflows/mkdocs-publish.yml
@@ -80,15 +80,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install \
-          mike \
-          mkdocs-material \
-          mkdocs-macros-plugin \
-          mkdocs-monorepo-plugin \
-          mkdocs-site-urls \
-          mkdocs-caption \
-          markdown-tables-extended \
-          mkdocs-minify-plugin
+        pip install -r tools/requirements-docs.txt
 
     - name: Get Git Info
       id: git-info

--- a/tools/mkdocs/Dockerfile
+++ b/tools/mkdocs/Dockerfile
@@ -4,14 +4,8 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     git
 
-RUN pip install \
-    mkdocs-material \
-    mkdocs-macros-plugin \
-    mkdocs-monorepo-plugin \
-    mkdocs-site-urls \
-    mkdocs-caption \
-    markdown-tables-extended \
-    mkdocs-minify-plugin
+COPY requirements-docs.txt /requirements-docs.txt
+RUN pip install -r /requirements-docs.txt
 
 RUN pip install --force-reinstall click==8.2.1
 

--- a/tools/nginx/Dockerfile
+++ b/tools/nginx/Dockerfile
@@ -14,19 +14,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && rm -f /etc/nginx/conf.d/default.conf
 
+COPY tools/requirements-docs.txt /requirements-docs.txt
+RUN pip install --no-cache-dir -r /requirements-docs.txt
+
+# Extras not referenced in mkdocs.yml — left unpinned pending a follow-up
+# that confirms whether they're still needed.
 RUN pip install --no-cache-dir \
-    mike \
-    mkdocs \
-    mkdocs-material \
-    mkdocs-monorepo-plugin \
-    mkdocs-macros-plugin \
-    mkdocs-minify-plugin \
-    mkdocs-caption \
     markdown-include \
-    pymdown-extensions \
-    mkdocs-git-revision-date-localized-plugin \
-    markdown-tables-extended \
-    mkdocs-site-urls
+    mkdocs-git-revision-date-localized-plugin
 
 # Copy nginx configuration
 COPY tools/nginx/nginx.conf /etc/nginx/nginx.conf

--- a/tools/requirements-docs.txt
+++ b/tools/requirements-docs.txt
@@ -1,0 +1,32 @@
+# Documentation build dependencies for the mkdocs-publish and mkdocs-pdf workflows.
+#
+# Pins match the versions installed in the last successful CI runs
+# (2026-04-22). Refresh this file deliberately by a PR that bumps versions
+# and verifies a clean build, rather than letting CI drift on every run.
+
+# Core mkdocs stack
+mkdocs==1.6.1
+mkdocs-material==9.7.6
+mike==2.2.0
+
+# mkdocs plugins referenced in mkdocs.yml
+mkdocs-macros-plugin==1.5.0
+mkdocs-monorepo-plugin==1.1.2
+mkdocs-site-urls==0.3.1
+mkdocs-caption==1.3.0
+mkdocs-minify-plugin==0.8.0
+markdown-tables-extended==0.1.3
+pymdown-extensions==10.21.2
+
+# PDF/CHM build dependencies (used by mkdocs-pdf workflow only)
+weasyprint==68.1
+beautifulsoup4==4.14.3
+markdown==3.10.2
+ruamel.yaml==0.19.1
+pygments==2.20.0
+htmlmin==0.1.12
+csscompressor==0.9.5
+cssutils==2.14.0
+
+# Git dep: pinned to a specific commit for reproducibility
+caption @ git+https://github.com/flywire/caption@68da7c5f2e14dc04d46494c752b377b2d58a2a54

--- a/tools/utils/Dockerfile
+++ b/tools/utils/Dockerfile
@@ -9,22 +9,16 @@ RUN apt-get update && apt-get install -y \
 # Create working directory
 WORKDIR /docs
 
-# Install Python dependencies for utils scripts
+# Install mkdocs stack from the pinned requirements file (shared with CI)
+COPY requirements-docs.txt /requirements-docs.txt
+RUN pip install --no-cache-dir -r /requirements-docs.txt
+
+# Utility-script-only dependencies, unrelated to mkdocs — left unpinned
 RUN pip install --no-cache-dir \
-    mkdocs \
-    mkdocs-material \
-    mkdocs-monorepo-plugin \
-    mkdocs-macros-plugin \
-    mkdocs-caption \
-    pymdown-extensions \
-    markdown-tables-extended \
-    ruamel.yaml \
-    beautifulsoup4 \
     aiohttp \
     lxml \
     Pillow \
-    watchdog \
-    markdown
+    watchdog
 
 # Copy utils scripts
 COPY utils /utils


### PR DESCRIPTION
## Summary
- Cherry-picks #767 (merge commit `b31bcbe45a`) onto `v20.0`.
- Pins the mkdocs build stack via `tools/requirements-docs.txt`, consumed by both CI workflows (`mkdocs-pdf.yml`, `mkdocs-publish.yml`) and the local build Dockerfiles (`tools/mkdocs`, `tools/nginx`, `tools/utils`).
