### PR TITLE
Remove odd sentence on ⎕SH and ⎕CMD pages

### DIFF
--- a/language-reference-guide/docs/system-functions/execute-unix-command.md
+++ b/language-reference-guide/docs/system-functions/execute-unix-command.md
@@ -19,8 +19,7 @@ search:
 `⎕SH` executes a UNIX shell or a Windows Command Processor.  `⎕SH` is a synonym of `⎕CMD`.  Either function may be used in either environment (UNIX or Windows) with exactly the same effect.  `⎕SH` is probably more natural for the UNIX user.  This section describes the behaviour of `⎕SH` and `⎕CMD` under UNIX.  See [Execute Windows Command](execute-windows-command.md) for a discussion of the behaviour of these system functions under Windows.
 
 
-The system commands [`)SH`](../system-commands/sh.md) and [`)CMD`](../system-commands/cmd.md) provide similar facilities. For further information, see [Execute (UNIX) Command: ](../system-commands/sh.md) and [Example](../system-commands/cmd.md).
-
+The system commands [`)SH`](../system-commands/sh.md) and [`)CMD`](../system-commands/cmd.md) provide similar facilities.
 
 
 `Y` must be a simple character scalar or vector representing a UNIX shell command.  `R` is a nested vector of character vectors.

--- a/language-reference-guide/docs/system-functions/execute-windows-command.md
+++ b/language-reference-guide/docs/system-functions/execute-windows-command.md
@@ -14,7 +14,7 @@ search:
 `⎕CMD` executes the Windows Command Processor or UNIX shell or starts another Windows application program.  `⎕CMD` is a synonym of `⎕SH`.  Either system function may be used in either environment (Windows or UNIX) with exactly the same effect.  `⎕CMD` is probably more natural for the Windows user.  This section describes the behaviour of `⎕CMD` and `⎕SH` under Windows. See [Execute (UNIX) Command](execute-unix-command.md) for a discussion of the behaviour of these system functions under UNIX.
 
 
-The system commands [`)SH`](../system-commands/sh.md) and [`)CMD`](../system-commands/cmd.md) provide similar facilities. For further information, see [Execute (UNIX) Command: ](../system-commands/sh.md) and [Example](../system-commands/cmd.md).
+The system commands [`)SH`](../system-commands/sh.md) and [`)CMD`](../system-commands/cmd.md) provide similar facilities.
 
 
 See also [`⎕SHELL`](shell.md).


### PR DESCRIPTION
As #775 states, remove an odd sentence.