### PR TITLE
Match ⎕SH Table of Contents entries and titles

### DIFF
--- a/language-reference-guide/docs/system-functions/execute-unix-command.md
+++ b/language-reference-guide/docs/system-functions/execute-unix-command.md
@@ -12,7 +12,7 @@ search:
 
 
 
-<h1 class="heading"><span class="name">Execute (UNIX) Command</span> <span class="command">{R}←⎕SH Y</span></h1>
+<h1 class="heading"><span class="name">Execute Unix Command</span> <span class="command">{R}←⎕SH Y</span></h1>
 
 
 

--- a/language-reference-guide/docs/system-functions/start-unix-auxiliary-processor.md
+++ b/language-reference-guide/docs/system-functions/start-unix-auxiliary-processor.md
@@ -12,7 +12,7 @@ search:
 
 
 
-<h1 class="heading"><span class="name">Start UNIX Auxiliary Processor</span> <span class="command">{R}←X ⎕SH Y</span></h1>
+<h1 class="heading"><span class="name">Start Unix Auxiliary Processor</span> <span class="command">{R}←X ⎕SH Y</span></h1>
 
 
 

--- a/language-reference-guide/mkdocs.yml
+++ b/language-reference-guide/mkdocs.yml
@@ -420,7 +420,7 @@ nav:
           - '<code>⎕SAVE</code>: Save Workspace': system-functions/save.md
           - '<code>⎕SD</code>: Screen Dimensions': system-functions/sd.md
           - '<code>⎕SE</code>: Session Namespace': system-functions/se.md
-          - '<code>⎕SH</code>: Execute UNIX Command': system-functions/execute-unix-command.md
+          - '<code>⎕SH</code>: Execute Unix Command': system-functions/execute-unix-command.md
           - '<code>⎕SH</code>: Start UNIX Auxiliary Processor': system-functions/start-unix-auxiliary-processor.md
           - '<code>⎕SHADOW</code>: Shadow Name': system-functions/shadow.md
           - '<code>⎕SHELL</code>: Execute external program': system-functions/shell.md

--- a/language-reference-guide/mkdocs.yml
+++ b/language-reference-guide/mkdocs.yml
@@ -421,7 +421,7 @@ nav:
           - '<code>⎕SD</code>: Screen Dimensions': system-functions/sd.md
           - '<code>⎕SE</code>: Session Namespace': system-functions/se.md
           - '<code>⎕SH</code>: Execute Unix Command': system-functions/execute-unix-command.md
-          - '<code>⎕SH</code>: Start UNIX Auxiliary Processor': system-functions/start-unix-auxiliary-processor.md
+          - '<code>⎕SH</code>: Start Unix Auxiliary Processor': system-functions/start-unix-auxiliary-processor.md
           - '<code>⎕SHADOW</code>: Shadow Name': system-functions/shadow.md
           - '<code>⎕SHELL</code>: Execute external program': system-functions/shell.md
           - '<code>⎕SI</code>: State Indicator': system-functions/si.md


### PR DESCRIPTION
As #774 explains, the various ⎕SH pages don't match their ToC entries. Correct this.