### PR TITLE
Add missing ⎕ATX row to the System Functions (by Category) page

### DIFF
--- a/language-reference-guide/docs/system-functions/index.md
+++ b/language-reference-guide/docs/system-functions/index.md
@@ -20,6 +20,7 @@ Dyalog includes a collection of built-in facilities that provide various service
 |[`⎕ARBIN`](arbin.md) |Arbitrary Input       |Dyadic function|
 |[`⎕ARBOUT`](arbout.md)|Arbitrary Output      |Dyadic function|
 |[`⎕AT`](at.md)     |Object Attributes       |Ambivalent function|
+|[`⎕ATX`](atx.md)   |Extended Attributes     |Dyadic function|
 |[`⎕AV`](av.md)   |Atomic Vector              |Constant|
 |[`⎕AVU`](avu.md)  |Atomic Vector - Unicode         |Variable|
 |[`⎕BASE`](base.md)     |Base Class   |Reference|

--- a/language-reference-guide/docs/system-functions/system-functions-by-category.md
+++ b/language-reference-guide/docs/system-functions/system-functions-by-category.md
@@ -30,6 +30,7 @@ These provide information on, and control, the current workspace and its content
 
 |Name     |Description              |Form|
 |---------|-------------------------|-----|
+|[`⎕ATX`](atx.md)   |Extended Attributes     |Dyadic function|
 |[`⎕EX`](ex.md)     |Expunge objects         |Monadic function|
 |[`⎕LX`](lx.md)    |Latent Expression        |Variable|
 |[`⎕NC`](nc.md)    |Name Classification      |Monadic function|


### PR DESCRIPTION
As #773 states, `⎕ATX` is missing from the `System Functions (by Category) page". Add it