### PR TITLE
Build CHM only on main, drop the PDF release path

### DIFF
--- a/.github/workflows/full-release.yml
+++ b/.github/workflows/full-release.yml
@@ -15,9 +15,8 @@ permissions:
 
 jobs:
   build-assets:
-    uses: ./.github/workflows/mkdocs-pdf.yml
+    uses: ./.github/workflows/mkdocs-chm.yml
     with:
-      generate_pdf: true
       generate_chm: true
       publish_release: true
     secrets: inherit

--- a/.github/workflows/mkdocs-chm.yml
+++ b/.github/workflows/mkdocs-chm.yml
@@ -1,21 +1,14 @@
-name: Convert MkDocs to PDF and CHM
+name: Convert MkDocs to CHM
 
 on:
   workflow_dispatch:
     inputs:
-      generate_pdf:
-        description: 'Generate PDF documentation'
-        type: boolean
-        default: true
       generate_chm:
         description: 'Generate CHM help file'
         type: boolean
         default: true
   workflow_call:
     inputs:
-      generate_pdf:
-        type: boolean
-        default: true
       generate_chm:
         type: boolean
         default: true
@@ -50,15 +43,7 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y \
-          libcairo2-dev \
-          libpango1.0-dev \
-          libgdk-pixbuf2.0-dev \
-          libffi-dev \
-          shared-mime-info \
-          fonts-liberation \
-          fonts-dejavu \
-          fpc               # for "chmcmd", part of Free Pascal
+        sudo apt-get install -y fpc   # for "chmcmd", part of Free Pascal
 
     - name: Install Python dependencies
       run: |
@@ -67,52 +52,12 @@ jobs:
 
     - name: Prepare directories
       run: |
-        # Ensure output directories exist with proper permissions
-        mkdir -p pdf/output
-        chmod 755 pdf/output
-
+        # Ensure output directory exists with proper permissions
         mkdir -p chm/output
         chmod 755 chm/output
-        
-        # List directory structure for debugging
-        echo "Directory structure:"
-        ls -la pdf/
-        ls -la chm/
 
-    - name: Convert MkDocs to PDF
-      if: ${{ inputs.generate_pdf }}
-      env:
-        GIT_INFO: ${{ steps.git-info.outputs.GIT_INFO }}
-        BUILD_DATE: ${{ steps.git-info.outputs.DATE }}
-      working-directory: ${{ github.workspace }}
-      run: |
-        # Verify required files and directories exist
-        [ -f "pdf/mkdocs2pdf.py" ] || { echo "pdf/mkdocs2pdf.py not found"; exit 1; }
-        [ -f "mkdocs.yml" ] || { echo "mkdocs.yml not found in repository root"; exit 1; }
-        [ -d "pdf/assets" ] || { echo "pdf/assets directory not found"; exit 1; }
-        [ -f "pdf/config.json" ] || { echo "Error: pdf/config.json not found"; exit 1; }
-        [ -d "object-reference" ] || { echo "Error: object-reference directory not found"; exit 1; }
-        [ -f "pdf/fix_objref.py" ] || { echo "Error: pdf/fix_objref.py not found"; exit 1; }
-        
-        # Make scripts executable
-        chmod +x pdf/mkdocs2pdf.py
-        chmod +x pdf/fix_objref.py
-        
-        # Run the fix_objref.py script to transform markdown files
-        python pdf/fix_objref.py --dir "object-reference"
-        
-        # Check the exit status of the previous command
-        if [ $? -ne 0 ]; then
-          echo "Error: fix_objref.py failed"
-          exit 1
-        fi
-        
-        # Run the conversion script
-        python pdf/mkdocs2pdf.py \
-          --mkdocs-yml mkdocs.yml \
-          --config pdf/config.json \
-          --project-dir pdf/output \
-          --assets-dir pdf/assets
+        echo "Directory structure:"
+        ls -la chm/
 
     - name: Convert MkDocs to CHM
       if: ${{ inputs.generate_chm }}
@@ -207,10 +152,6 @@ jobs:
         # Collect assets based on what was generated
         ASSETS=""
         PARTS=""
-        if ${{ inputs.generate_pdf }}; then
-          ASSETS="$ASSETS pdf/output/*.pdf"
-          PARTS="$PARTS PDFs"
-        fi
         if ${{ inputs.generate_chm }}; then
           ASSETS="$ASSETS chm/output/*.chm"
           PARTS="$PARTS CHM"

--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,7 @@ docs/_build/
 
 .cache
 .env
+
+# Claude Code
+CLAUDE.md
+.claude/

--- a/tools/jenkins/RELEASE.md
+++ b/tools/jenkins/RELEASE.md
@@ -46,7 +46,7 @@ publish it to the live site — see [Procedure C](#c-publish-the-upcoming-versio
 | `TRUNK_VERSION` | `Jenkinsfile` | Which version maps to the SVN *trunk* (vs `branches/<ver>/`). Equals **N** while N is in development. |
 | `.rsync-exclude` | `.rsync-exclude` | Defence-in-depth backstop. A version listed here is skipped by `rsync` even if it is in `PRODUCTION_VERSIONS`. |
 | `set_as_latest` | workflow input | When ticked, `mike` repoints the default/`latest` alias (and the root redirect) to the version being published. |
-| GitHub release `v<ver>.*` | (GitHub Releases) | Jenkins' `getVersionedReleaseAssets` downloads PDF/CHM from the newest non-draft release whose tag starts `v<ver>.`. |
+| GitHub release `v<ver>.*` | (GitHub Releases) | Jenkins' `getVersionedReleaseAssets` downloads the release assets from the newest non-draft release whose tag starts `v<ver>.` (CHM for all versions; PDFs only on v20 and earlier). |
 
 > The `Jenkinsfile` and `.rsync-exclude` that Jenkins actually runs live at the
 > root of `gh-pages`, and [`mkdocs-publish.yml`](../../.github/workflows/mkdocs-publish.yml)
@@ -61,13 +61,15 @@ publish it to the live site — see [Procedure C](#c-publish-the-upcoming-versio
 Routine update to the version that is already live and the default.
 
 1. Merge the content PR into the `vM.0` branch.
-2. If PDF/CHM changed: run **Full Release** (or `mkdocs-pdf.yml`) from `vM.0`
-   and publish the resulting GitHub release (not draft).
-3. Run **Publish MkDocs Documentation** from `vM.0`:
-   - leave `version_override` empty (auto-detected as `M` from `mkdocs.yml`);
-   - leave `set_as_latest` **ticked only if M is still the default** (normally
-     yes, until N is promoted).
-4. Jenkins deploys to `docs.dyalog.com/M/` because **M** is in
+2. Publish from `vM.0`. Leave `set_as_latest` **ticked only if M is still the
+   default** (normally yes, until N is promoted):
+   - If the PDF/CHM assets changed, run **Full Release**. It rebuilds the
+     assets, publishes them as a non-draft GitHub release, and republishes the
+     site in one run.
+   - If only content changed, run **Publish MkDocs Documentation** (leave
+     `version_override` empty, auto-detected as `M`) to republish the site
+     against the existing release assets.
+3. Jenkins deploys to `docs.dyalog.com/M/` because **M** is in
    `PRODUCTION_VERSIONS`.
 
 ---
@@ -94,7 +96,7 @@ remains the default. **No `vN.0` git or SVN branch is required** — N stays on
 
 **Prerequisites**
 
-- A **non-draft** GitHub release tagged `vN.*` exists with the PDF/CHM assets.
+- A **non-draft** GitHub release tagged `vN.*` exists with the CHM asset.
   Without it, Jenkins' `getVersionedReleaseAssets` aborts the build with
   `No release found matching vN.*`. Produce one via **Full Release** from
   `main` and publish it.

--- a/tools/requirements-docs.txt
+++ b/tools/requirements-docs.txt
@@ -1,4 +1,4 @@
-# Documentation build dependencies for the mkdocs-publish and mkdocs-pdf workflows.
+# Documentation build dependencies for the mkdocs-publish and mkdocs-chm workflows.
 #
 # Pins match the versions installed in the last successful CI runs
 # (2026-04-22). Refresh this file deliberately by a PR that bumps versions
@@ -18,7 +18,9 @@ mkdocs-minify-plugin==0.8.0
 markdown-tables-extended==0.1.3
 pymdown-extensions==10.21.2
 
-# PDF/CHM build dependencies (used by mkdocs-pdf workflow only)
+# CHM build dependencies (used by mkdocs-chm workflow only).
+# weasyprint is retained for parity with the v20 branch's PDF build; the
+# mkdocs-chm workflow on main no longer builds PDFs.
 weasyprint==68.1
 beautifulsoup4==4.14.3
 markdown==3.10.2


### PR DESCRIPTION
## Summary

From v21 (main) the documentation release builds and uploads the CHM asset only; PDFs are no longer produced. The v20.0 branch keeps its own workflow and continues to build PDFs, so each branch's Full Release produces the assets appropriate to that version.

Changes:
- Rename `.github/workflows/mkdocs-pdf.yml` to `mkdocs-chm.yml` and remove the PDF generation step, the `generate_pdf` inputs, the WeasyPrint-only apt dependencies, and the PDF release-asset branch.
- Point `full-release.yml` at the renamed workflow.
- Update `tools/requirements-docs.txt` comments for the rename (the `weasyprint` pin is retained, now annotated as unused on main).
- Update `tools/jenkins/RELEASE.md`: the asset-download note, Procedure A (Full Release is now the asset path), and the Procedure C prerequisite.

A separate commit ignores local Claude Code files (`CLAUDE.md`, `.claude/`).

## How it was tested

Both edited workflow files parse as YAML. No `generate_pdf` references remain. Git records the workflow file as a rename.

Refs #832
