### PR TITLE
Make the v20 PDF workflow callable only via Full Release

### DIFF
--- a/.github/workflows/mkdocs-pdf.yml
+++ b/.github/workflows/mkdocs-pdf.yml
@@ -1,16 +1,6 @@
 name: Convert MkDocs to PDF and CHM
 
 on:
-  workflow_dispatch:
-    inputs:
-      generate_pdf:
-        description: 'Generate PDF documentation'
-        type: boolean
-        default: true
-      generate_chm:
-        description: 'Generate CHM help file'
-        type: boolean
-        default: true
   workflow_call:
     inputs:
       generate_pdf:

--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,7 @@ docs/_build/
 
 .cache
 .env
+
+# Claude Code
+CLAUDE.md
+.claude/


### PR DESCRIPTION
## Summary

After main's asset workflow was renamed to `mkdocs-chm.yml` (see #833), `mkdocs-pdf.yml` exists only on `v20.0` and is no longer on the default branch, so its manual Run button would never appear in the Actions UI. Restrict it to `workflow_call` so Full Release is the single entry point. PDFs still build: `full-release.yml` calls this workflow against the `v20.0` ref.

Also cherry-picks the gitignore entry for local Claude Code files (`CLAUDE.md`, `.claude/`).

## How it was tested

The workflow parses as YAML; the only remaining trigger is `workflow_call`. The Full Release wiring (`full-release.yml` to this workflow) is unchanged.

Base branch is `v20.0`, not `main`.

Refs #832
