### PR TITLE
Bump pymdown-extensions to 10.21.3 for CVE-2026-46338

### DIFF
--- a/tools/requirements-docs.txt
+++ b/tools/requirements-docs.txt
@@ -16,7 +16,7 @@ mkdocs-site-urls==0.3.1
 mkdocs-caption==1.3.0
 mkdocs-minify-plugin==0.8.0
 markdown-tables-extended==0.1.3
-pymdown-extensions==10.21.2
+pymdown-extensions==10.21.3
 
 # CHM build dependencies (used by mkdocs-chm workflow only).
 # weasyprint is retained for parity with the v20 branch's PDF build; the


### PR DESCRIPTION
## Summary

Bumps `pymdown-extensions` from 10.21.2 to 10.21.3, the patched release for GHSA-62q4-447f-wv8h / CVE-2026-46338 (sibling-prefix path traversal in `pymdownx.snippets`).

Assessment: the `pymdownx.snippets` extension is not enabled in the root `mkdocs.yml`, any of the sub-guide configs, or the standalone PDF/CHM renderers, so the vulnerable code path is not reachable in this build. The bump clears the Dependabot alert and removes the latent risk should `snippets` ever be enabled.

This is a security-only patch within the same minor version. CI verifies a clean build, per the pinning policy in the file.

## How it was tested

Single-line version bump; relies on the documentation build in CI.
