### PR TITLE
Remove polyfill.io references from conversion of new doc set

### DIFF
--- a/compiler-user-guide/mkdocs.yml
+++ b/compiler-user-guide/mkdocs.yml
@@ -16,7 +16,6 @@ extra_css:
   - documentation-assets/css/extra.css
 extra_javascript:
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 plugins:
   - privacy

--- a/dotnet-interface-guide/mkdocs.yml
+++ b/dotnet-interface-guide/mkdocs.yml
@@ -16,7 +16,6 @@ extra_css:
   - documentation-assets/css/extra.css
 extra_javascript:
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 plugins:
   - privacy

--- a/shared-code-files-user-guide/mkdocs.yml
+++ b/shared-code-files-user-guide/mkdocs.yml
@@ -17,7 +17,6 @@ extra_css:
   - style/admonition-ucmdhelp.css
 extra_javascript:
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 plugins:
   - privacy


### PR DESCRIPTION
We removed polyfill a long while back from the doc source, but not from the conversion tools.



Ref #449 