### PR TITLE
Remove footnotes from the language reference guide

### DIFF
--- a/language-reference-guide/docs/primitive-operators/i-beam/create-data-binding-source.md
+++ b/language-reference-guide/docs/primitive-operators/i-beam/create-data-binding-source.md
@@ -21,8 +21,7 @@ search:
     **.NET Framework only**
 
 
-Creates an object that may be used as a data source for WPF data binding. [^1]
-
+Creates an object that may be used as a data source for WPF data binding. See Microsoft Developer Network, Data Binding Overview for a full explaination of the concepts of WPF data binding.
 
 This function connects a *Binding Target* to a *Binding Source*. In WPF a Binding Target is a particular property of a user interface object; for example, the Text property of a TextBox object. A Binding Source is  a *Path* to a value in a data object (which may contain other values). The value of the Binding Source determines the value of the Binding Target. If two-way binding is in place, a change in a user-interface component causes the bound data value to change accordingly. In the example of the TextBox, the value in the Binding Source changes as the user types into the TextBox.
 
@@ -408,8 +407,3 @@ If Reason is `'CellChanged'`, Path is the row and column number (in origin 0) of
 
 
 If Reason is `'RowDeleted'` or `'RowInserted'`, Path is the number of the row that has been added or removed (in origin 0) and Value is `⎕NULL`.
-
-
-
-
-[^1]: It is beyond the scope of this document to fully explain the concepts of WPF data binding. See Microsoft Developer Network, Data Binding Overview.

--- a/language-reference-guide/docs/primitive-operators/i-beam/create-data-binding-source.md
+++ b/language-reference-guide/docs/primitive-operators/i-beam/create-data-binding-source.md
@@ -21,7 +21,7 @@ search:
     **.NET Framework only**
 
 
-Creates an object that may be used as a data source for WPF data binding. See Microsoft Developer Network, Data Binding Overview for a full explaination of the concepts of WPF data binding.
+Creates an object that may be used as a data source for WPF data binding. For more information on the concepts of WPF data binding, see [Microsoft Developer Network's Data Binding Overview](https://learn.microsoft.com/en-us/dotnet/desktop/wpf/data/).
 
 This function connects a *Binding Target* to a *Binding Source*. In WPF a Binding Target is a particular property of a user interface object; for example, the Text property of a TextBox object. A Binding Source is  a *Path* to a value in a data object (which may contain other values). The value of the Binding Source determines the value of the Binding Target. If two-way binding is in place, a change in a user-interface component causes the bound data value to change accordingly. In the example of the TextBox, the value in the Binding Source changes as the user types into the TextBox.
 

--- a/language-reference-guide/docs/primitive-operators/i-beam/specify-workspace-available.md
+++ b/language-reference-guide/docs/primitive-operators/i-beam/specify-workspace-available.md
@@ -17,7 +17,7 @@ search:
 
 
 
-This function is identical to the system function `⎕WA` except that it provides the means to specify the amount of memory [^1]  that is *committed* for the workspace rather than have it assigned by the internal algorithm. Committed memory is memory that is allocated to a specific process and thereby reduces the amount of memory available for other applications. See also [Workspace Management](../../../../windows-installation-and-configuration-guide/workspace-management).
+This function is identical to the system function `⎕WA` except that it provides the means to specify the amount of memory that is *committed* for the workspace rather than have it assigned by the internal algorithm. Committed memory is memory that is allocated to a specific process and thereby reduces the amount of memory available for other applications. See also [Workspace Management](../../../../windows-installation-and-configuration-guide/workspace-management). The memory committed for the workspace includes the virtual memory required for memory mapped to disk.
 
 
 Like `⎕WA`,  `2002⌶` compacts the workspace so that it occupies the minimum number of bytes possible, adds an *extra amount*, and then de-commits all the remaining memory that it is currently using, allowing it to be allocated by the operating system for use by other applications.
@@ -44,4 +44,3 @@ Note that this function does not change the size of the *extra amount* that will
 
 
 
-[^1]: The term memory here means virtual memory which includes memory mapped to disk.

--- a/language-reference-guide/docs/primitive-operators/reduce/index.md
+++ b/language-reference-guide/docs/primitive-operators/reduce/index.md
@@ -44,7 +44,7 @@ Table: Identity Elements {: #IdentityElements }
 |Multiply|`×`| `1`      |
 |Divide|`÷`| `1`      |
 |Residue|`| `        |`0`|
-|Minimum|`⌊`| `M`[^1]  |
+|Minimum|`⌊`| `M`    |
 |Maximum|`⌈`| `-M`     |
 |Power|`*`| `1`      |
 |Binomial|`!`| `1`      |
@@ -61,6 +61,9 @@ Table: Identity Elements {: #IdentityElements }
 |Replicate|`/⌿`| `1`      |
 |Expand|`\⍀`| `1`      |
 |Rotate|`⌽⊖`| `0`      |
+
+!!! Info "Information"
+    `M` represents the largest representable value: typically this is 1.7E308, unless [`⎕FR`](../../system-functions/fr.md) is 1287, when the value is 1E6145.
 
 <h2 class="example">Examples</h2>
 ```apl
@@ -122,5 +125,3 @@ For backwards compatibility reasons, `+/` and `×/` of simple vectors are still 
 0
 ```
 This also applies to `+⌿` and `×⌿`.
-
-[^1]: `M` represents the largest representable value: typically this is 1.7E308, unless `⎕FR` is 1287, when the value is 1E6145.

--- a/language-reference-guide/docs/primitive-operators/reduce/index.md
+++ b/language-reference-guide/docs/primitive-operators/reduce/index.md
@@ -62,8 +62,7 @@ Table: Identity Elements {: #IdentityElements }
 |Expand|`\⍀`| `1`      |
 |Rotate|`⌽⊖`| `0`      |
 
-!!! Info "Information"
-    `M` represents the largest representable value: typically this is 1.7E308, unless [`⎕FR`](../../system-functions/fr.md) is 1287, when the value is 1E6145.
+In [](#IdentityElements), `M` represents the largest representable value. Typically this is 1.7E308, unless [`⎕FR`](../../system-functions/fr.md) is `1287`, in which case it becomes 1E6145
 
 <h2 class="example">Examples</h2>
 ```apl

--- a/language-reference-guide/docs/system-functions/ai.md
+++ b/language-reference-guide/docs/system-functions/ai.md
@@ -38,5 +38,5 @@ Elements beyond 4 are not defined but reserved.
     Under UNIX, `⎕AI[1]` is the effective UID of the account whereas [`⎕AN`](./an.md) returns the real name.
 
 !!! windows "Dyalog on Microsoft Windows"
-    Under Window, `⎕AI[1]` is the aplnid (network ID from configuration dialog box).
+    Under Microsoft Windows, `⎕AI[1]` is the aplnid (network ID from configuration dialog box).
 

--- a/language-reference-guide/docs/system-functions/ai.md
+++ b/language-reference-guide/docs/system-functions/ai.md
@@ -20,7 +20,7 @@ This is a simple integer vector, whose four elements are:
 
 
 |--------|-------------------------------------------------|
-|`⎕AI[1]`|user identification. [^1]                        |
+|`⎕AI[1]`|user identification.                             |
 |`⎕AI[2]`|compute time for the APL session in milliseconds.|
 |`⎕AI[3]`|connect time for the APL session in milliseconds.|
 |`⎕AI[4]`|keying time for the APL session in milliseconds. |
@@ -30,13 +30,13 @@ Elements beyond 4 are not defined but reserved.
 
 <h2 class="example">Example</h2>
 ```apl
-
      ⎕AI
 52 7396 2924216 2814831
 ```
 
+!!! unix "Dyalog on UNIX"
+    Under UNIX, `⎕AI[1]` is the effective UID of the account whereas [`⎕AN`](./an.md) returns the real name.
 
+!!! windows "Dyalog on Microsoft Windows"
+    Under Window, `⎕AI[1]` is the aplnid (network ID from configuration dialog box).
 
-
-
-[^1]: Under Windows, this is the aplnid (network ID from configuration dialog box). Under UNIX and Linux this is the effective UID of the account whereas ⎕AN returns the real name.

--- a/language-reference-guide/docs/system-functions/atx.md
+++ b/language-reference-guide/docs/system-functions/atx.md
@@ -31,7 +31,7 @@ This function provides information about a name in a workspace, including its us
 |Restrictions|30|Source can be displayed|`¯1`|
 |            |31|Execution can be suspended mid-execution|`¯1`|
 |_          _|32|Responds to weak interrupt|`¯1`|
-|Class[^1]|40|Syntactic supra-class ( `¯1` : invalid name, `0` : undefined, `1` : label, `2` : variable, `3` : function, `4` : operator, `8` : event, `9` : object)|`¯1`|
+|Class |40|Syntactic supra-class ( `¯1` : invalid name, `0` : undefined, `1` : label, `2` : variable, `3` : function, `4` : operator, `8` : event, `9` : object)|`¯1`|
 |      |41|Syntactic sub-class ( `0` : none, `1` : traditional/plain, `2` : field/dynamic/instance, `3` : property/derived/primitive, `4` : class, `5` : interface, `6` : external, `7` : external interface)|`0`|
 |_     _|42|Full syntactic class (sum of supra- and sub-class)|`¯1`|
 |Source|50|File name|`''`|
@@ -44,7 +44,8 @@ This function provides information about a name in a workspace, including its us
 |          |61|Normalised source (with AUTOFORMAT=1 and TABSTOPS=4)|`0⍴⊂''`|
 |_        _|62|Most precise available source (verbatim with fallback to normalised)|`0⍴⊂''`|
 
-
+!!! Warning "Warning"
+    Names in the Class group that can return `¯1` (meaning "invalid name") might return a different value in future versions of Dyalog, including values that are not currently possible and ones that deviate from the current `⎕NC` values.
 
 `R` depends on the combination of `X` and `Y`:
 
@@ -116,5 +117,3 @@ This function provides information about a name in a workspace, including its us
 │└────────────┴─────────────┘│└────────────┘│
 └────────────────────────────┴──────────────┘
 ```
-
-[^1]: Names in the Class group that can return `¯1` (meaning "invalid name") might return a different value in future versions of Dyalog, including values that are not currently possible and ones that deviate from the current `⎕NC` values.

--- a/language-reference-guide/docs/system-functions/fcreate.md
+++ b/language-reference-guide/docs/system-functions/fcreate.md
@@ -15,14 +15,15 @@ search:
 
 <h1 class="heading"><span class="name">File Create</span> <span class="command">{R}←X ⎕FCREATE Y</span></h1>
 
+`Y` must be a simple integer scalar or a 1 or 2 element vector:  
 
-
-`Y` must be a simple integer scalar or a 1 or 2 element vector. The first element is the *file tie number*. The second element, if specified, must be 64.
-
+- The first element is the *file tie number*.
+- The second element, if specified, must be `64`. 
 
 The *file tie number* must not be the tie number associated with another tied file.
 
-
+!!! Legacy "Legacy"
+    The second element of Y sets the span of the file which in earlier Versions of Dyalog APL could be 32 or 64. Small-span (32-bit) component files may no longer be created and this element is retained only for backwards compatibility of code.
 
 `X` must be either:
 
@@ -37,10 +38,6 @@ The newly created file is tied for exclusive use.
 
 
 The shy result of `⎕FCREATE` is the tie number of the new file.
-
-!!! Legacy "Legacy"
-    The second element of Y sets the span of the file which in earlier Versions of Dyalog APL could be 32 or 64. Small-span (32-bit) component files may no longer be created and this element is retained only for backwards compatibility of code.
-
 
 ## Automatic Tie Number Allocation
 

--- a/language-reference-guide/docs/system-functions/fcreate.md
+++ b/language-reference-guide/docs/system-functions/fcreate.md
@@ -17,13 +17,11 @@ search:
 
 `Y` must be a simple integer scalar or a 1 or 2 element vector:  
 
-- The first element is the *file tie number*.
+- The first element is the *file tie number*. The *file tie number* must not be the tie number associated with another tied file.
 - The second element, if specified, must be `64`. 
 
-The *file tie number* must not be the tie number associated with another tied file.
-
 !!! Legacy "Legacy"
-    The second element of Y sets the span of the file which in earlier Versions of Dyalog APL could be 32 or 64. Small-span (32-bit) component files may no longer be created and this element is retained only for backwards compatibility of code.
+    The second element of `Y` sets the span of the file which in earlier versions of Dyalog could be `32` or `64`. Small-span (32-bit) component files can no longer be created; this element is retained for backwards compatibility purposes.
 
 `X` must be either:
 

--- a/language-reference-guide/docs/system-functions/fcreate.md
+++ b/language-reference-guide/docs/system-functions/fcreate.md
@@ -17,7 +17,7 @@ search:
 
 
 
-`Y` must be a simple integer scalar or a 1 or 2 element vector. The first element is the *file tie number*. The second element, if specified, must be 64[^1].
+`Y` must be a simple integer scalar or a 1 or 2 element vector. The first element is the *file tie number*. The second element, if specified, must be 64.
 
 
 The *file tie number* must not be the tie number associated with another tied file.
@@ -37,6 +37,10 @@ The newly created file is tied for exclusive use.
 
 
 The shy result of `⎕FCREATE` is the tie number of the new file.
+
+!!! Legacy "Legacy"
+    The second element of Y sets the span of the file which in earlier Versions of Dyalog APL could be 32 or 64. Small-span (32-bit) component files may no longer be created and this element is retained only for backwards compatibility of code.
+
 
 ## Automatic Tie Number Allocation
 
@@ -120,13 +124,6 @@ will name a variant of `⎕FCREATE` which will create component file with level 
       'newfile'JFCREATE 0
 1
 ```
-
-
-
-
-
-
-[^1]: This element sets the span of the file which in earlier Versions of Dyalog APL could be 32 or 64. Small-span (32-bit) component files may no longer be created and this element is retained only for backwards compatibility of code.
 
 !!! Info "Information"
     Component files that have both journalling and checksum properties set to `0` have been deprecated; from Dyalog v21.0 it will not be possible to create files with this combination of properties. For information on how to identify code that creates component files that have both journalling and checksum properties set to `0` in your existing codebase, see the [Release Notes](../../../release-notes/announcements/deprecated-functionality/).

--- a/language-reference-guide/docs/system-functions/fr.md
+++ b/language-reference-guide/docs/system-functions/fr.md
@@ -19,10 +19,10 @@ search:
 The value of `⎕FR` determines the way that floating-point operations are performed.
 
 
-If `⎕FR` is 645, all floating-point calculations are performed using IEEE 754 64-bit floating-point operations and the results of these operations are represented internally using *binary64*[^1] floating-point format.
+If `⎕FR` is 645, all floating-point calculations are performed using IEEE 754 64-bit floating-point operations and the results of these operations are represented internally using [*binary64*](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) floating-point format.
 
 
-If `⎕FR` is 1287, all floating-point calculations are performed using IEEE 754-2008 128-bit decimal floating-point operations and the results of these operations are represented internally using *decimal128*[^2] format.
+If `⎕FR` is 1287, all floating-point calculations are performed using IEEE 754-2008 128-bit decimal floating-point operations and the results of these operations are represented internally using [*decimal128*](https://en.wikipedia.org/wiki/Decimal128_floating-point_format) format.
 
 
 
@@ -112,10 +112,3 @@ WARNING: The use of COMPLEX numbers when `⎕FR` is 1287 is not recommended, bec
 
 - any 128-bit decimal array into which a complex number is inserted or appended will be forced in its entirety into complex representation, potentially losing precision.
 - All comparisons are done using `⎕DCT` when `⎕FR` is 1287, and the default value of `1E¯28` is equivalent to 0 for complex numbers.
-
-
-
-
-
-[^1]: https://en.wikipedia.org/wiki/Double_precision_floating-point_format
-[^2]: https://en.wikipedia.org/wiki/Decimal128_floating-point_format

--- a/language-reference-guide/docs/system-functions/na.md
+++ b/language-reference-guide/docs/system-functions/na.md
@@ -15,7 +15,7 @@ search:
     - a Shared Library (.so or .dylib) under Linux or macOS
     - a static library (.a) under AIX
 
-A DLL[^1] is a collection of functions typically written in C (or C++) each of which may take arguments and return a result.
+A library, refered to here generically as a DLL, is a collection of functions typically written in C (or C++) each of which may take arguments and return a result.
 
 Instructional examples using `⎕NA` can be found in the supplied workspace `quadna`.
 
@@ -124,11 +124,11 @@ The options are summarised in the following table and their functions detailed b
 |Type       |`I`     |int                                                                                                    |
 |           |`U`     |unsigned int                                                                                           |
 |           |`C`     |char                                                                                                   |
-|           |`T`     |char [^1]                                                                                              |
+|           |`T`     |char                                                                                                   |
 |           |`F`     |float                                                                                                  |
 |           |`D`     |decimal                                                                                                |
 |           |`J`     |complex                                                                                                |
-|           |`P`     |uintptr-t [^2]                                                                                         |
+|           |`P`     |uintptr-t (equivalent to U4 on 32-bit versions and U8 on 64-bit)                                       |
 |           |`A`     |APL array                                                                                              |
 |_         _|`Z`     |APL array with header (as passed to a TCP/IP socket)                                                   |
 |Width      |`1`     |1-byte                                                                                                 |
@@ -953,6 +953,3 @@ A result is returned from the function *only* if all the calls are successful Ot
 ⎕NA'I4 winnm    |sndPlaySound         <0T U4'
 
 ```
-
-[^1]: Classic Edition:  - translated to/from ANSI
-[^2]: equivalent to U4 on 32-bit versions and U8 on 64-bit versions

--- a/language-reference-guide/docs/system-functions/na.md
+++ b/language-reference-guide/docs/system-functions/na.md
@@ -11,11 +11,11 @@ search:
 
 `⎕NA` provides access from APL to compiled functions within a library. A library is implemented according to the Operating System as follows:
 
-    - a Dynamic Link Library(DLL) under Windows
-    - a Shared Library (.so or .dylib) under Linux or macOS
-    - a static library (.a) under AIX
+- a Dynamic Link Library(**.dll**) under Windows
+- a Shared Library (**.so** or **.dylib**) under Linux or macOS
+- a static library (**.a**) under AIX
 
-A library, refered to here generically as a DLL, is a collection of functions typically written in C (or C++) each of which may take arguments and return a result.
+A library, referred to here generically as a a Dynamic Link Library (DLL), is a collection of functions typically written in C (or C++) each of which may take arguments and return a result.
 
 Instructional examples using `⎕NA` can be found in the supplied workspace `quadna`.
 
@@ -124,11 +124,11 @@ The options are summarised in the following table and their functions detailed b
 |Type       |`I`     |int                                                                                                    |
 |           |`U`     |unsigned int                                                                                           |
 |           |`C`     |char                                                                                                   |
-|           |`T`     |char                                                                                                   |
+|           |`T`     |char  (Classic Edition: translated to/from ANSI)                                                       |
 |           |`F`     |float                                                                                                  |
 |           |`D`     |decimal                                                                                                |
 |           |`J`     |complex                                                                                                |
-|           |`P`     |uintptr-t (equivalent to U4 on 32-bit versions and U8 on 64-bit)                                       |
+|           |`P`     |uintptr-t (equivalent to U4 and U8 on 32-bit and 64-bit widths respectively)                           |
 |           |`A`     |APL array                                                                                              |
 |_         _|`Z`     |APL array with header (as passed to a TCP/IP socket)                                                   |
 |Width      |`1`     |1-byte                                                                                                 |

--- a/language-reference-guide/docs/system-functions/nread.md
+++ b/language-reference-guide/docs/system-functions/nread.md
@@ -49,7 +49,7 @@ Table: Unicode Edition: Conversion Codes
 |-------|--------------------|-----------------|------------|
 |11     |count               |1 bit Boolean    |8 `×` count |
 |80     |count               |8 bits character |count       |
-|82 [^1]|count               |8 bits character |count       |
+|82     |count               |8 bits character |count       |
 |83     |count               |8 bits integer   |count       |
 |160    |2 `×` count         |16-bits character|count       |
 |163    |2 `×` count         |16 bits integer  |count       |
@@ -59,7 +59,8 @@ Table: Unicode Edition: Conversion Codes
 |1287   |16 `×` count        |128 bits decimal |count       |
 |1289   |16 `×` count        |128 bits complex |count       |
 
-
+!!! Legacy "Legacy"
+    Conversion code 82 is permitted in the Unicode Edition for compatibility and causes 1-byte data on file to be translated (according to [⎕NXLATE](./nxlate.md)) from [⎕AV](./av.md) indices into normal (Unicode) characters of type 80, 160 or 320.
 
 
 Table: Classic Edition: Conversion Codes
@@ -85,8 +86,3 @@ Table: Classic Edition: Conversion Codes
       DATA←⎕NREAD ¯1 82 ¯1 0       ⍝ Shorter version
 
 ```
-
-
-
-
-[^1]: Conversion code 82 is permitted in the Unicode Edition for compatibility and causes 1-byte data on file to be translated (according to ⎕NXLATE ) from ⎕AV indices into normal (Unicode) characters of type 80, 160 or 320.

--- a/language-reference-guide/docs/system-functions/nread.md
+++ b/language-reference-guide/docs/system-functions/nread.md
@@ -60,7 +60,7 @@ Table: Unicode Edition: Conversion Codes
 |1289   |16 `×` count        |128 bits complex |count       |
 
 !!! Legacy "Legacy"
-    Conversion code 82 is permitted in the Unicode Edition for compatibility and causes 1-byte data on file to be translated (according to [⎕NXLATE](./nxlate.md)) from [⎕AV](./av.md) indices into normal (Unicode) characters of type 80, 160 or 320.
+    Conversion code 82 is permitted in the Unicode edition for backwards compatibility purposes and causes 1-byte data on file to be translated (according to [⎕NXLATE](./nxlate.md)) from [⎕AV](./av.md) indices into normal (Unicode) characters of type 80, 160 or 320.
 
 
 Table: Classic Edition: Conversion Codes

--- a/language-reference-guide/docs/system-functions/ntie.md
+++ b/language-reference-guide/docs/system-functions/ntie.md
@@ -25,7 +25,7 @@ If `Y[2]` is omitted, the system tries to open the file with the default value o
 
 |Needed from existing users                     ||Granted to subsequent users                     ||
 |--------------------------|---------------------|---------------------------|---------------------|
-|0                         |read access          |0                          |see note             |
+|0                         |read access          |0                          |no access (exclusive)|
 |1                         |write access         |16                         |no access (exclusive)|
 |2                         |read and write access|32                         |read access          |
 |&nbsp;                    |&nbsp;               |48                         |write access         |
@@ -34,11 +34,10 @@ If `Y[2]` is omitted, the system tries to open the file with the default value o
 
 On UNIX systems, the second column has no meaning and only the first code (`16|mode`) is passed to the `open(2)` call as the access parameter. See include file `fcntl.h` for details. See also [Native File Lock](nlock.md) which is not platform dependent.
 
-`R` is the tie number by which the file may subsequently be referred. If `Y[1]` is a negative integer, then `R` is a shy result; if `Y[1]` is 0, `R` is an explicit result.
-
 !!! Legacy "Legacy"
-    The original meaning of `Y[2]` granting subsequent users a value 0 is no longer relevant. 0 now means the same as 16 (no access).
+    The original objective of this value (granting subsequent users a value of 0) is no longer relevant, and 0 now means the same as 16. The option remains for backwards compatibility purposes.
 
+`R` is the tie number by which the file may subsequently be referred. If `Y[1]` is a negative integer, then `R` is a shy result; if `Y[1]` is 0, `R` is an explicit result.
 
 ## Automatic Tie Number Allocation
 

--- a/language-reference-guide/docs/system-functions/ntie.md
+++ b/language-reference-guide/docs/system-functions/ntie.md
@@ -25,7 +25,7 @@ If `Y[2]` is omitted, the system tries to open the file with the default value o
 
 |Needed from existing users                     ||Granted to subsequent users                     ||
 |--------------------------|---------------------|---------------------------|---------------------|
-|0                         |read access          |0                          |see note [^1]        |
+|0                         |read access          |0                          |see note             |
 |1                         |write access         |16                         |no access (exclusive)|
 |2                         |read and write access|32                         |read access          |
 |&nbsp;                    |&nbsp;               |48                         |write access         |
@@ -35,6 +35,10 @@ If `Y[2]` is omitted, the system tries to open the file with the default value o
 On UNIX systems, the second column has no meaning and only the first code (`16|mode`) is passed to the `open(2)` call as the access parameter. See include file `fcntl.h` for details. See also [Native File Lock](nlock.md) which is not platform dependent.
 
 `R` is the tie number by which the file may subsequently be referred. If `Y[1]` is a negative integer, then `R` is a shy result; if `Y[1]` is 0, `R` is an explicit result.
+
+!!! Legacy "Legacy"
+    The original meaning of `Y[2]` granting subsequent users a value 0 is no longer relevant. 0 now means the same as 16 (no access).
+
 
 ## Automatic Tie Number Allocation
 
@@ -63,7 +67,3 @@ ntie←{                  ⍝ tie file and return tie no.
 !!! note
     If the native file is already tied, executing `⎕NTIE` with the same or a different tie number simply re-ties it with the same or the new tie number. Re-tying a file with a tie number of 0, re-ties it with the same tie number. This feature can be used to re-tie the file using a different mode.
 
-
-
-
-[^1]: The original meaning of this value is no longer relevant. 0 now means the same as 16 (no access).

--- a/language-reference-guide/docs/system-functions/ntie.md
+++ b/language-reference-guide/docs/system-functions/ntie.md
@@ -35,7 +35,7 @@ If `Y[2]` is omitted, the system tries to open the file with the default value o
 On UNIX systems, the second column has no meaning and only the first code (`16|mode`) is passed to the `open(2)` call as the access parameter. See include file `fcntl.h` for details. See also [Native File Lock](nlock.md) which is not platform dependent.
 
 !!! Legacy "Legacy"
-    The original objective of this value (granting subsequent users a value of 0) is no longer relevant, and 0 now means the same as 16. The option remains for backwards compatibility purposes.
+    The original objective of value 0 from existing users (granting subsequent users a value of 0) is no longer relevant, and 0 now means the same as 16. The option remains for backwards compatibility purposes.
 
 `R` is the tie number by which the file may subsequently be referred. If `Y[1]` is a negative integer, then `R` is a shy result; if `Y[1]` is 0, `R` is an explicit result.
 

--- a/language-reference-guide/docs/system-functions/or.md
+++ b/language-reference-guide/docs/system-functions/or.md
@@ -16,8 +16,7 @@ search:
 
 
 
-`⎕OR` converts a defined function, defined operator or namespace to a special form, described as its *object representation*, that may be assigned to a variable and/or stored on a component file[^1]. Classes and Instances are however outside the domain of `⎕OR`.
-
+`⎕OR` converts a defined function, defined operator or namespace to a special form, described as its *object representation*, that may be assigned to a variable and/or stored on a component file. Classes and Instances are however outside the domain of `⎕OR`.
 
 Taking the `⎕OR` of a defined function or operator is an extremely fast operation as it simply changes the type information in the object's header, leaving its internal structure unaltered.  Converting the object representation back to an executable function or operator using `⎕FX` is also very fast.
 
@@ -27,7 +26,8 @@ However, the saved results of `⎕OR` which were produced on a different hardwar
 
 `⎕OR` may also be used to convert a namespace (either a plain namespace or a named GUI object created by `⎕WC`) into a form that can be stored in a variable or on a component file.  The namespace may be reconstructed using `⎕NS` or `⎕WC` with its original name or with a new one.  `⎕OR` may therefore be used to *clone* a namespace or GUI object.
 
-
+!!! Warning "Warning"
+    ⎕OR and GUI objects stored in workspaces or in component files are not portable between 32-bit and 64-bit versions of Dyalog nor between different implementations (platforms) and are not backwards compatible.
 
 `Y` must be a simple character scalar or vector which contains the name of an APL object.
 
@@ -151,8 +151,3 @@ This example illustrates how `⎕OR` can be used to clone a GUI object; in this 
 
 
 Note too that `⎕WC` and `⎕NS` may be used interchangeably to rebuild *pure* namespaces or GUI namespaces from a `⎕OR` object.  You may therefore use `⎕NS` to rebuild a Form or use `⎕WC` to rebuild a pure namespace that has no GUI components.
-
-
-
-
-[^1]: ⎕OR and GUI objects stored in workspaces or in component files are not portable between 32-bit and 64-bit versions of Dyalog nor between different implementations (platforms) and are not backwards compatible

--- a/language-reference-guide/docs/system-functions/or.md
+++ b/language-reference-guide/docs/system-functions/or.md
@@ -16,7 +16,7 @@ search:
 
 
 
-`⎕OR` converts a defined function, defined operator or namespace to a special form, described as its *object representation*, that may be assigned to a variable and/or stored on a component file. Classes and Instances are however outside the domain of `⎕OR`.
+`⎕OR` converts a defined function, defined operator, or namespace to a special form, described as its *object representation*, that can be assigned to a variable and/or stored on a component file. Classes and instances are, however, outside the domain of `⎕OR`.
 
 Taking the `⎕OR` of a defined function or operator is an extremely fast operation as it simply changes the type information in the object's header, leaving its internal structure unaltered.  Converting the object representation back to an executable function or operator using `⎕FX` is also very fast.
 
@@ -27,7 +27,7 @@ However, the saved results of `⎕OR` which were produced on a different hardwar
 `⎕OR` may also be used to convert a namespace (either a plain namespace or a named GUI object created by `⎕WC`) into a form that can be stored in a variable or on a component file.  The namespace may be reconstructed using `⎕NS` or `⎕WC` with its original name or with a new one.  `⎕OR` may therefore be used to *clone* a namespace or GUI object.
 
 !!! Warning "Warning"
-    ⎕OR and GUI objects stored in workspaces or in component files are not portable between 32-bit and 64-bit versions of Dyalog nor between different implementations (platforms) and are not backwards compatible.
+     `⎕OR` and `GUI` objects stored in workspaces or component files are not portable between 32-bit and 64-bit widths of Dyalog, nor between different implementations (platforms), and are not backwards-compatible.
 
 `Y` must be a simple character scalar or vector which contains the name of an APL object.
 

--- a/language-reference-guide/docs/system-functions/xml.md
+++ b/language-reference-guide/docs/system-functions/xml.md
@@ -85,7 +85,7 @@ For conversion *to* XML, `Y` is a 3, 4 or 5 column matrix and the result `R` is 
 ## Introduction to XML and Glossary of Terms
 
 
-XML is an open standard, designed to allow exchange of data between applications. The full specification [^1] describes functionality, including processing directives and other directives, which can transform XML data as it is read, and which a full XML processor would be expected to handle.
+XML is an open standard, designed to allow exchange of data between applications. The [full specification](http://www.w3.org/TR/2008/REC-xml-20081126/) describes functionality, including processing directives and other directives, which can transform XML data as it is read, and which a full XML processor would be expected to handle.
 
 
 The `⎕XML` function is designed to handle XML to the extent required to import and export APL data. It favours speed over complexity - some markup is tolerated but largely ignored, and there are no XML query or validation features. APL applications which require processing, querying or validation will need to call external tools for this, and finally call `⎕XML` on the resulting XML to perform the transformation into APL arrays.
@@ -501,8 +501,3 @@ When converting from XML, this option determines what happens when an unknown en
 |Converting to XML                                                                                                                ||
 |Replace (replace)   |Esc ( `⎕UCS 27` ) is preserved                                                                               |
 |`Preserve(preserve)`|Esc ( `⎕UCS 27` ) is replaced by '&'                                                                         |
-
-
-
-
-[^1]: http://www.w3.org/TR/2008/REC-xml-20081126/


### PR DESCRIPTION
As #621 explains, the existing footnotes should be removed.

This PR removes footnotes within the language reference guide.
Footnotes within ⎕DT have been left due to #717