### PR TITLE
Source third-party licences docx from the dyalog repo

### DIFF
--- a/.github/workflows/test-jenkins-simulation.yml
+++ b/.github/workflows/test-jenkins-simulation.yml
@@ -17,6 +17,11 @@ on:
         required: true
         default: '21.0'
         type: string
+      licences_in_docbin:
+        description: 'Versions whose licences docx ships inside docbin (simulates LICENCES_IN_DOCBIN)'
+        required: true
+        default: '20.0'
+        type: string
 
 jobs:
   simulate-jenkins:
@@ -188,6 +193,7 @@ jobs:
       env:
         TRUNK_VERSION: ${{ inputs.trunk_version }}
         PRODUCTION_VERSIONS: ${{ inputs.production_versions }}
+        LICENCES_IN_DOCBIN: ${{ inputs.licences_in_docbin }}
       run: |
         echo "=== SVN path mapping ==="
 
@@ -195,14 +201,21 @@ jobs:
           if [ "${VERSION}" = "${TRUNK_VERSION}" ]; then
             DOCBIN="docbin/trunk/documentation"
             README="dyalog/trunk/svn/docs/readmes"
+            LICENCES="dyalog/trunk/svn/docs/licences"
           else
             DOCBIN="docbin/branches/${VERSION}/documentation"
             README="dyalog/branches/${VERSION}/svn/docs/readmes"
+            LICENCES="dyalog/branches/${VERSION}/svn/docs/licences"
           fi
           echo "Version ${VERSION}:"
           echo "  docbin:  ${DOCBIN}"
           echo "  readmes: ${README}"
           echo "  sharpplot: dyalogtools/Causeway/trunk/release"
+          if echo " ${LICENCES_IN_DOCBIN} " | grep -q " ${VERSION} "; then
+            echo "  licences: (shipped inside docbin)"
+          else
+            echo "  licences: ${LICENCES}"
+          fi
         done
 
     - name: Test rsync-exclude

--- a/tools/jenkins/Jenkinsfile
+++ b/tools/jenkins/Jenkinsfile
@@ -20,6 +20,20 @@ def getSvnReadmeUrl(String version) {
     return "dyalog/branches/${version}/svn/docs/readmes"
 }
 
+def getSvnLicencesUrl(String version) {
+    if (version == env.TRUNK_VERSION) {
+        return "dyalog/trunk/svn/docs/licences"
+    }
+    return "dyalog/branches/${version}/svn/docs/licences"
+}
+
+// True when the third-party licences docx for this version is sourced
+// from the dyalog repo (svn/docs/licences) rather than from within the
+// docbin checkout. Versions listed in LICENCES_IN_DOCBIN predate the move.
+def licencesFromDyalogRepo(String version) {
+    return !env.LICENCES_IN_DOCBIN.split(' ').contains(version)
+}
+
 /**
  * Download release assets for a specific documentation version.
  * Finds the latest non-draft release whose tag starts with "v{version}."
@@ -105,6 +119,12 @@ pipeline {
         // The "development" version currently on trunk in SVN.
         // When v21 is released and v22 development starts, update this to '22.0'.
         TRUNK_VERSION = '21.0'
+
+        // Versions whose "Licences for third-party components.docx" still lives
+        // inside the docbin checkout. 21.0 onwards sources it from the dyalog
+        // repo (svn/docs/licences); 20.0 predates the move. Drop a version from
+        // this list once its licences file has moved to the dyalog repo.
+        LICENCES_IN_DOCBIN = '20.0'
 
         GITDOCURL       = 'documentation'
 
@@ -209,6 +229,9 @@ pipeline {
                                     doSvnCheckout(getSvnDocbinUrl(version), "files", true, 'svncom')
                                     doSvnCheckout(env.SVNSHARPPLOTURL, "files/sharpplot", true, 'svncom')
                                     doSvnCheckout(getSvnReadmeUrl(version), "files/readmes", true, 'svncom')
+                                    if (licencesFromDyalogRepo(version)) {
+                                        doSvnCheckout(getSvnLicencesUrl(version), "files/licences", true, 'svncom')
+                                    }
                                     sh "\$WORKSPACE/get_svn_docbin ${version}"
                                 }
                             }

--- a/tools/jenkins/RELEASE.md
+++ b/tools/jenkins/RELEASE.md
@@ -101,9 +101,15 @@ remains the default. **No `vN.0` git or SVN branch is required** — N stays on
   `No release found matching vN.*`. Produce one via **Full Release** from
   `main` and publish it.
 - The SVN trunk docbin (`docbin/trunk/documentation`) is fully populated for N
-  — `filelist.txt`, `theme/`, plus the sharpplot and readmes checkouts. The
-  `Get files from svn/docbin` stage bails if the filelist and checkout disagree.
-  (`get_svn_docbin` itself is version-agnostic; this is a content check.)
+  — `filelist.txt`, `theme/`, plus the sharpplot, readmes and licences
+  checkouts. The `Get files from svn/docbin` stage bails if the filelist and
+  checkout disagree. (`get_svn_docbin` itself is version-agnostic; this is a
+  content check.)
+- The third-party licences docx (`Licences for third-party components.docx`)
+  exists at `dyalog/trunk/svn/docs/licences`. From 21.0 onwards it is sourced
+  from the dyalog repo, not docbin; `get_svn_docbin` promotes it into `files/`
+  and registers it in the working `filelist.txt`. Versions listed in
+  `LICENCES_IN_DOCBIN` (currently `20.0`) instead ship it inside docbin.
 
 **Steps** (on `main`)
 
@@ -171,7 +177,9 @@ When N is released and N+1 development begins. This is the heavyweight
 3. In `Jenkinsfile`, set `TRUNK_VERSION = 'N+1'`. The SVN helpers then resolve
    N+1 to trunk and N to `branches/N/`.
 4. **Before** this switch, the SVN branches for the now-released N must exist:
-   `docbin/branches/N/documentation` and `dyalog/branches/N/svn/docs/readmes`.
+   `docbin/branches/N/documentation`, `dyalog/branches/N/svn/docs/readmes` and
+   `dyalog/branches/N/svn/docs/licences` (the last only for versions not listed
+   in `LICENCES_IN_DOCBIN`).
 5. Add `N+1` to `.rsync-exclude` as the new development version's backstop.
 
 ---
@@ -182,6 +190,8 @@ When N is released and N+1 development begins. This is the heavyweight
 |---------|-------|-----|
 | Jenkins: `No release found matching v<ver>.*` | No non-draft GitHub release for that version | Publish a `v<ver>.*` release (not draft) |
 | Jenkins `get_svn_docbin` bails: `SVN includes files that are not in ./filelist.txt` (lists a file) | A file was added to that version's SVN docbin but not to its `filelist.txt` (common on `trunk` when promoting the dev version) | Add the listed file to `filelist.txt` in the version's docbin (`docbin/trunk/documentation` for the trunk version, `docbin/branches/<ver>/documentation` otherwise) as a **tab-separated** line, e.g. `./File.pdf<TAB>web` (`web` = publish; non-`web` = keep out of the site). Commit to SVN, then re-run the build. |
+| Jenkins `get_svn_docbin` bails: `filelist.txt includes files which are not in SVN` listing `Licences for third-party components.docx` | The docx still lives in the version's docbin `filelist.txt` after the move to the dyalog repo, so it is registered twice | Remove the docx and its `filelist.txt` entry from that version's docbin (it now lives in `dyalog/.../svn/docs/licences`). Alternatively, if the version predates the move, add it to `LICENCES_IN_DOCBIN`. |
+| Jenkins `get_svn_docbin` bails: `No ./licences/Licences for third-party components.docx file exists` | The version is sourced from the dyalog repo but the docx is missing or misnamed at `dyalog/.../svn/docs/licences` | Ensure the docx exists there under exactly that name (the site links to it by that name). Commit to SVN, then re-run. |
 | Jenkins `get_svn_docbin` bails: `filelist.txt includes files which are not in SVN` (lists a file) | `filelist.txt` references a file that was removed from the docbin | Remove the stale entry from `filelist.txt` (or restore the file in SVN). Commit, then re-run the build. |
 | Version deployed but missing from live dropdown | Production-root `versions.json` not synced (expected for previews) | Update root `versions.json` on the server, or promote via [Procedure D](#d-promote-the-upcoming-version-to-full-production) |
 | Version published to staging but not live | Not in `PRODUCTION_VERSIONS`, or still listed in `.rsync-exclude` | Add to `PRODUCTION_VERSIONS` / remove from `.rsync-exclude` on `main`, then publish |

--- a/tools/jenkins/get_svn_docbin
+++ b/tools/jenkins/get_svn_docbin
@@ -32,7 +32,14 @@ SHARPPLOTCHM="sharpplot.chm"
 READMEDIR="./readmes"
 SETUPREADME="setup_readme.htm"
 DYALOGREADME="dyalog_readme.htm"
+LICENCESDIR="./licences"
+LICENCESFILE="Licences for third-party components.docx"
 FILELISTFILE="./filelist.txt"
+
+# Set when the licences docx is taken from a separate checkout (the dyalog
+# repo) rather than from within docbin. Empty for versions that still ship it
+# inside docbin, where it is already tracked in $FILELISTFILE.
+LICENCESMOVED=""
 
 TMPFILE="$(basename $0).$$"
 TMPFILELIST="$TMPFILE.filelist.$$"
@@ -40,8 +47,9 @@ TMPFILELIST="$TMPFILE.filelist.$$"
 [ $# -ne 1 ] && Exit 1 "Usage: $0 version"
 VERSION=$1
 
-# 1. move sharplot.chm up one level and delete .svn, readmes and sharpplot directories
-echo "Move sharplot.chm, setup_readme and dyalog_readme  up one level and delete .svn, readmes and sharpplot directories .."
+# 1. move sharpplot.chm, the readmes (and, when present, the licences docx) up
+#    one level and delete the .svn, sharpplot, readmes and licences directories
+echo "Move sharpplot.chm, setup_readme, dyalog_readme (and licences, if present) up one level and clean up directories .."
 cd $FILESDIR || Exit 2 "Unable to cd to $FILESDIR after exporting from svn"
 [ ! -f $SHARPPLOTDIR/$SHARPPLOTCHM ] && Exit 2 "No $SHARPPLOTDIR/$SHARPPLOTCHM file exists; bailing"
 [ ! -f $READMEDIR/$SETUPREADME ] && Exit 2 "No $READMEDIR/$SETUPREADME file exists; bailing"
@@ -50,13 +58,25 @@ cd $FILESDIR || Exit 2 "Unable to cd to $FILESDIR after exporting from svn"
 mv $SHARPPLOTDIR/$SHARPPLOTCHM $READMEDIR/$SETUPREADME $READMEDIR/$DYALOGREADME .
 rm -rf .svn $SHARPPLOTDIR $READMEDIR
 
+# The licences directory is only checked out for versions whose third-party
+# licences file lives in the dyalog repo. When present, promote the docx to
+# $FILESDIR (where the site links to it) and drop the checkout directory.
+if [ -d "$LICENCESDIR" ]; then
+	[ ! -f "$LICENCESDIR/$LICENCESFILE" ] && Exit 2 "No $LICENCESDIR/$LICENCESFILE file exists; bailing"
+	mv "$LICENCESDIR/$LICENCESFILE" .
+	rm -rf "$LICENCESDIR"
+	LICENCESMOVED=yes
+fi
+
 # 2. Sanity check: all files in the file list should be present
 echo "Check that all files in filelist are present .."
-# We have to cope with $SHARPPLOTCHM, $SETUPREADME and $DYALOGREADME.  The simplest way is to add them to
+# We have to cope with $SHARPPLOTCHM, $SETUPREADME and $DYALOGREADME (and, when it
+# came from the dyalog repo, $LICENCESFILE).  The simplest way is to add them to
 # $FILELISTFILE at this point ..
 echo "./$SHARPPLOTCHM\tweb" >>$FILELISTFILE
 echo "./$SETUPREADME\tweb" >>$FILELISTFILE
 echo "./$DYALOGREADME\tweb" >>$FILELISTFILE
+[ -n "$LICENCESMOVED" ] && echo "./$LICENCESFILE\tweb" >>$FILELISTFILE
 egrep -v "^#|^$|^[ 	]*$" $FILELISTFILE >$TMPFILE && mv $TMPFILE $FILELISTFILE
 [ 0 -eq $(wc -l $FILELISTFILE | awk '{print $1}') ] && Exit 2 "$FILELISTFILE is empty"
 

--- a/tools/jenkins/it.md
+++ b/tools/jenkins/it.md
@@ -16,16 +16,20 @@ The Jenkinsfile on `gh-pages` (which Jenkins monitors) will be updated automatic
 v21 is the current development version, so it reads from trunk -- same paths Jenkins already uses:
 - `docbin/trunk/documentation`
 - `dyalog/trunk/svn/docs/readmes`
+- `dyalog/trunk/svn/docs/licences` (third-party licences docx; 21.0 onwards)
 
 v20.0 reads from branches (already exist):
 - `docbin/branches/20.0/documentation`
 - `dyalog/branches/20.0/svn/docs/readmes`
+
+v20.0 has no licences checkout: its third-party licences docx still ships inside docbin, so `20.0` is listed in the Jenkinsfile `LICENCES_IN_DOCBIN` variable.
 
 Future action (when v21 releases and v22 development starts):
 
 Create these SVN branches before updating `TRUNK_VERSION` to `22.0`:
 - `docbin/branches/21.0/documentation`
 - `dyalog/branches/21.0/svn/docs/readmes`
+- `dyalog/branches/21.0/svn/docs/licences`
 
 ## gitdocs2svn -- no changes needed
 


### PR DESCRIPTION
From 21.0 the "Licences for third-party components.docx" file lives in the dyalog repo (svn/docs/licences), alongside the readmes, rather than inside the docbin checkout. The deploy pipeline now checks it out next to the readmes and get_svn_docbin promotes it up into files/ and registers it in the working filelist.txt.

20.0 predates the move and still ships the docx inside docbin, so it is listed in LICENCES_IN_DOCBIN and skipped by the new checkout. A single deploy run fetches assets for every entry in PRODUCTION_VERSIONS, so the checkout is gated per version and get_svn_docbin promotes the docx only when the licences checkout is present. Emptying LICENCES_IN_DOCBIN once 20.0 retires makes the behaviour unconditional.

Refs #896