### PR TITLE
Note that Min/MaxButton hide HelpButton on a Form

### DIFF
--- a/object-reference/docs/objects/form.md
+++ b/object-reference/docs/objects/form.md
@@ -21,8 +21,8 @@ precedence. The user may obtain help by clicking on the Question (?) button and
 then on a control in the Form. It is up to you to provide the help by responding
 to the [Help](../methodorevents/help.md) event on the control.
 
-!!! note
-    If [MinButton](../properties/minbutton.md) or [MaxButton](../properties/maxbutton.md) is `1`, then [HelpButton](../properties/helpbutton.md) is always hidden, whatever its value. This is a Microsoft Windows limitation.
+!!! Info "Information"
+    If either [MinButton](../properties/minbutton.md) or [MaxButton](../properties/maxbutton.md) is `1`, then [HelpButton](../properties/helpbutton.md) is always hidden, irrespective of its value. This is a Microsoft Windows limitation.
 
 By default, a Form may be moved and resized using the mouse. These actions
 are achieved by dragging on the title bar and border respectively. It follows

--- a/object-reference/docs/objects/form.md
+++ b/object-reference/docs/objects/form.md
@@ -21,6 +21,9 @@ precedence. The user may obtain help by clicking on the Question (?) button and
 then on a control in the Form. It is up to you to provide the help by responding
 to the [Help](../methodorevents/help.md) event on the control.
 
+!!! note
+    If [MinButton](../properties/minbutton.md) or [MaxButton](../properties/maxbutton.md) is `1`, then [HelpButton](../properties/helpbutton.md) is always hidden, whatever its value. This is a Microsoft Windows limitation.
+
 By default, a Form may be moved and resized using the mouse. These actions
 are achieved by dragging on the title bar and border respectively. It follows
 that a Form that is [Moveable ](../properties/moveable.md)**must** have a title bar, and one that is [Sizeable](../properties/sizeable.md) **must** have a border, regardless of the value of other properties. Also, if

--- a/object-reference/docs/properties/helpbutton.md
+++ b/object-reference/docs/properties/helpbutton.md
@@ -4,8 +4,7 @@
 
 This is a Boolean property that specifies whether or not a Question (?) button appears in the title bar of a Form or SubForm. However, this does not apply if the Form has a maximise or minimise button which both take precedence. The user may obtain help by clicking on the Question (?) button and then on a control in the Form. It is up to you to provide the help by responding to the [Help](../methodorevents/help.md) event on the control. The default value of HelpButton is 0.
 
-!!! note
-    If [MinButton](minbutton.md) or [MaxButton](maxbutton.md) is `1`, then HelpButton is always hidden, whatever its value. This is a Microsoft Windows limitation.
+If either [MinButton](minbutton.md) or [MaxButton](maxbutton.md) is `1`, then HelpButton is always hidden, irrespective of its value. This is a Microsoft Windows limitation.
 
 **Application**
 

--- a/object-reference/docs/properties/helpbutton.md
+++ b/object-reference/docs/properties/helpbutton.md
@@ -4,6 +4,9 @@
 
 This is a Boolean property that specifies whether or not a Question (?) button appears in the title bar of a Form or SubForm. However, this does not apply if the Form has a maximise or minimise button which both take precedence. The user may obtain help by clicking on the Question (?) button and then on a control in the Form. It is up to you to provide the help by responding to the [Help](../methodorevents/help.md) event on the control. The default value of HelpButton is 0.
 
+!!! note
+    If [MinButton](minbutton.md) or [MaxButton](maxbutton.md) is `1`, then HelpButton is always hidden, whatever its value. This is a Microsoft Windows limitation.
+
 **Application**
 
 Objects: [Form](../objects/form.md), [PropertySheet](../objects/propertysheet.md), [SubForm](../objects/subform.md)

--- a/object-reference/docs/properties/maxbutton.md
+++ b/object-reference/docs/properties/maxbutton.md
@@ -6,6 +6,9 @@ This property determines whether or not an object has a "maximise" button. Press
 
 Note that MaxButton is independent of [Sizeable](sizeable.md), that is, you can define an object that can be maximised but not resized. If any of the properties MaxButton, [MinButton](minbutton.md), [SysMenu](sysmenu.md) and [Sizeable](sizeable.md) are set to 1, the object will have a title bar.
 
+!!! note
+    If MaxButton or [MinButton](minbutton.md) is `1`, then [HelpButton](helpbutton.md) is always hidden, whatever its value. This is a Microsoft Windows limitation.
+
 **Application**
 
 Objects: [Form](../objects/form.md), [HTMLRenderer](../objects/htmlrenderer.md), [SubForm](../objects/subform.md)

--- a/object-reference/docs/properties/maxbutton.md
+++ b/object-reference/docs/properties/maxbutton.md
@@ -6,8 +6,7 @@ This property determines whether or not an object has a "maximise" button. Press
 
 Note that MaxButton is independent of [Sizeable](sizeable.md), that is, you can define an object that can be maximised but not resized. If any of the properties MaxButton, [MinButton](minbutton.md), [SysMenu](sysmenu.md) and [Sizeable](sizeable.md) are set to 1, the object will have a title bar.
 
-!!! note
-    If MaxButton or [MinButton](minbutton.md) is `1`, then [HelpButton](helpbutton.md) is always hidden, whatever its value. This is a Microsoft Windows limitation.
+If either [MinButton](minbutton.md) or MaxButton is `1`, then [HelpButton](helpbutton.md) is always hidden, irrespective of its value. This is a Microsoft Windows limitation.
 
 **Application**
 

--- a/object-reference/docs/properties/minbutton.md
+++ b/object-reference/docs/properties/minbutton.md
@@ -8,6 +8,9 @@ Note that MinButton is independent of [Sizeable](sizeable.md), that is, you can 
 
 If any of the properties MinButton, [MaxButton](maxbutton.md), [SysMenu](sysmenu.md), and [Moveable](moveable.md) are set to 1, the object will have a title bar.
 
+!!! note
+    If MinButton or [MaxButton](maxbutton.md) is `1`, then [HelpButton](helpbutton.md) is always hidden, whatever its value. This is a Microsoft Windows limitation.
+
 **Application**
 
 Objects: [Form](../objects/form.md), [HTMLRenderer](../objects/htmlrenderer.md), [SubForm](../objects/subform.md)

--- a/object-reference/docs/properties/minbutton.md
+++ b/object-reference/docs/properties/minbutton.md
@@ -8,8 +8,7 @@ Note that MinButton is independent of [Sizeable](sizeable.md), that is, you can 
 
 If any of the properties MinButton, [MaxButton](maxbutton.md), [SysMenu](sysmenu.md), and [Moveable](moveable.md) are set to 1, the object will have a title bar.
 
-!!! note
-    If MinButton or [MaxButton](maxbutton.md) is `1`, then [HelpButton](helpbutton.md) is always hidden, whatever its value. This is a Microsoft Windows limitation.
+If either MinButton or [MaxButton](maxbutton.md) is `1`, then [HelpButton](helpbutton.md) is always hidden, irrespective of its value. This is a Microsoft Windows limitation.
 
 **Application**
 


### PR DESCRIPTION
Add a note to the Form object and the HelpButton, MaxButton, and MinButton property pages: when MinButton or MaxButton is 1, HelpButton is always hidden regardless of its value, which is a Microsoft Windows limitation.

Fixes #937