### PR TITLE
Document the 4061 Thread Discrepancy Counts I-beam

### DIFF
--- a/language-reference-guide/docs/primitive-operators/i-beam/index.md
+++ b/language-reference-guide/docs/primitive-operators/i-beam/index.md
@@ -94,6 +94,7 @@ Key to notes in the following table:
 |`4001` |[Change User](./change-user.md)                                                       |X     |
 |`4002` |[Reap Forked Tasks](./reap-forked-tasks.md)                                           |AIX   |
 |`4007` |[Signal Counts](./signal-counts.md)                                                   |X     |
+|`4061` |[Thread Discrepancy Counts](./thread-discrepancy-counts.md)                           |&nbsp;|
 |`5171` |[Discard Source Information](./discard-source-information.md)                         |&nbsp;|
 |`5172` |[Discard Source Code](./discard-source-code.md)                                       |&nbsp;|
 |`5176` |[List Loaded Files](./list-loaded-files.md)                                           |&nbsp;|

--- a/language-reference-guide/docs/primitive-operators/i-beam/thread-discrepancy-counts.md
+++ b/language-reference-guide/docs/primitive-operators/i-beam/thread-discrepancy-counts.md
@@ -1,0 +1,37 @@
+---
+search:
+  boost: 2
+---
+
+
+# <span>Thread Discrepancy Counts</span> `R←4061⌶Y`{{key}}
+
+`Y` must be `0` but is ignored.
+
+As it runs, the interpreter checks that its own record of each thread's scheduling status is consistent. These checks are always enabled.
+
+The result `R` is an integer vector of the number of times each discrepancy has been detected since the interpreter started:
+
+|Element|Discrepancy                   |
+|-------|------------------------------|
+|`R[1]` |Inconsistent thread status    |
+|`R[2]` |Possible missed thread wakeup |
+
+A non-zero count reports that the interpreter detected an inconsistency in its own scheduling, not that the application is at fault.
+
+Details of each occurrence are written to the log file enabled by [`109⌶`](log-file-for-deprecations.md). This function reports the counts when no such log file is enabled, so that you can see whether anything was detected, then enable logging and run the application again to capture the details. The first time a discrepancy is detected, if no log file is enabled, a message is written to the Status window.
+
+!!! note
+    These checks verify assumptions made by the current thread scheduler and are expected to be withdrawn in a later release.
+
+<h2 class="example">Example</h2>
+```apl
+      4061⌶0
+5 1
+```
+Five inconsistent thread statuses and one possible missed thread wakeup have been detected.
+
+<!-- Hidden search keywords -->
+<div style="display: none;">
+  4061⌶
+</div>

--- a/language-reference-guide/mkdocs.yml
+++ b/language-reference-guide/mkdocs.yml
@@ -242,6 +242,7 @@ nav:
               - '4001: Change User': primitive-operators/i-beam/change-user.md
               - '4002: Reap Forked Tasks': primitive-operators/i-beam/reap-forked-tasks.md
               - '4007: Signal Counts': primitive-operators/i-beam/signal-counts.md
+              - '4061: Thread Discrepancy Counts': primitive-operators/i-beam/thread-discrepancy-counts.md
               - '5171: Discard Source Information': primitive-operators/i-beam/discard-source-information.md
               - '5172: Discard Source Code': primitive-operators/i-beam/discard-source-code.md
               - '5176: List Loaded Files': primitive-operators/i-beam/list-loaded-files.md


### PR DESCRIPTION
Add the Thread Discrepancy Counts page for `4061⌶`, which reports how many
times the interpreter has detected an inconsistency in its own thread
scheduling: an inconsistent thread status, or a possible missed thread
wakeup. Note that the argument must be 0 and is ignored, that the checks are
always enabled, that the details go to the log file enabled by `109⌶`, and
that a message is written to the Status window on the first detection when no
log file is enabled.

List the new I-beam in the I-Beam table and add it to the navigation.

Refs #754