### PR TITLE
Show the Documents folder name as it actually varies

### DIFF
--- a/earlier-release-notes/docs/release-notes-v19-0/configuration-parameters/log-file.md
+++ b/earlier-release-notes/docs/release-notes-v19-0/configuration-parameters/log-file.md
@@ -4,7 +4,7 @@ This parameter specifies the pathname to the Session log file; it can be absolut
 
 The Session log file is not interchangeable between different versions/editions/widths of Dyalog – this means that opening a new instance of Dyalog will overwrite any contents of the Session log file populated by an already‑running instance. However, if the LOG_FILE parameter contains a '`*`' (for example,  `JD.*.dlf` ) then at start-up Dyalog will attempt to open, and then **lock**, a file where the '`*`' has been replaced with an increasing integer value (starting with 000, so `JD.000.dlf`, `JD.001.dlf` etc). If said file cannot be opened and locked, the value will be incremented. The process will fail, and no log will be used if the extension number would exceed 999.
 
-The default is `Users\<username>\Documents\Dyalog APL-<bits> <DyalogMajor>.<DyalogMinor> <Unicode|Classic> Files\default_*.dlf`, for example, `Users\Bob\Documents\Dyalog APL-64 19.0 Unicode Files\default_*.dlf`
+The default is `Users\<username>\Documents\Dyalog APL[-64] <DyalogMajor>.<DyalogMinor> [Unicode ]Files\default_*.dlf`, for example, `Users\Bob\Documents\Dyalog APL-64 19.0 Unicode Files\default_*.dlf`
 
 Note that the LogFile property of `⎕SE` reports the name of the log file that is being used.
 

--- a/earlier-release-notes/docs/release-notes-v19-0/configuration-parameters/log-file.md
+++ b/earlier-release-notes/docs/release-notes-v19-0/configuration-parameters/log-file.md
@@ -4,7 +4,7 @@ This parameter specifies the pathname to the Session log file; it can be absolut
 
 The Session log file is not interchangeable between different versions/editions/widths of Dyalog – this means that opening a new instance of Dyalog will overwrite any contents of the Session log file populated by an already‑running instance. However, if the LOG_FILE parameter contains a '`*`' (for example,  `JD.*.dlf` ) then at start-up Dyalog will attempt to open, and then **lock**, a file where the '`*`' has been replaced with an increasing integer value (starting with 000, so `JD.000.dlf`, `JD.001.dlf` etc). If said file cannot be opened and locked, the value will be incremented. The process will fail, and no log will be used if the extension number would exceed 999.
 
-The default is `Users\<username>\Documents\Dyalog APL[-64] <DyalogMajor>.<DyalogMinor> [Unicode ]Files\default_*.dlf`, for example, `Users\Bob\Documents\Dyalog APL-64 19.0 Unicode Files\default_*.dlf`
+The default is `<DocumentsDirectory>\Dyalog APL[-64] <DyalogMajor>.<DyalogMinor> [Unicode ]Files\default_*.dlf`, for example, `C:\Users\Bob\Documents\Dyalog APL-64 19.0 Unicode Files\default_*.dlf`
 
 Note that the LogFile property of `⎕SE` reports the name of the log file that is being used.
 

--- a/windows-installation-and-configuration-guide/docs/configuration-parameters/log-file.md
+++ b/windows-installation-and-configuration-guide/docs/configuration-parameters/log-file.md
@@ -8,6 +8,6 @@ This is mitigated by including a __\*__ character in the default Session log’s
 
 NOTE: The LogFile property of `⎕SE` reports the name of the log file that is being used.
 
-The default is __<DocumentsDirectory\>\Dyalog APL-<bits\> <DyalogMajor\><DyalogMinor\> <Unicode|Classic\> Files\default_\*.dlfx__, for example, __C:\Users\Bob\Documents\Dyalog APL-64 20.0 Unicode Files\default_\*.dlfx__
+The default is __<DocumentsDirectory\>\Dyalog APL[-64] <DyalogMajor\>.<DyalogMinor\> [Unicode ]Files\default_\*.dlfx__, for example, __C:\Users\Bob\Documents\Dyalog APL-64 20.0 Unicode Files\default_\*.dlfx__
 
 See also [Use log file](../configuring-the-ide/configuration-dialog/configuration-dialog-session-tab.md).


### PR DESCRIPTION
The width is omitted for the 32-bit interpreter and the edition for the Classic edition, so the folder is Dyalog APL 19.0 Files for the 32-bit Classic edition, not Dyalog APL-32 19.0 Classic Files. Mark both parts optional instead of implying that each is always present, in the current guide and in the copy carried by the v19.0 release notes. While here, add the separator between the major and minor version numbers in the current guide, which the example already shows.

Refs Dyalog/documentation#959