### PR TITLE
Point three broken cross-document links at their targets

### DIFF
--- a/language-reference-guide/docs/system-functions/format-monadic.md
+++ b/language-reference-guide/docs/system-functions/format-monadic.md
@@ -40,8 +40,8 @@ search:
 
 ## See Also
 
-- [Display of Arrays](../../../programming-reference-guide/introduction/arrays/display-of-arrays) – how arrays appear in the session
-- [`⍕`](../primitive-functions/format) – Format: returns a character array (vector or matrix depending on input rank)
+- [Display of Arrays](../../programming-reference-guide/introduction/arrays/display-of-arrays) – how arrays appear in the session
+- [`⍕`](../primitive-functions/format.md) – Format: returns a character array (vector or matrix depending on input rank)
 
 <!-- Hidden search keywords -->
 <div style="display: none;">

--- a/language-reference-guide/docs/system-functions/format-monadic.md
+++ b/language-reference-guide/docs/system-functions/format-monadic.md
@@ -40,8 +40,8 @@ search:
 
 ## See Also
 
-- [Display of Arrays](../../programming-reference-guide/introduction/arrays/display-of-arrays) – how arrays appear in the session
-- [`⍕`](format) – Format: returns a character array (vector or matrix depending on input rank)
+- [Display of Arrays](../../../programming-reference-guide/introduction/arrays/display-of-arrays) – how arrays appear in the session
+- [`⍕`](../primitive-functions/format) – Format: returns a character array (vector or matrix depending on input rank)
 
 <!-- Hidden search keywords -->
 <div style="display: none;">

--- a/language-reference-guide/docs/system-functions/pp.md
+++ b/language-reference-guide/docs/system-functions/pp.md
@@ -7,7 +7,7 @@ search:
 
 `⎕PP` is the number of significant digits in the display of numeric output. `⎕PP` may be assigned any integer value in the range 1 to 34. `⎕PP` has Namespace scope.
 
-`⎕PP` is used to format numbers displayed directly. It is an implicit argument of monadic function [Format (`⍕`)](format), [monadic `⎕FMT`](format-monadic), and for display of numbers using [`⎕`](../system-functions/evaluated-input-output) and [`⍞`](../system-functions/character-input-output) output. `⎕PP` is ignored for the display of integers.
+`⎕PP` is used to format numbers displayed directly. It is an implicit argument of monadic function [Format (`⍕`)](../primitive-functions/format), [monadic `⎕FMT`](format-monadic), and for display of numbers using [`⎕`](../system-functions/evaluated-input-output) and [`⍞`](../system-functions/character-input-output) output. `⎕PP` is ignored for the display of integers.
 
 <h2 class="example">Examples</h2>
 ```apl
@@ -27,13 +27,13 @@ If `⎕PP` is set to a value `≥17` (when `⎕FR` is 645) or 34 (when `⎕FR` i
 
 `⎕PP` does **not** apply in the following contexts:
 
-- [Array notation output](display-of-arrays.md#array-notation) (when `]APLAN.Output` is on)
+- [Array notation output](../../../programming-reference-guide/introduction/arrays/display-of-arrays.md#array-notation) (when `]APLAN.Output` is on)
 - [`⎕JSON`](json.md) export
 - [`⎕CSV`](csv.md) export
 
 ## See Also
 
-- [Display of Arrays](../../programming-reference-guide/introduction/arrays/display-of-arrays.md) – how arrays appear in the session
+- [Display of Arrays](../../../programming-reference-guide/introduction/arrays/display-of-arrays.md) – how arrays appear in the session
 
 <!-- Hidden search keywords -->
 <div style="display: none;">

--- a/language-reference-guide/docs/system-functions/pp.md
+++ b/language-reference-guide/docs/system-functions/pp.md
@@ -7,7 +7,7 @@ search:
 
 `⎕PP` is the number of significant digits in the display of numeric output. `⎕PP` may be assigned any integer value in the range 1 to 34. `⎕PP` has Namespace scope.
 
-`⎕PP` is used to format numbers displayed directly. It is an implicit argument of monadic function [Format (`⍕`)](../primitive-functions/format), [monadic `⎕FMT`](format-monadic), and for display of numbers using [`⎕`](../system-functions/evaluated-input-output) and [`⍞`](../system-functions/character-input-output) output. `⎕PP` is ignored for the display of integers.
+`⎕PP` is used to format numbers displayed directly. It is an implicit argument of monadic function [Format (`⍕`)](../primitive-functions/format.md), [monadic `⎕FMT`](format-monadic), and for display of numbers using [`⎕`](../system-functions/evaluated-input-output) and [`⍞`](../system-functions/character-input-output) output. `⎕PP` is ignored for the display of integers.
 
 <h2 class="example">Examples</h2>
 ```apl
@@ -27,13 +27,13 @@ If `⎕PP` is set to a value `≥17` (when `⎕FR` is 645) or 34 (when `⎕FR` i
 
 `⎕PP` does **not** apply in the following contexts:
 
-- [Array notation output](../../../programming-reference-guide/introduction/arrays/display-of-arrays.md#array-notation) (when `]APLAN.Output` is on)
+- [Array notation output](../../programming-reference-guide/introduction/arrays/display-of-arrays.md#array-notation) (when `]APLAN.Output` is on)
 - [`⎕JSON`](json.md) export
 - [`⎕CSV`](csv.md) export
 
 ## See Also
 
-- [Display of Arrays](../../../programming-reference-guide/introduction/arrays/display-of-arrays.md) – how arrays appear in the session
+- [Display of Arrays](../../programming-reference-guide/introduction/arrays/display-of-arrays.md) – how arrays appear in the session
 
 <!-- Hidden search keywords -->
 <div style="display: none;">

--- a/language-reference-guide/docs/system-functions/pp.md
+++ b/language-reference-guide/docs/system-functions/pp.md
@@ -7,7 +7,7 @@ search:
 
 `⎕PP` is the number of significant digits in the display of numeric output. `⎕PP` may be assigned any integer value in the range 1 to 34. `⎕PP` has Namespace scope.
 
-`⎕PP` is used to format numbers displayed directly. It is an implicit argument of monadic function [Format (`⍕`)](../primitive-functions/format.md), [monadic `⎕FMT`](format-monadic), and for display of numbers using [`⎕`](../system-functions/evaluated-input-output) and [`⍞`](../system-functions/character-input-output) output. `⎕PP` is ignored for the display of integers.
+`⎕PP` is used to format numbers displayed directly. It is an implicit argument of monadic function [_format_ (`⍕`)](../primitive-functions/format.md), [monadic `⎕FMT`](format-monadic), and for display of numbers using [`⎕`](../system-functions/evaluated-input-output) and [`⍞`](../system-functions/character-input-output) output. `⎕PP` is ignored for the display of integers.
 
 <h2 class="example">Examples</h2>
 ```apl


### PR DESCRIPTION
Fixes #962.

Three links in the Language Reference Guide resolved inside `system-functions/`, where their targets do not exist.

`format-monadic.md` line 44 and `pp.md` line 10 both link the primitive function Format, written as `](format)`, which names no page in `system-functions/`. They now address `../primitive-functions/format.md`.

`pp.md` line 30 gave only the file name of `display-of-arrays.md`, which lives in the Programming Reference Guide. It now carries the full path, matching the link to that whole page further down the same file.