### PR TITLE
⎕FMT, ⎕TRAP, ⎕UCS: special control chars NEED to be uppercase

### DIFF
--- a/language-reference-guide/docs/system-functions/format-dyadic.md
+++ b/language-reference-guide/docs/system-functions/format-dyadic.md
@@ -60,6 +60,10 @@ The **format specification** consists of a series of control phrases, with adjac
 
 The surrounding affixture delimiters may be replaced by the alternative pairs described for Text Insertion.
 
+!!! Warning "Warning"
+    Note, the affixtures, qualifiers and control phrases must be specified in upper case.
+
+
 <h2 class="example">Examples</h2>
 
 A vector is treated as a column:

--- a/language-reference-guide/docs/system-functions/trap.md
+++ b/language-reference-guide/docs/system-functions/trap.md
@@ -27,6 +27,9 @@ Table: Trappable Event Codes {: #TrapEvents }
 |`N`|Next|The event is excluded from the current `⎕TRAP` definition.  The search will continue through further localised definitions of `⎕TRAP` .|
 |`S`|Stop|Stops the search and causes the normal APL action to be taken in the environment in which the event occurred.|
 
+!!! Warning "Warning"
+    Note, the ACTION codes must be specified in upper case.
+
 |Code     |Event                                          |
 |---------|-----------------------------------------------|
 |`0`      |`Any event in range 1-999`                     |

--- a/language-reference-guide/docs/system-functions/ucs.md
+++ b/language-reference-guide/docs/system-functions/ucs.md
@@ -13,6 +13,9 @@ The optional left argument `X` is either a simple character vector or a one- or 
 - `'UTF-16'`
 - `'UTF-32'`
 
+!!! Warning "Warning"
+    Note, the encoding scheme value must be in specified upper case.
+
 The second element (if present) is either `0` (the default) to consume and return byte values as positive integers or `83` to use 1-byte integers (type 83). `83` can only be used with `'UTF-8'`.
 
 If `X` does not abide by the above restrictions, a `DOMAIN ERROR` is issued.


### PR DESCRIPTION
As #806 describes, warn that  special codes must be in upper case