### PR TITLE
Fix remaining minor documentation items

### DIFF
--- a/language-reference-guide/docs/system-functions/dt.md
+++ b/language-reference-guide/docs/system-functions/dt.md
@@ -20,7 +20,7 @@ A *datetime* is a date and time of day represented by a *time number*, a *timest
 
 `X` can be a single element (<code>X<sub>R</sub></code>) or a 2-element vector (<code>X<sub>Y</sub> X<sub>R</sub></code>). Each of <code>X<sub>Y</sub></code> and <code>X<sub>R</sub></code> can be:
 
-- an integer *datetime code* (see [](#time-numbers) and [](#timestamps))
+- an integer *datetime code* (see [](#timenumbers) and [](#timestamps))
 - a character vector containing a *pattern* that describes how a datetime is formatted as text (see [Formatting Patterns](#formatting-patterns)).
 
 When <code>X<sub>R</sub></code> is an integer it must be either `0` or a code from [](#timenumbers) or [](#timestamps). `0` specifies that the elements of `Y` are to be validated; a non-zero value specifies the datetime representation to which the elements of `Y` are to be converted. When <code>X<sub>R</sub></code> is a pattern, the elements of `R` are character vectors, each derived by formatting the corresponding element of `Y` as text according to the pattern.

--- a/language-reference-guide/docs/system-functions/ucs.md
+++ b/language-reference-guide/docs/system-functions/ucs.md
@@ -15,7 +15,7 @@ The optional left argument `X` is either a simple character vector or a one- or 
 
 The second element (if present) is either `0` (the default) which causes ⎕UCS to consume and return integers between 0 and 255 or `83` which causes ⎕UCS to consume and return integers between `¯128` and `+127`. `83` can only be used with `'UTF-8'`.  See [`⎕DR`](dr.md) for more information about type 83 values.
 
-If `X` does not abide by the above restrictions, a `DOMAIN ERROR` is issued.
+If `X` is any other value, a `DOMAIN ERROR` is generated.
 
 If `X` is omitted, `Y` is a simple character or integer array, and the result `R` is a simple integer or character array with the same rank and shape as `Y`.
 

--- a/unix-installation-and-configuration-guide/docs/miscellaneous.md
+++ b/unix-installation-and-configuration-guide/docs/miscellaneous.md
@@ -1,4 +1,6 @@
-# Session logfile
+# Miscellaneous
+
+## Session logfile
 
 By default the session logfile is called default.dlf. By default this file is created as ~/.dyalog/default.dlf on Linux, AIX and macOS, and in ~/.config/dyalog/default.dlf on the Pi. This can be overridden by setting the environment variable **LOGFILE**.
 

--- a/unix-installation-and-configuration-guide/docs/starting-apl-from-scripts.md
+++ b/unix-installation-and-configuration-guide/docs/starting-apl-from-scripts.md
@@ -1,6 +1,4 @@
-# Miscellaneous
-
-## Running from scripts
+# Starting APL from scripts
 
 Dyalog APL can be run with input being directed from a script file, and output being redirected as well.
 
@@ -12,7 +10,7 @@ The Unicode edition by default expects that the input file has Unicode character
 
 The example below shows the same set of APL expressions as they would appear in a script file for classic and Unicode editions: it is rather easier to read the Unicode edition's input !
 
-### Classic example
+## Classic example
 ```apl
 ^O(2^NLnqK.K K^OGetBuildID^NK^O),(^NK.KLwgK^OAPLVersion^NK^O)
 ^Ovar^N[1+1 J^HC^O Check input from file: Classic
@@ -21,7 +19,7 @@ The example below shows the same set of APL expressions as they would appear in 
 ^Nloff
 ```
 
-### Unicode example
+## Unicode example
 ```apl
 (+2⎕NQ'.'  'GetBuildID'),('.'⎕WG'APLVersion')
 var←1÷1 ⍝ Check input from file: Unicode

--- a/unix-installation-and-configuration-guide/mkdocs.yml
+++ b/unix-installation-and-configuration-guide/mkdocs.yml
@@ -64,7 +64,7 @@ nav:
       - Configuration Files: configuration-parameters/configuration-files.md
       - Environment Variables: configuration-parameters/environment-variables.md
   - Configuring the Editor: configuring-the-editor.md
-  - Starting from scripts: starting-apl-from-scripts.md
+  - Starting APL from scripts: starting-apl-from-scripts.md
   - Magic: magic.md
   - SE and SALT: se-and-user-commands.md
   - HOME dyalog directory: home-dyalog-directory.md


### PR DESCRIPTION
- dt: aim the datetime-code cross-reference at the Time numbers table id so it renders as a table reference instead of a blank
- ucs: reword the domain-error sentence to name the triggering case
- unix miscellaneous: title now matches the filename and contents list, with the session logfile text as a subsection
- unix starting APL from scripts: title, filename, and contents list now agree, and the redundant inner heading is gone

Part of #861.