### PR TITLE
List what each system variable is an implicit argument of

### DIFF
--- a/language-reference-guide/docs/system-functions/ct.md
+++ b/language-reference-guide/docs/system-functions/ct.md
@@ -5,15 +5,22 @@ search:
 
 # <span>Comparison Tolerance</span> `⎕CT`
 
-The value of `⎕CT` determines the precision with which two numbers are judged to be equal.  Two numbers, `X` and `Y`, are judged to be equal if `(|X-Y)≤⎕CT×(|X)⌈|Y`where `≤` is applied without tolerance.
+The value of `⎕CT` determines the precision with which two numbers are judged to be equal.
+
+`⎕CT` is an [implicit argument](../primitive-functions/notes.md#implicit-arguments) of:
+
+- monadic functions: [`⌈`](../primitive-functions/ceiling.md), [`⌊`](../primitive-functions/floor.md), [`∪`](../primitive-functions/unique.md), [`≠`](../primitive-functions/unique-mask.md)
+- dyadic functions: [`~`](../primitive-functions/without.md), [`<`](../primitive-functions/less-than.md), [`≤`](../primitive-functions/less-than-or-equal-to.md), [`=`](../primitive-functions/equal-to.md), [`≥`](../primitive-functions/greater-than-or-equal-to.md), [`>`](../primitive-functions/greater-than.md), [`≠`](../primitive-functions/not-equal-to.md), [`≡`](../primitive-functions/match.md), [`≢`](../primitive-functions/not-match.md), [`⍳`](../primitive-functions/index-of.md), [`∊`](../primitive-functions/membership.md), [`∪`](../primitive-functions/union.md), [`∩`](../primitive-functions/intersection.md), [`⍷`](../primitive-functions/find.md), [`|`](../primitive-functions/magnitude.md), [`∨`](../primitive-functions/greatest-common-divisor-or.md), [`∧`](../primitive-functions/lowest-common-multiple-and.md)
+- operators: [`⌸`](../primitive-operators/key.md)
+- system functions: [`⎕FMT`](format-dyadic.md)
+
+Two numbers, `X` and `Y`, are judged to be equal if `(|X-Y)≤⎕CT×(|X)⌈|Y`where `≤` is applied without tolerance.
 
 Thus `⎕CT` is not used as an absolute value in comparisons, but rather specifies a relative value that is dependent on the magnitude of the number with the greater magnitude. It then follows that `⎕CT` has no effect when either of the numbers is zero.
 
 `⎕CT` may be assigned any value in the range from `0` to  `2*¯32`  (about `2.3E¯10`). A value of `0` ensures exact comparison.  The value in a clear workspace is `1E¯14`. `⎕CT` has Namespace scope.
 
 If [`⎕FR`](fr.md) is 1287, the system uses `⎕DCT`. See [Decimal Comparison Tolerance ](dct.md).
-
-`⎕CT` and `⎕DCT` are implicit arguments of the monadic primitive functions Ceiling (`⌈`), Floor (`⌊`) and Unique (`∪`), and of the dyadic functions Equal (`=`), Excluding (`~`), Find (`⍷`), Greater (`>`), Greater or Equal (`≥`), Greatest Common Divisor (`∨`), Index of (`⍳`), Intersection (`∩`), Less (`<`), Less or Equal (`≤`), Lowest Common Multiple (`∧`), Match (`≡`), Membership (`∊`), Not Match (`≢`), Not Equal (`≠`), Residue (`|`) and Union (`∪`), as well as `⎕FMT` O-format.
 
 <h2 class="example">Examples</h2>
 ```apl

--- a/language-reference-guide/docs/system-functions/dct.md
+++ b/language-reference-guide/docs/system-functions/dct.md
@@ -7,9 +7,14 @@ search:
 
 The value of `⎕DCT` determines the precision with which two numbers are judged to be equal when the value of `⎕FR` is 1287. If `⎕FR` is 645, the system uses `⎕CT`.
 
-`⎕DCT` may be assigned any value in the range from `0` to `2*¯32` (about `2.3283064365386962890625E¯10`). A value of `0` ensures exact comparison. The value in a clear workspace is `1E¯28`. `⎕DCT` has Namespace scope.
+`⎕DCT` is an [implicit argument](../primitive-functions/notes.md#implicit-arguments) of:
 
-`⎕CT` and `⎕DCT` are implicit arguments of the monadic primitive functions Ceiling (`⌈`), Floor (`⌊`) and Unique (`∪`), and of the dyadic functions Equal (`=`), Excluding (`~`), Find (`⍷`), Greater (`>`), Greater or Equal (`≥`), Greatest Common Divisor (`∨`), Index of (`⍳`), Intersection (`∩`), Less (`<`), Less or Equal (`≤`), Lowest Common Multiple (`∧`), Match (`≡`), Membership (`∊`), Not Match (`≢`), Not Equal (`≠`), Residue (`|`) and Union (`∪`), as well as `⎕FMT` O-format.
+- monadic functions: [`⌈`](../primitive-functions/ceiling.md), [`⌊`](../primitive-functions/floor.md), [`∪`](../primitive-functions/unique.md), [`≠`](../primitive-functions/unique-mask.md)
+- dyadic functions: [`~`](../primitive-functions/without.md), [`<`](../primitive-functions/less-than.md), [`≤`](../primitive-functions/less-than-or-equal-to.md), [`=`](../primitive-functions/equal-to.md), [`≥`](../primitive-functions/greater-than-or-equal-to.md), [`>`](../primitive-functions/greater-than.md), [`≠`](../primitive-functions/not-equal-to.md), [`≡`](../primitive-functions/match.md), [`≢`](../primitive-functions/not-match.md), [`⍳`](../primitive-functions/index-of.md), [`∊`](../primitive-functions/membership.md), [`∪`](../primitive-functions/union.md), [`∩`](../primitive-functions/intersection.md), [`⍷`](../primitive-functions/find.md), [`|`](../primitive-functions/magnitude.md), [`∨`](../primitive-functions/greatest-common-divisor-or.md), [`∧`](../primitive-functions/lowest-common-multiple-and.md)
+- operators: [`⌸`](../primitive-operators/key.md)
+- system functions: [`⎕FMT`](format-dyadic.md)
+
+`⎕DCT` may be assigned any value in the range from `0` to `2*¯32` (about `2.3283064365386962890625E¯10`). A value of `0` ensures exact comparison. The value in a clear workspace is `1E¯28`. `⎕DCT` has Namespace scope.
 
 For further information, see [Comparison Tolerance](ct.md).
 

--- a/language-reference-guide/docs/system-functions/div.md
+++ b/language-reference-guide/docs/system-functions/div.md
@@ -7,11 +7,14 @@ search:
 
 The value of `⎕DIV` determines how division by zero is to be treated.  If `⎕DIV=0`, division by 0 produces a `DOMAIN ERROR` except that the special case of `0÷0` returns 1.
 
+`⎕DIV` is an [implicit argument](../primitive-functions/notes.md#implicit-arguments) of:
+
+- monadic functions: [`÷`](../primitive-functions/reciprocal.md)
+- dyadic functions: [`÷`](../primitive-functions/divide.md)
+
 If `⎕DIV=1`, division by 0 returns 0.
 
-`⎕DIV` may be assigned the value 0 or 1.  The value in a clear workspace is 0.
-
-`⎕DIV` is an implicit argument of the monadic function Reciprocal (`÷`) and the dyadic function Divide (`÷`). `⎕DIV` has Namespace scope.
+`⎕DIV` may be assigned the value 0 or 1.  The value in a clear workspace is 0. `⎕DIV` has Namespace scope.
 
 <h2 class="example">Examples</h2>
 ```apl

--- a/language-reference-guide/docs/system-functions/fr.md
+++ b/language-reference-guide/docs/system-functions/fr.md
@@ -7,6 +7,17 @@ search:
 
 The value of `⎕FR` determines the way that floating-point operations are performed.
 
+`⎕FR` is an [implicit argument](../primitive-functions/notes.md#implicit-arguments) of:
+
+- monadic functions that compute real numbers: [`÷`](../primitive-functions/reciprocal.md), [`*`](../primitive-functions/exponential.md), [`⍟`](../primitive-functions/natural-logarithm.md), [`!`](../primitive-functions/factorial.md), [`○`](../primitive-functions/pi-times.md), [`⌹`](../primitive-functions/matrix-inverse.md)
+- dyadic functions that compute real numbers: [`+`](../primitive-functions/plus.md), [`-`](../primitive-functions/minus.md), [`×`](../primitive-functions/times.md), [`÷`](../primitive-functions/divide.md), [`*`](../primitive-functions/power.md), [`⍟`](../primitive-functions/logarithm.md), [`|`](../primitive-functions/magnitude.md), [`!`](../primitive-functions/binomial.md), [`○`](../primitive-functions/circular-functions.md), [`∨`](../primitive-functions/greatest-common-divisor-or.md), [`∧`](../primitive-functions/lowest-common-multiple-and.md), [`⊥`](../primitive-functions/decode.md), [`⊤`](../primitive-functions/encode.md), [`⌹`](../primitive-functions/matrix-divide.md)
+- monadic functions that perform tolerant comparisons: [`⌈`](../primitive-functions/ceiling.md), [`⌊`](../primitive-functions/floor.md), [`∪`](../primitive-functions/unique.md)
+- dyadic functions that perform tolerant comparisons: [`~`](../primitive-functions/without.md), [`<`](../primitive-functions/less-than.md), [`≤`](../primitive-functions/less-than-or-equal-to.md), [`=`](../primitive-functions/equal-to.md), [`≥`](../primitive-functions/greater-than-or-equal-to.md), [`>`](../primitive-functions/greater-than.md), [`≠`](../primitive-functions/not-equal-to.md), [`≡`](../primitive-functions/match.md), [`≢`](../primitive-functions/not-match.md), [`⍳`](../primitive-functions/index-of.md), [`∊`](../primitive-functions/membership.md), [`∪`](../primitive-functions/union.md), [`∩`](../primitive-functions/intersection.md), [`⍷`](../primitive-functions/find.md)
+- monadic functions that perform intolerant comparisons: [`⍒`](../primitive-functions/grade-down.md), [`⍋`](../primitive-functions/grade-up.md)
+- dyadic functions that perform intolerant comparisons: [`⌈`](../primitive-functions/maximum.md), [`⌊`](../primitive-functions/minimum.md), [`⍒`](../primitive-functions/dyadic-grade-down.md), [`⍋`](../primitive-functions/dyadic-grade-up.md), [`⍸`](../primitive-functions/interval-index.md)
+- operators: [`⌸`](../primitive-operators/key.md)
+- system functions: [`⎕FX`](fx.md)
+
 If `⎕FR` is 645, all floating-point calculations are performed using IEEE 754 64-bit floating-point operations and the results of these operations are represented internally using [*binary64*](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) floating-point format.
 
 If `⎕FR` is 1287, all floating-point calculations are performed using IEEE 754-2008 128-bit decimal floating-point operations and the results of these operations are represented internally using [*decimal128*](https://en.wikipedia.org/wiki/Decimal128_floating-point_format) format.

--- a/language-reference-guide/docs/system-functions/io.md
+++ b/language-reference-guide/docs/system-functions/io.md
@@ -7,9 +7,15 @@ search:
 
 `⎕IO` determines the index of the first element of a non-empty vector.
 
-`⎕IO` may be assigned the value 0 or 1.  The value in a clear workspace is 1. `⎕IO` has Namespace scope.
+`⎕IO` is an [implicit argument](../primitive-functions/notes.md#implicit-arguments) of:
 
-`⎕IO` is an implicit argument of any function derived from the bracket axis (`[K]`), of the monadic functions _fix_ (`⎕FX`), _grade down_ (`⍒`), _grade up_ (`⍋`), _index generator_ (`⍳`), _roll_ (`?`), and _where_ (`⍸`), of the dyadic functions _deal_ (`?`), _dyadic grade down_ (`⍒`), _dyadic grade up_ (`⍋`), _index_ (`⌷`), _index of_ (`⍳`), indexed assignment, indexing, _pick_ (`⊃`), _dyadic transpose_ (`⍉`), _interval index_ (`⍸`), and of the system function _extended diagnostic message_ (`⎕DMX`).
+- monadic functions: [`⍳`](../primitive-functions/index-generator.md), [`?`](../primitive-functions/roll.md), [`⍒`](../primitive-functions/grade-down.md), [`⍋`](../primitive-functions/grade-up.md), [`⍸`](../primitive-functions/where.md)
+- dyadic functions: [`⍳`](../primitive-functions/index-of.md), [`?`](../primitive-functions/deal.md), [`⍒`](../primitive-functions/dyadic-grade-down.md), [`⍋`](../primitive-functions/dyadic-grade-up.md), [`⍉`](../primitive-functions/dyadic-transpose.md), [`⊃`](../primitive-functions/pick.md), [`⌷`](../primitive-functions/index-function/index.md), [`⍸`](../primitive-functions/interval-index.md)
+- operators: [`⌸`](../primitive-operators/key.md), [`@`](../primitive-operators/at.md)
+- system functions: [`⎕FX`](fx.md), [`⎕DMX`](dmx.md)
+- other syntax: bracket indexing and bracket axis, indexed assignment
+
+`⎕IO` may be assigned the value 0 or 1.  The value in a clear workspace is 1. `⎕IO` has Namespace scope.
 
 <h2 class="example">Examples</h2>
 ```apl

--- a/language-reference-guide/docs/system-functions/ml.md
+++ b/language-reference-guide/docs/system-functions/ml.md
@@ -5,7 +5,15 @@ search:
 
 # <span>Migration Level</span> `⎕ML`
 
-`⎕ML` determines the degree of migration of the Dyalog APL language towards IBM's APL2.  Setting this variable to other than its default value of `1` changes the interpretation of certain symbols and language constructs. `⎕ML` has Namespace scope.
+`⎕ML` determines the degree of migration of the Dyalog APL language towards IBM's APL2.
+
+`⎕ML` is an [implicit argument](../primitive-functions/notes.md#implicit-arguments) of:
+
+- monadic functions: [`∊`](../primitive-functions/enlist.md), [`↑`](../primitive-functions/mix.md), [`⊃`](../primitive-functions/first.md), [`≡`](../primitive-functions/depth.md)
+- dyadic functions: [`⊂`](../primitive-functions/partitioned-enclose.md)
+- system functions: [`⎕TC`](tc.md)
+
+Setting this variable to other than its default value of `1` changes the interpretation of certain symbols and language constructs. `⎕ML` has Namespace scope.
 
 |-------|----------|-----------------------------------------------------------------------------------------------------|
 |`⎕ML←0`|&nbsp;    |Original Native Dyalog                                                                               |

--- a/language-reference-guide/docs/system-functions/pp.md
+++ b/language-reference-guide/docs/system-functions/pp.md
@@ -5,9 +5,17 @@ search:
 
 # <span>Print Precision</span> `⎕PP`
 
-`⎕PP` is the number of significant digits in the display of numeric output. `⎕PP` may be assigned any integer value in the range 1 to 34. `⎕PP` has Namespace scope.
+`⎕PP` is the number of significant digits in the display of numeric output.
 
-`⎕PP` is used to format numbers displayed directly. It is an implicit argument of monadic function [_format_ (`⍕`)](../primitive-functions/format.md), [monadic `⎕FMT`](format-monadic), and for display of numbers using [`⎕`](../system-functions/evaluated-input-output) and [`⍞`](../system-functions/character-input-output) output. `⎕PP` is ignored for the display of integers.
+`⎕PP` is an [implicit argument](../primitive-functions/notes.md#implicit-arguments) of:
+
+- monadic functions: [`⍕`](../primitive-functions/format.md)
+- system functions: [`⎕FMT`](format-monadic.md)
+- other syntax: [`⎕`](evaluated-input-output.md) and [`⍞`](character-input-output.md) output
+
+`⎕PP` is ignored for the display of integers.
+
+`⎕PP` may be assigned any integer value in the range 1 to 34. `⎕PP` has Namespace scope.
 
 <h2 class="example">Examples</h2>
 ```apl

--- a/language-reference-guide/docs/system-functions/rl.md
+++ b/language-reference-guide/docs/system-functions/rl.md
@@ -5,7 +5,14 @@ search:
 
 # <span>Random Link</span> `⎕RL`
 
-`⎕RL` is a 2-element vector. Its first element contains the  base or *random number seed* and its second element is an integer that identifies the random number generator that is currently  in use. Together these items define how the system generates random numbers using [Roll](../primitive-functions/roll.md) and [Deal](../primitive-functions/deal.md).
+`⎕RL` defines how the system generates random numbers.
+
+`⎕RL` is an [implicit argument](../primitive-functions/notes.md#implicit-arguments) of:
+
+- monadic functions: [`?`](../primitive-functions/roll.md)
+- dyadic functions: [`?`](../primitive-functions/deal.md)
+
+`⎕RL` is a 2-element vector. Its first element contains the  base or *random number seed* and its second element is an integer that identifies the random number generator that is currently  in use.
 
 In a `clear ws` `⎕RL` is `(⍬ 1)`. `⎕RL` has Namespace scope.
 


### PR DESCRIPTION
Fixes #885.

Each of the ⎕CT, ⎕DCT, ⎕DIV, ⎕FR, ⎕IO, ⎕ML, ⎕PP, and ⎕RL pages now states, near the top, what it is an implicit argument of: a cross-referenced list of the monadic functions, dyadic functions, operators, system functions, and other syntax affected (each bullet present only when non-empty), sourced from the implicit-arguments tables in the notes on primitive functions and in the system functions by category.

Note: the ⎕ML entry uses the corrected dependence (monadic ∊ ↑ ⊃ ≡; dyadic ⊂; ⎕TC). The #implicitargs table in notes.md still lists monadic ⊂ ⊆ for ⎕ML and needs the same correction separately (#581).