### PR TITLE
Generalise configuration-setting substitution across the guides

### DIFF
--- a/unix-installation-and-configuration-guide/docs/configuration-parameters/configuration-files.md
+++ b/unix-installation-and-configuration-guide/docs/configuration-parameters/configuration-files.md
@@ -40,14 +40,6 @@ If the same name is defined multiple times within a configuration file then the 
 
 An array can be used to define file paths, for example, `WSPATH: ["/dir1", "/dir2"]`. The only parameters which can be defined as arrays are **WSPATH**, **WSEXT** and **CFEXT**.
 
-## References to other Configuration Parameters
-
-Configuration parameters that are string values can include references to other configuration parameters (irrespective of where they are defined) using square bracket delimiters. For example, `MySetting: "[DYALOG]/MyFile"` will replace `[DYALOG]` with the value of the **DYALOG** configuration parameter.
-
-If the referenced configuration parameter is not defined then no substitution will take place; the reference, including the square bracket delimiters, will remain in place.
-
-To include literal square brackets in a string, prefix them with a `\` character.
-
 ## Nested Structures
 
 Configuration files support nested parameter structures by defining an object that corresponds to the structure. For example:

--- a/unix-installation-and-configuration-guide/docs/configuration-parameters/configuration-parameters.md
+++ b/unix-installation-and-configuration-guide/docs/configuration-parameters/configuration-parameters.md
@@ -14,7 +14,7 @@ For more information on configuration files, see [Configuration Files](configura
 
 ## References to other Configuration Parameters
 
-Configuration parameters that are string values can include references to other configuration parameters (irrespective of where they are defined) using square bracket delimiters. For example, `MySetting: "[DYALOG]/MyFile"` will replace `[DYALOG]` with the value of the **DYALOG** configuration parameter.
+Configuration parameters can include references to other configuration parameters (irrespective of where they are defined) using square bracket delimiters. For example, `MySetting: "[DYALOG]/MyFile"` will replace `[DYALOG]` with the value of the **DYALOG** configuration parameter.
 
 If the referenced configuration parameter is not defined then no substitution will take place; the reference, including the square bracket delimiters, will remain in place.
 

--- a/unix-installation-and-configuration-guide/docs/configuration-parameters/configuration-parameters.md
+++ b/unix-installation-and-configuration-guide/docs/configuration-parameters/configuration-parameters.md
@@ -11,3 +11,11 @@ Dyalog can be customised using configuration parameters. These can be set in var
 This provides a great deal of flexibility, enabling a user to override one setting with another. For example, a "usual" workspace size (**MAXWS**) can be defined in the user configuration file, but be temporarily superseded by entering a different value when starting a Dyalog Session from the command line.
 
 For more information on configuration files, see [Configuration Files](configuration-files.md). For more information on environment variables, see [Environment Variables](environment-variables.md).
+
+## References to other Configuration Parameters
+
+Configuration parameters that are string values can include references to other configuration parameters (irrespective of where they are defined) using square bracket delimiters. For example, `MySetting: "[DYALOG]/MyFile"` will replace `[DYALOG]` with the value of the **DYALOG** configuration parameter.
+
+If the referenced configuration parameter is not defined then no substitution will take place; the reference, including the square bracket delimiters, will remain in place.
+
+To include literal square brackets in a string, prefix them with a `\` character.

--- a/windows-installation-and-configuration-guide/docs/configuration-files.md
+++ b/windows-installation-and-configuration-guide/docs/configuration-files.md
@@ -111,29 +111,6 @@ WSPATH: ["/dir1", "/dir2"]
 
 The only parameters which may be defined as arrays are **WSPATH**, **WSEXT** and **CFEXT**.
 
-#### References to other Configuration Parameters
-
-Configuration parameters may include references to other configuration parameters (regardless of where they are defined) using square bracket delimiters. For example:
-```apl
-MySetting: "[DYALOG]/MyFile"
-```
-
-will replace `[DYALOG`] with the value of the **DYALOG** configuration value.
-
-If the string inside the `[]` delimiters is "`.`", the "`.`" is replaced is replaced with the path of the directory containing the configuration file itself. Therefore,
-```apl
-FILENAME: "[.]/x.txt"
-```
-
-will set the parameter **FILENAME** to a value which is a reference to a file called `x.txt` in the same directory as the configuration file defining it.
-
-Note that:
-
-- If the referenced configuration parameter is not defined then no substitution will take place; the reference, including square bracket delimiters, will remain in place.
-- To include square brackets in a string, prefix the '[' with a '\' character.
-
-`[=DOCUMENTS]` is a pre-defined substitution parameter that is replaced with the location of the user's Documents folder (for example, `C:\Users\Bob\Documents`).
-
 #### Nested Structures
 
 Some parameters are stored in sub-folders in the Windows Registry. Currently, all such parameters used by Dyalog APL itself relate to the Windows IDE, but you can create your own application-specific structures..

--- a/windows-installation-and-configuration-guide/docs/configuration-files.md
+++ b/windows-installation-and-configuration-guide/docs/configuration-files.md
@@ -132,6 +132,8 @@ Note that:
 - If the referenced configuration parameter is not defined then no substitution will take place; the reference, including square bracket delimiters, will remain in place.
 - To include square brackets in a string, prefix the '[' with a '\' character.
 
+`[=DOCUMENTS]` is a pre-defined substitution parameter that is replaced with the location of the user's Documents folder (for example, `C:\Users\Bob\Documents`).
+
 #### Nested Structures
 
 Some parameters are stored in sub-folders in the Windows Registry. Currently, all such parameters used by Dyalog APL itself relate to the Windows IDE, but you can create your own application-specific structures..

--- a/windows-installation-and-configuration-guide/docs/configuration-files.md
+++ b/windows-installation-and-configuration-guide/docs/configuration-files.md
@@ -113,7 +113,7 @@ The only parameters which may be defined as arrays are **WSPATH**, **WSEXT** and
 
 #### References to other Configuration Parameters
 
-Configuration parameters which are string values may include references to other configuration parameters (regardless of where they are defined) using square bracket delimiters. For example:
+Configuration parameters may include references to other configuration parameters (regardless of where they are defined) using square bracket delimiters. For example:
 ```apl
 MySetting: "[DYALOG]/MyFile"
 ```

--- a/windows-installation-and-configuration-guide/docs/configuration-parameters/configuration-parameters.md
+++ b/windows-installation-and-configuration-guide/docs/configuration-parameters/configuration-parameters.md
@@ -49,7 +49,7 @@ MySetting: "[DYALOG]/MyFile"
 
 will replace `[DYALOG`] with the value of the **DYALOG** configuration value.
 
-If the string inside the `[]` delimiters is "`.`", the "`.`" is replaced is replaced with the path of the directory containing the configuration file itself. Therefore,
+If the string inside the `[]` delimiters is "`.`", the "`.`" is replaced with the path of the directory containing the configuration file itself. Therefore,
 ```apl
 FILENAME: "[.]/x.txt"
 ```

--- a/windows-installation-and-configuration-guide/docs/configuration-parameters/configuration-parameters.md
+++ b/windows-installation-and-configuration-guide/docs/configuration-parameters/configuration-parameters.md
@@ -39,3 +39,26 @@ You can change parameters in the Registry in one of two ways:
 
 - Using the Configuration dialog box that is obtained by selecting *Configure* from the *Options* menu on the Dyalog APL/W session. See ["The Configuration Dialog Box"](../configuring-the-ide/configuration-dialog/configuration-dialog-general-tab.md) for details.
 - By directly editing the Windows Registry using `REGEDIT.EXE` or `REGEDIT32.EXE`. This is necessary for parameters that are not editable via the Configuration dialog box.
+
+## References to other Configuration Parameters
+
+Configuration parameters may include references to other configuration parameters (regardless of where they are defined) using square bracket delimiters. For example:
+```apl
+MySetting: "[DYALOG]/MyFile"
+```
+
+will replace `[DYALOG`] with the value of the **DYALOG** configuration value.
+
+If the string inside the `[]` delimiters is "`.`", the "`.`" is replaced is replaced with the path of the directory containing the configuration file itself. Therefore,
+```apl
+FILENAME: "[.]/x.txt"
+```
+
+will set the parameter **FILENAME** to a value which is a reference to a file called `x.txt` in the same directory as the configuration file defining it.
+
+Note that:
+
+- If the referenced configuration parameter is not defined then no substitution will take place; the reference, including square bracket delimiters, will remain in place.
+- To include square brackets in a string, prefix the '[' with a '\' character.
+
+`[=DOCUMENTS]` is a pre-defined substitution parameter that is replaced with the location of the user's Documents folder (for example, `C:\Users\Bob\Documents`).


### PR DESCRIPTION
Substitution parameters apply to all configuration settings, not only those defined in configuration files. In the Unix guide, move the References to other Configuration Parameters section up from the configuration files page to the general configuration parameters page. In the Windows guide, note the pre-defined [=DOCUMENTS] substitution.

Fixes #988.