### PR TITLE
887 standardise variants

### DIFF
--- a/language-reference-guide/docs/system-functions/csv.md
+++ b/language-reference-guide/docs/system-functions/csv.md
@@ -100,7 +100,7 @@ The `Separator`, `QuoteChar`, and `EscapeChar` characters, when defined, must be
 
 Other options defined for export are also accepted but ignored.
 
-### Variant Option: `QuoteChar`, `EscapeChar`, and `DoubleQuote`
+### Variant Options: `QuoteChar`, `EscapeChar`, and `DoubleQuote`
 
 If `EscapeChar` is set then any character can be prefixed by the escape character. The escape character is typically defined as `'\'`. The escape character immediately followed by the character `c` is the literal character `c`, even if `c` alone would have been a metacharacter.
 
@@ -283,7 +283,7 @@ The `Separator`, `QuoteChar`, and `EscapeChar` characters, when defined, must be
 
 The `Overwrite` variant option (a Boolean) from Version 16.0 remains supported but is deprecated in favour of `IfExists`.
 
-### Variant Option: `QuoteChar`, `EscapeChar`, and `DoubleQuote`
+### Variant Options: `QuoteChar`, `EscapeChar`, and `DoubleQuote`
 
 - The CSV text will be generated such that it can be read back according to the corresponding rules for import.
 - If these options do not permit this (for example, a field contains the quote character and neither `DoubleQuote` or `EscapeChar` are set) an error is signalled.

--- a/language-reference-guide/docs/system-functions/csv.md
+++ b/language-reference-guide/docs/system-functions/csv.md
@@ -102,19 +102,19 @@ Other options defined for export are also accepted but ignored.
 
 ### Variant Options: `QuoteChar`, `EscapeChar`, and `DoubleQuote`
 
-If `EscapeChar` is set then any character can be prefixed by the escape character. The escape character is typically defined as `'\'`. The escape character immediately followed by the character `c` is the literal character `c`, even if `c` alone would have been a metacharacter.
+If `EscapeChar` is set, then any character can be prefixed by the escape character. The escape character is typically defined as `'\'`. The escape character immediately followed by the character `c` is the literal character `c`, even if `c` alone would have been a metacharacter.
 
-If `QuoteChar` is set then fields can be delimited by the specified quote character. Within quoted fields all characters except the quote character, and the escape character if defined, are literal characters.
+If `QuoteChar` is set, then fields can be delimited by the specified quote character. Within quoted fields all characters except the quote character, and the escape character if defined, are literal characters.
 
-If `DoubleQuote` is set to `1` then two consecutive quote characters within a quoted field are interpreted as the single literal quote character.
+If `DoubleQuote` is set to `1`, then two consecutive quote characters within a quoted field are interpreted as the single literal quote character.
 
 ## Result
 
 The result `R` contains the imported data.
 
-If `Y[4]` does not specify that the data contains a header then `R` contains the entire data in the form specified by the `Invert` variant option.
+If `Y[4]` does not specify that the data contains a header, then `R` contains the entire data in the form specified by the `Invert` variant option.
 
-If `Y[4]` does specify that the data contains a header then `R` is a 2-element vector where:
+If `Y[4]` does specify that the data contains a header, then `R` is a 2-element vector where:
 
 - `R[1]` is the imported data excluding the header.
 - `R[2]` is a vector of character vectors containing the header record.
@@ -227,7 +227,7 @@ In all cases the files must contain text using one of the supported encodings (s
 Note that:
 
 - native files are read from the current file position. On successful completion, the file position will be at the first unprocessed character (end of file if the `Records` variant option is not specified). If an error is signalled the file position is undefined.
-- the result does not report the file encoding or line ending type as it does with `⎕NGET`. If this information is required then it must be obtained by other means.
+- the result does not report the file encoding or line ending type as it does with `⎕NGET`. If this information is required, then it must be obtained by other means.
 
 # Dyadic `⎕CSV`
 
@@ -270,7 +270,7 @@ Table: Variant options for `⎕CSV` { #variantoptionsforcsv2 }
 |`Decimal`|the decimal mark in numeric fields - one of `'.'` or `','`|`'.'`|
 |`DoubleQuote`|A Boolean which indicates whether (`1`) or not (`0`) a quote character within a quoted field is represented by two consecutive quote characters|`1`|
 |`EscapeChar`|The escape character, which can be specified as an empty character vector (meaning none is defined) or a character scalar|`0`|
-|`ForceQuotes`|A number specifying the degree to which quotes are applied around fields even if not strictly required. Possible values are:<ul><li>`0` – add only if required</li><li>`1` – add to all fields containing character data and to fields containing numeric data if required</li><li>`2` – add to all fields even if not required</li></ul>If `ForceQuotes` is a scalar, the value applies to all columns; if it is a vector of values then each value applies to the corresponding column.|`0`|
+|`ForceQuotes`|A number specifying the degree to which quotes are applied around fields, even if not strictly required. Possible values are:<ul><li>`0` – add only if required</li><li>`1` – add to all fields containing character data and to fields containing numeric data if required</li><li>`2` – add to all fields, even if not required</li></ul>If `ForceQuotes` is a scalar, the value applies to all columns; if it is a vector of values, then each value applies to the corresponding column.|`0`|
 |`IfExists`|a character vector `'Error'` or `'Replace'` which specifies, when creating a named file which already exists, whether to overwrite it ( `'Replace'` ) or signal an error ( `'Error'` )|`'Error'`|
 |`LineEnding`|the line ending sequence - see [Line separators:](nget.md)|(13 10) on Windows; 10 on other platforms|
 |`QuoteChar`|The field quote character (delimiter), which can be specified as an empty character vector (meaning none is defined) or a character scalar|`"`|
@@ -290,7 +290,7 @@ The `Overwrite` variant option (a Boolean) from Version 16.0 remains supported b
 - Quoting and Escaping is used as conservatively as possible.
 - If both `QuoteChar` and `EscapeChar` are set, quoting is favoured.
 
-If `Y` specifies that the CSV data is written to a file then `R` is the number of bytes (not characters) written, and is [shy](../../../programming-reference-guide/introduction/results#shy-results).
+If `Y` specifies that the CSV data is written to a file, then `R` is the number of bytes (not characters) written, and is [shy](../../../programming-reference-guide/introduction/results#shy-results).
 
 Otherwise, `R` is the CSV data in the format specified in Y, and is not shy.
 

--- a/language-reference-guide/docs/system-functions/csv.md
+++ b/language-reference-guide/docs/system-functions/csv.md
@@ -23,7 +23,7 @@ Note that when importing CSV data, all fields are assumed to be character fields
 
 ## MetaCharacters
 
-Some characters in a CSV file are metacharacters that define the structure of the data; for example, the field separator character between fields. Characters that are not metacharacters are literal characters. The variant options QuoteChar, EscapeChar, and DoubleQuote make it possible to interpret metacharacters as literal characters, and thus permit fields to contain field separator characters, leading and trailing spaces, and line-endings.
+Some characters in a CSV file are metacharacters that define the structure of the data; for example, the field separator character between fields. Characters that are not metacharacters are literal characters. The variant options `QuoteChar`, `EscapeChar`, and `DoubleQuote` make it possible to interpret metacharacters as literal characters, and thus permit fields to contain field separator characters, leading and trailing spaces, and line-endings.
 
 Fixed-width fields do not require these options and they are ignored if fixed-width fields are being processed.
 
@@ -65,9 +65,9 @@ This is a scalar numeric code or vector of numeric codes that specifies the fiel
 |`0`|The field is ignored.|
 |`1`|The field contains character data.|
 |`2`|The field is to be interpreted as being numeric. Empty cells and cells which cannot be converted to numeric values are not tolerated and cause an error to be signalled.|
-|`3`|The field is to be interpreted as being numeric but invalid numeric values are tolerated. Empty fields and fields which cannot be converted to numeric values are replaced with the Fill variant option (default 0).|
-|`4`|The field is to be interpreted numeric data but invalid numeric data is tolerated. Empty fields and fields which cannot be converted to numeric values are returned instead as character data; this type is disallowed when variant option Invert is set to 1.|
-|`5`|The field is to be interpreted as being numeric but empty fields are tolerated and are replaced with the Fill variant option (default 0). Non-empty cells which cannot be converted to numeric values are not tolerated and cause an error to be signalled.|
+|`3`|The field is to be interpreted as being numeric but invalid numeric values are tolerated. Empty fields and fields which cannot be converted to numeric values are replaced with the `Fill` variant option (default `0`).|
+|`4`|The field is to be interpreted numeric data but invalid numeric data is tolerated. Empty fields and fields which cannot be converted to numeric values are returned instead as character data; this type is disallowed when variant option `Invert` is set to `1`.|
+|`5`|The field is to be interpreted as being numeric but empty fields are tolerated and are replaced with the `Fill` variant option (default `0`). Non-empty cells which cannot be converted to numeric values are not tolerated and cause an error to be signalled.|
 
 Note that if *Column Types* is specified by a scalar 4, all numeric data in all fields will be converted to numbers.
 
@@ -75,30 +75,30 @@ Note that if *Column Types* is specified by a scalar 4, all numeric data in all 
 
 This is a Boolean value (default 0) to specify whether or not the first record in a CSV file is a list of column labels. If *Header Row Indicator* is 1, the first record (the *header row*) is treated differently from other records. It is assumed to contain character data (labels) regardless of `Y[3]` and is returned separately in the result.
 
-## Variant options
+## Variant Options
 
-Monadic `⎕CSV` may be applied using the  Variant operator with the following options. The Principal option is Invert.
+Monadic `⎕CSV` may be applied using the  Variant operator with the following options. The principal option is `Invert`.
 
 |Name       |Meaning                                     |Default|
 |-----------|--------------------------------------------|-------|
-|Decimal    |The decimal mark in numeric fields - one of `'.'` or `','` |   `'.'`|
-|DoubleQuote|A Boolean that indicates whether (`1`) or not (`0`) a quote character within a quoted field is represented by two consecutive quote characters     |`1`    |
-|EscapeChar |The escape character, which may be specified as an empty character vector (meaning none is defined) or a character scalar                |`''`   |
-|Fill       |The numeric value substituted for invalid numeric data in  columns of type 3   |`0`    |
-|Invert     |A number specifying how the CSV data should be returned. Possible values are:<ul><li>`0` – A table (a matrix whose elements are character vectors or scalars or numbers).</li><li>`1` – A vector, each of whose items contain field (column) values. Character field values are character matrices; numeric field values are numeric vectors.</li><li>`2` – A vector, each of whose items contain field (column) values. Character field values are vectors of character vectors; numeric field values are numeric vectors.</li></ul>    |`0`    |
-|QuoteChar  |The field quote character (delimiter), which may be specified as an empty character vector (meaning none is defined) or a character scalar                 |`"`    |
-|Ragged     |A Boolean specifying whether records with varying numbers  of fields are allowed; see notes below                                                          |`0`    |
-|Records    |The maximum number of records to process or 0 for no limit.                    |`0`    |
-|Separator  |The field separator, any single character. If Widths is other than `⍬`, Separator is ignored.                                                            |`','`  |
-|Thousands  |The thousands separator in numeric fields, which can be specified as an empty character vector (meaning no separator is defined) or a character scalar   |`''`   |
-|Trim       |A Boolean specifying whether undelimited/unescaped whitespace is trimmed at the beginning and end of fields            |`1`    |
-|Widths     |A vector of numeric values describing the width (in characters) of the corresponding columns in the CSV source, or `⍬` for variable width delimited fields|`⍬`    |
+|`Decimal`    |The decimal mark in numeric fields - one of `'.'` or `','` |   `'.'`|
+|`DoubleQuote`|A Boolean that indicates whether (`1`) or not (`0`) a quote character within a quoted field is represented by two consecutive quote characters     |`1`    |
+|`EscapeChar` |The escape character, which may be specified as an empty character vector (meaning none is defined) or a character scalar                |`''`   |
+|`Fill`       |The numeric value substituted for invalid numeric data in  columns of type 3   |`0`    |
+|`Invert`<br><small>principal</small>|A number specifying how the CSV data should be returned. Possible values are:<ul><li>`0` – A table (a matrix whose elements are character vectors or scalars or numbers).</li><li>`1` – A vector, each of whose items contain field (column) values. Character field values are character matrices; numeric field values are numeric vectors.</li><li>`2` – A vector, each of whose items contain field (column) values. Character field values are vectors of character vectors; numeric field values are numeric vectors.</li></ul>    |`0`    |
+|`QuoteChar`  |The field quote character (delimiter), which may be specified as an empty character vector (meaning none is defined) or a character scalar                 |`"`    |
+|`Ragged`     |A Boolean specifying whether records with varying numbers  of fields are allowed; see notes below                                                          |`0`    |
+|`Records`    |The maximum number of records to process or 0 for no limit.                    |`0`    |
+|`Separator`  |The field separator, any single character. If Widths is other than `⍬`, Separator is ignored.                                                            |`','`  |
+|`Thousands`  |The thousands separator in numeric fields, which can be specified as an empty character vector (meaning no separator is defined) or a character scalar   |`''`   |
+|`Trim`       |A Boolean specifying whether undelimited/unescaped whitespace is trimmed at the beginning and end of fields            |`1`    |
+|`Widths`     |A vector of numeric values describing the width (in characters) of the corresponding columns in the CSV source, or `⍬` for variable width delimited fields|`⍬`    |
 
-The Separator, QuoteChar, and EscapeChar characters, when defined, must be different.
+The `Separator`, `QuoteChar`, and `EscapeChar` characters, when defined, must be different.
 
 Other options defined for export are also accepted but ignored.
 
-### QuoteChar, EscapeChar, and DoubleQuote Options
+### `QuoteChar`, `EscapeChar`, and `DoubleQuote` Options
 
 If EscapeChar is set then any character may be prefixed by the escape character. The escape character is typically defined as `'\'`. The escape character immediately followed by the character `c` is the literal character `c` even if `c` alone would have been a metacharacter.
 
@@ -110,7 +110,7 @@ If DoubleQuote is set to 1 then two consecutive quote characters within a quoted
 
 The result `R` contains the imported data.
 
-If `Y[4]` does not specify that the data contains a header then `R` contains the entire data in the form specified by the Invert variant option.
+If `Y[4]` does not specify that the data contains a header then `R` contains the entire data in the form specified by the `Invert` variant option.
 
 If `Y[4]` does specify that the data contains a header then `R` is a 2-element vector where:
 
@@ -206,7 +206,7 @@ If `Y[4]` does specify that the data contains a header then `R` is a 2-element v
 - Fields containing embedded new lines are supported (they must, of course, appear in quotes or be prefixed by the escape character). On import, line endings are always converted to a single line feed character.
 - If Ragged is not set then all records must have the same number of fields (character delimited format) or same number of characters (fixed width field format).
 - If Ragged is set:
-- The expected number of columns must be specified using the Widths variant option and/or the column types in `Y[3]`.
+- The expected number of columns must be specified using the `Widths` variant option and/or the column types in `Y[3]`.
 - In character delimited format, all processed records are implicitly extended or truncated as required so that they contain the expected number of fields; implicitly added fields will be empty.
 - In fixed width format, all processed records are implicitly extended with spaces or truncated as required so that they contain as many characters as are specified in the Widths option declaration.
 
@@ -224,7 +224,7 @@ In all cases the files must contain text using one of the supported encodings (s
 
 Note that:
 
-- native files are read from the current file position. On successful completion, the file position will be at the first unprocessed character (end of file if the Records variant option is not specified). If an error is signalled the file position is undefined.
+- native files are read from the current file position. On successful completion, the file position will be at the first unprocessed character (end of file if the `Records` variant option is not specified). If an error is signalled the file position is undefined.
 - the result does not report the file encoding or line ending type as it does with `⎕NGET`. If this information is required then it must be obtained by other means.
 
 # Dyadic `⎕CSV`
@@ -257,29 +257,29 @@ If `Y[1]` is a file name or tie number, *Description* may be:
 
 If `Y[1]` is empty, *Description* may be a character scalar `'S'` (simple) or `'N'` (nested). If omitted, the default is `'S'`
 
-## Variant options
+## Variant Options
 
 Dyadic `⎕CSV` may be applied using the _variant_ operator with the following options.
 
 |Name|Meaning|Default|
 |---|---|---|
-|Decimal|the decimal mark in numeric fields - one of `'.'` or `','`|`'.'`|
-|DoubleQuote|A Boolean which indicates whether (`1`) or not (`0`) a quote character within a quoted field is represented by two consecutive quote characters|`1`|
-|EscapeChar|The escape character, which may be specified as an empty character vector (meaning none is defined) or a character scalar|`0`|
-|ForceQuotes|A number specifying the degree to which quotes are applied around fields even if not strictly required. Possible values are:<ul><li>`0` – add only if required</li><li>`1` – add to all fields containing character data and to fields containing numeric data if required</li><li>`2` – add to all fields even if not required</li></ul>If ForceQuotes is a scalar, the value applies to all columns; if it is a vector of values then each value applies to the corresponding column.|`0`|
-|IfExists|a character vector `'Error'` or `'Replace'` which specifies, when creating a named file which already exists, whether to overwrite it ( `'Replace'` ) or signal an error ( `'Error'` )|`'Error'`|
-|LineEnding|the line ending sequence - see [Line separators:](nget.md)|(13 10) on Windows; 10 on other platforms|
-|QuoteChar|The field quote character (delimiter), which may be specified as an empty character vector (meaning none is defined) or a character scalar|`"`|
-|Separator|the field separator, any single character. If Widths is other than `⍬` , Separator is ignored.|`','`|
-|Thousands|the thousands separator in numeric fields, which can be specified as an empty character vector (meaning no separator is defined) or a character scalar|`''`|
-|Trim|a Boolean specifying whether whitespace is trimmed at the beginning and end of character fields|`1`|
-|Widths|a vector of numeric values describing the width (in characters) of the corresponding columns in the CSV source, or `⍬` for variable width delimited fields|`⍬`|
+|`Decimal`|the decimal mark in numeric fields - one of `'.'` or `','`|`'.'`|
+|`DoubleQuote`|A Boolean which indicates whether (`1`) or not (`0`) a quote character within a quoted field is represented by two consecutive quote characters|`1`|
+|`EscapeChar`|The escape character, which may be specified as an empty character vector (meaning none is defined) or a character scalar|`0`|
+|`ForceQuotes`|A number specifying the degree to which quotes are applied around fields even if not strictly required. Possible values are:<ul><li>`0` – add only if required</li><li>`1` – add to all fields containing character data and to fields containing numeric data if required</li><li>`2` – add to all fields even if not required</li></ul>If ForceQuotes is a scalar, the value applies to all columns; if it is a vector of values then each value applies to the corresponding column.|`0`|
+|`IfExists`|a character vector `'Error'` or `'Replace'` which specifies, when creating a named file which already exists, whether to overwrite it ( `'Replace'` ) or signal an error ( `'Error'` )|`'Error'`|
+|`LineEnding`|the line ending sequence - see [Line separators:](nget.md)|(13 10) on Windows; 10 on other platforms|
+|`QuoteChar`|The field quote character (delimiter), which may be specified as an empty character vector (meaning none is defined) or a character scalar|`"`|
+|`Separator`|the field separator, any single character. If Widths is other than `⍬` , Separator is ignored.|`','`|
+|`Thousands`|the thousands separator in numeric fields, which can be specified as an empty character vector (meaning no separator is defined) or a character scalar|`''`|
+|`Trim`|a Boolean specifying whether whitespace is trimmed at the beginning and end of character fields|`1`|
+|`Widths`|a vector of numeric values describing the width (in characters) of the corresponding columns in the CSV source, or `⍬` for variable width delimited fields|`⍬`|
 
-The Separator, QuoteChar, and EscapeChar characters, when defined, must be different. Other options defined for import are also accepted but ignored.
+The `Separator`, `QuoteChar`, and `EscapeChar` characters, when defined, must be different. Other options defined for import are also accepted but ignored.
 
-The Overwrite variant option (Boolean) from Version 16.0 remains supported but is deprecated in favour of IfExists.
+The `Overwrite` variant option (a Boolean) from Version 16.0 remains supported but is deprecated in favour of `IfExists`.
 
-### QuoteChar, EscapeChar, and DoubleQuote options
+### `QuoteChar`, `EscapeChar`, and `DoubleQuote` options
 
 - The CSV text will be generated such that it can be read back according to the corresponding rules for import.
 - If these options do not permit this (for example, a field contains the quote character and neither DoubleQuote or EscapeChar are set) an error is signalled.

--- a/language-reference-guide/docs/system-functions/csv.md
+++ b/language-reference-guide/docs/system-functions/csv.md
@@ -39,7 +39,7 @@ Fixed-width fields do not require these options and they are ignored if fixed-wi
 |`[3]`|Column Types               |
 |`[4]`|Header Row Indicator       |
 
-*Source* may be one of:
+*Source* can be one of:
 
 - a character vector or scalar containing a file name
 - a native tie number
@@ -48,10 +48,10 @@ Fixed-width fields do not require these options and they are ignored if fixed-wi
 
 *Description*
 
-If `Y[1]` is a file name or tie number *Description* may be one of:
+If `Y[1]` is a file name or tie number *Description* can be one of:
 
 - a character vector specifying the file encoding such as `'UTF-8'` (see [File Encodings](nget.md)).
-- a 256-element numeric vector that maps each possible byte value (0-255) to a Unicode code point (1st element = Unicode code point corresponding to byte value 0, and so on). ¯1 indicates that the corresponding byte value is not mapped to any character. Apart from ¯1, no value may appear in the table more than once.
+- a 256-element numeric vector that maps each possible byte value (0-255) to a Unicode code point (1st element = Unicode code point corresponding to byte value 0, and so on). ¯1 indicates that the corresponding byte value is not mapped to any character. Apart from ¯1, no value can appear in the table more than once.
 
 If omitted or empty, the file encoding is deduced (see below).
 
@@ -77,19 +77,21 @@ This is a Boolean value (default 0) to specify whether or not the first record i
 
 ## Variant Options
 
-Monadic `⎕CSV` may be applied using the  Variant operator with the following options. The principal option is `Invert`.
+Monadic `⎕CSV` can be applied using the _variant_ operator with the options shown in [](#variantoptionsforcsv). The principal option is `Invert`.
+
+Table: Variant options for `⎕CSV` { #variantoptionsforcsv }
 
 |Name       |Meaning                                     |Default|
 |-----------|--------------------------------------------|-------|
 |`Decimal`    |The decimal mark in numeric fields - one of `'.'` or `','` |   `'.'`|
 |`DoubleQuote`|A Boolean that indicates whether (`1`) or not (`0`) a quote character within a quoted field is represented by two consecutive quote characters     |`1`    |
-|`EscapeChar` |The escape character, which may be specified as an empty character vector (meaning none is defined) or a character scalar                |`''`   |
+|`EscapeChar` |The escape character, which can be specified as an empty character vector (meaning none is defined) or a character scalar                |`''`   |
 |`Fill`       |The numeric value substituted for invalid numeric data in  columns of type 3   |`0`    |
 |`Invert`<br><small>principal</small>|A number specifying how the CSV data should be returned. Possible values are:<ul><li>`0` – A table (a matrix whose elements are character vectors or scalars or numbers).</li><li>`1` – A vector, each of whose items contain field (column) values. Character field values are character matrices; numeric field values are numeric vectors.</li><li>`2` – A vector, each of whose items contain field (column) values. Character field values are vectors of character vectors; numeric field values are numeric vectors.</li></ul>    |`0`    |
-|`QuoteChar`  |The field quote character (delimiter), which may be specified as an empty character vector (meaning none is defined) or a character scalar                 |`"`    |
+|`QuoteChar`  |The field quote character (delimiter), which can be specified as an empty character vector (meaning none is defined) or a character scalar                 |`"`    |
 |`Ragged`     |A Boolean specifying whether records with varying numbers  of fields are allowed; see notes below                                                          |`0`    |
 |`Records`    |The maximum number of records to process or 0 for no limit.                    |`0`    |
-|`Separator`  |The field separator, any single character. If Widths is other than `⍬`, Separator is ignored.                                                            |`','`  |
+|`Separator`  |The field separator, any single character. If `Widths` is other than `⍬`, `Separator` is ignored.                                                            |`','`  |
 |`Thousands`  |The thousands separator in numeric fields, which can be specified as an empty character vector (meaning no separator is defined) or a character scalar   |`''`   |
 |`Trim`       |A Boolean specifying whether undelimited/unescaped whitespace is trimmed at the beginning and end of fields            |`1`    |
 |`Widths`     |A vector of numeric values describing the width (in characters) of the corresponding columns in the CSV source, or `⍬` for variable width delimited fields|`⍬`    |
@@ -98,13 +100,13 @@ The `Separator`, `QuoteChar`, and `EscapeChar` characters, when defined, must be
 
 Other options defined for export are also accepted but ignored.
 
-### `QuoteChar`, `EscapeChar`, and `DoubleQuote` Options
+### Variant Option: `QuoteChar`, `EscapeChar`, and `DoubleQuote`
 
-If EscapeChar is set then any character may be prefixed by the escape character. The escape character is typically defined as `'\'`. The escape character immediately followed by the character `c` is the literal character `c` even if `c` alone would have been a metacharacter.
+If `EscapeChar` is set then any character can be prefixed by the escape character. The escape character is typically defined as `'\'`. The escape character immediately followed by the character `c` is the literal character `c`, even if `c` alone would have been a metacharacter.
 
-If QuoteChar is set then fields may be delimited by the specified quote character. Within quoted fields all characters except the quote character, and the escape character if defined, are literal characters.
+If `QuoteChar` is set then fields can be delimited by the specified quote character. Within quoted fields all characters except the quote character, and the escape character if defined, are literal characters.
 
-If DoubleQuote is set to 1 then two consecutive quote characters within a quoted field are interpreted as the single literal quote character.
+If `DoubleQuote` is set to `1` then two consecutive quote characters within a quoted field are interpreted as the single literal quote character.
 
 ## Result
 
@@ -202,17 +204,17 @@ If `Y[4]` does specify that the data contains a header then `R` is a 2-element v
 
 - When `Y` specifies just the source of the CSV data, it does not need to be enclosed or ravelled to create a 1-element vector.
 - `Y[2]`, the description of the source, distinguishes an otherwise ambiguous character vector source (which could contain either CSV data or a file name). The other source forms are unambiguous but the description, when given, must still match the given source type.
-- Tab-separated fields may be imported by specifying `'Separator' (⎕UCS 9)`.
+- Tab-separated fields can be imported by specifying `'Separator' (⎕UCS 9)`.
 - Fields containing embedded new lines are supported (they must, of course, appear in quotes or be prefixed by the escape character). On import, line endings are always converted to a single line feed character.
-- If Ragged is not set then all records must have the same number of fields (character delimited format) or same number of characters (fixed width field format).
-- If Ragged is set:
+- If `Ragged` is not set, then all records must have the same number of fields (character delimited format) or same number of characters (fixed width field format).
+- If `Ragged` is set:
 - The expected number of columns must be specified using the `Widths` variant option and/or the column types in `Y[3]`.
 - In character delimited format, all processed records are implicitly extended or truncated as required so that they contain the expected number of fields; implicitly added fields will be empty.
-- In fixed width format, all processed records are implicitly extended with spaces or truncated as required so that they contain as many characters as are specified in the Widths option declaration.
+- In fixed width format, all processed records are implicitly extended with spaces or truncated as required so that they contain as many characters as are specified in the `Widths` option declaration.
 
-### File handling
+### File Handling
 
-Data may be read from a named file or a tied native file. A tied native file may be read in sections by repeatedly invoking `⎕CSV` for a specified maximum number of records (specified by the Records variant) until no more data is read.
+Data can be read from a named file or a tied native file. A tied native file can be read in sections by repeatedly invoking `⎕CSV` for a specified maximum number of records (specified by the `Records` variant) until no more data is read.
 
 In all cases the files must contain text using one of the supported encodings (see [File Encodings](nget.md)). The method used to determine the file encoding is as follows:
 
@@ -242,7 +244,7 @@ The left argument `X` is either:
 |`[1]`|Destination of CSV Data (see below)    |
 |`[2]`|Description of the CSV data (see below)|
 
-*Destination* - may be one of:
+*Destination* - can be one of:
 
 - a character vector or scalar containing a file name
 - a native tie number
@@ -250,27 +252,29 @@ The left argument `X` is either:
 
 *Description*
 
-If `Y[1]` is a file name or tie number, *Description* may be:
+If `Y[1]` is a file name or tie number, *Description* can be:
 
 - a character vector specifying the file encoding such as `'UTF-8'` (see [File Encodings](nget.md)).
-- a 256-element numeric vector that maps each possible byte value (0-255) to a Unicode code point (1st element = Unicode code point corresponding to byte value 0, and so on). ¯1 indicates that the corresponding byte value is not mapped to any character. Apart from ¯1, no value may appear in the table more than once.
+- a 256-element numeric vector that maps each possible byte value (0-255) to a Unicode code point (1st element = Unicode code point corresponding to byte value 0, and so on). ¯1 indicates that the corresponding byte value is not mapped to any character. Apart from ¯1, no value can appear in the table more than once.
 
-If `Y[1]` is empty, *Description* may be a character scalar `'S'` (simple) or `'N'` (nested). If omitted, the default is `'S'`
+If `Y[1]` is empty, *Description* can be a character scalar `'S'` (simple) or `'N'` (nested). If omitted, the default is `'S'`
 
 ## Variant Options
 
-Dyadic `⎕CSV` may be applied using the _variant_ operator with the following options.
+Dyadic `⎕CSV` can be applied using the _variant_ operator with the options shown in [](#variantoptionsforcsv2).
+
+Table: Variant options for `⎕CSV` { #variantoptionsforcsv2 }
 
 |Name|Meaning|Default|
 |---|---|---|
 |`Decimal`|the decimal mark in numeric fields - one of `'.'` or `','`|`'.'`|
 |`DoubleQuote`|A Boolean which indicates whether (`1`) or not (`0`) a quote character within a quoted field is represented by two consecutive quote characters|`1`|
-|`EscapeChar`|The escape character, which may be specified as an empty character vector (meaning none is defined) or a character scalar|`0`|
-|`ForceQuotes`|A number specifying the degree to which quotes are applied around fields even if not strictly required. Possible values are:<ul><li>`0` – add only if required</li><li>`1` – add to all fields containing character data and to fields containing numeric data if required</li><li>`2` – add to all fields even if not required</li></ul>If ForceQuotes is a scalar, the value applies to all columns; if it is a vector of values then each value applies to the corresponding column.|`0`|
+|`EscapeChar`|The escape character, which can be specified as an empty character vector (meaning none is defined) or a character scalar|`0`|
+|`ForceQuotes`|A number specifying the degree to which quotes are applied around fields even if not strictly required. Possible values are:<ul><li>`0` – add only if required</li><li>`1` – add to all fields containing character data and to fields containing numeric data if required</li><li>`2` – add to all fields even if not required</li></ul>If `ForceQuotes` is a scalar, the value applies to all columns; if it is a vector of values then each value applies to the corresponding column.|`0`|
 |`IfExists`|a character vector `'Error'` or `'Replace'` which specifies, when creating a named file which already exists, whether to overwrite it ( `'Replace'` ) or signal an error ( `'Error'` )|`'Error'`|
 |`LineEnding`|the line ending sequence - see [Line separators:](nget.md)|(13 10) on Windows; 10 on other platforms|
-|`QuoteChar`|The field quote character (delimiter), which may be specified as an empty character vector (meaning none is defined) or a character scalar|`"`|
-|`Separator`|the field separator, any single character. If Widths is other than `⍬` , Separator is ignored.|`','`|
+|`QuoteChar`|The field quote character (delimiter), which can be specified as an empty character vector (meaning none is defined) or a character scalar|`"`|
+|`Separator`|the field separator, any single character. If `Widths` is other than `⍬` , `Separator` is ignored.|`','`|
 |`Thousands`|the thousands separator in numeric fields, which can be specified as an empty character vector (meaning no separator is defined) or a character scalar|`''`|
 |`Trim`|a Boolean specifying whether whitespace is trimmed at the beginning and end of character fields|`1`|
 |`Widths`|a vector of numeric values describing the width (in characters) of the corresponding columns in the CSV source, or `⍬` for variable width delimited fields|`⍬`|
@@ -279,12 +283,12 @@ The `Separator`, `QuoteChar`, and `EscapeChar` characters, when defined, must be
 
 The `Overwrite` variant option (a Boolean) from Version 16.0 remains supported but is deprecated in favour of `IfExists`.
 
-### `QuoteChar`, `EscapeChar`, and `DoubleQuote` options
+### Variant Option: `QuoteChar`, `EscapeChar`, and `DoubleQuote`
 
 - The CSV text will be generated such that it can be read back according to the corresponding rules for import.
-- If these options do not permit this (for example, a field contains the quote character and neither DoubleQuote or EscapeChar are set) an error is signalled.
+- If these options do not permit this (for example, a field contains the quote character and neither `DoubleQuote` or `EscapeChar` are set) an error is signalled.
 - Quoting and Escaping is used as conservatively as possible.
-- If both QuoteChar and EscapeChar are set, quoting is favoured.
+- If both `QuoteChar` and `EscapeChar` are set, quoting is favoured.
 
 If `Y` specifies that the CSV data is written to a file then `R` is the number of bytes (not characters) written, and is [shy](../../../programming-reference-guide/introduction/results#shy-results).
 
@@ -347,7 +351,7 @@ FILE NAME ERROR: Unable to create file ("The file exists.")
 - Native files are written from the current file position. On successful completion, the file position will be at the end of the written data. If an error is signalled the amount of data written is undefined.
 - If the file encoding specifies that a BOM is required and output is to a native file, it will only be written if the file position is initially at 0 - that is, the start of the file is being written.
 - When fixed width fields are written, character data shorter than the specified width is padded with spaces to the right and character data longer than the specified width signals an error. Numeric data is converted to character data as far as possible so that it fits into the specified width. If this is not possible, an error is signalled.
-- Tab-separated fields may be exported by specifying `'Separator' (⎕UCS 9)`.
+- Tab-separated fields can be exported by specifying `'Separator' (⎕UCS 9)`.
 - Fields containing a single embedded new line are supported. On export, line feed characters are mapped back to the defined line ending sequence.
 
 <!-- Hidden search keywords -->

--- a/language-reference-guide/docs/system-functions/dt.md
+++ b/language-reference-guide/docs/system-functions/dt.md
@@ -89,7 +89,7 @@ Table: Time numbers { #timenumbers }
 |Misc. Operating Systems|||||
 | `70` |AmigaOS|Tick count 1&nbsp;ms ticks[^3]|1978-01-01 00:00|No|
 
-### Time Number to Time Number { .example }
+<h3 class="example">Example: Time number to time number</h3>
 
 ```apl
       2 1 ⎕DT 3⊃⎕FRDCI 1 1
@@ -101,7 +101,7 @@ Table: Time numbers { #timenumbers }
 ¯5
 ```
 
-### Time Number to Timestamp { .example }
+<h3 class="example">Example: Time number to timestamp</h3>
 
 ```apl
       1 ¯1 ⎕DT 0 43508.42843
@@ -142,7 +142,7 @@ Table: Timestamps { #timestamps }
 | DateTimePicker ||||
 | `¯30` | DateTime format                              | 4            | International Day Number, hour, minute, second               | `0 0 0 0`                              |
 
-### Timestamp to Time Number { .example }
+<h3 class="example">Example: Timestamp to time number</h3>
 
 ```apl
       ¯1 1 ⎕DT ⊂⎕TS
@@ -161,7 +161,7 @@ Table: Timestamps { #timestamps }
 
 ```
 
-### Timestamp to Timestamp { .example }
+<h3 class="example">Example: Timestamp to timestamp</h3>
 
 ```apl
       ¯30 ⎕DT ⊂⎕TS
@@ -267,7 +267,7 @@ The upper and lower case letters, underscore `_`, dollar `$`, and percent `%` ar
 !!! Info "Information"
     The characters `AaaaBbbb` consist of two adjacent format sequences because there is a sequence of As followed by a sequence of Bs. The characters `AaaaAaaa` consist of one format sequence because it only contains `A`s. It can be separated into two format sequences by inserting an empty `"` or `'` - delimited string, for example, `Aaaa""Aaaa`.
 
-### Formatting Datetimes { .example }
+<h3 class="example">Examples</h3>
 
 ```apl
       dt←1 ⎕DT ⊂2019 2 13 10 16 56
@@ -370,7 +370,7 @@ The formatted text is parsed and used to compute a datetime according to the giv
 
 If a pattern is rejected, or a text-formatted datetime cannot be matched against the pattern for any of the reasons above, a `DOMAIN ERROR` is signalled and an explanatory message is included.
 
-### Parsing Text Formats { .example }
+<h3 class="example">Examples</h3>
 
 ```apl
       'DD/MM/YYYY' 1 ⎕DT ⊂'13/02/2019'
@@ -444,7 +444,7 @@ If the namespace contains a definition that is supplied built into the interpret
 
 If a dictionary is incomplete (for example, is missing one of the expected named items, or one of the named items contains too few elements), an error is signalled if the missing content would be needed.
 
-<h4 class="example">Creating a Dictionary</h4>
+<h4 class="example">Example: Creating a dictionary</h4>
 
 The following creates a dictionary defined by the namespace `dict`, used in the examples that follow.
 
@@ -499,7 +499,7 @@ In the above example:
 - There is no explicit definition of patterns or names for language region `en_GB`. If this language is selected, the definitions for `en` will be used.
 - There is an explicit definition for `ShortMonthNames` for language region `en_US`. If this language is selected, the definition of `ShortMonthNames` is as defined, and as for `en` for other names. As `en` is not defined in the dictionary, the built-in defaults are used.
 
-<h4 class="example">Using a Dictionary</h4>
+<h4 class="example">Example: Using a dictionary</h4>
 
 ```apl
       '%DateVerbose%'(⎕DT⍠'Dictionary'dict) dt
@@ -524,6 +524,8 @@ In the above example:
 ```
 
 ## Validating Datetimes
+
+<h3 class="example">Examples</h3>
 
 ```apl
       0 ⎕DT ⎕TS (2020 13 1) 'J' 'DT' #

--- a/language-reference-guide/docs/system-functions/dt.md
+++ b/language-reference-guide/docs/system-functions/dt.md
@@ -402,10 +402,10 @@ If a pattern is rejected, or a text-formatted datetime cannot be matched against
 
 Table: Variant options overview { #variant-table }
 
-|Variant Option|Value|Effect|
-|---|---|---|
-|[`Language`](#variant-option-language)|`'en'` <small>(default)</small>, or another two- or five-character language name such as `'en_GB'`|The language used for formatting and matching datetimes.|
-|[`Dictionary`](#variant-option-dictionary)|a namespace|Additional or replacement month names and predefined patterns.|
+|Variant Option|Valid Values|Default|Effect|
+|---|---|---|---|
+|[`Language`](#variant-option-language)|`'en'`, or another two- or five-character language name such as `'en_GB'`|`'en'`|The language used for formatting and matching datetimes.|
+|[`Dictionary`](#variant-option-dictionary)|a namespace||Additional or replacement month names and predefined patterns.|
 
 ### Variant Option: Language
 

--- a/language-reference-guide/docs/system-functions/dt.md
+++ b/language-reference-guide/docs/system-functions/dt.md
@@ -23,7 +23,7 @@ A *datetime* is a date and time of day represented by a *time number*, a *timest
 - an integer *datetime code* (see [](#timenumbers) and [](#timestamps))
 - a character vector containing a *pattern* that describes how a datetime is formatted as text (see [Formatting Patterns](#formatting-patterns)).
 
-When <code>X<sub>R</sub></code> is an integer it must be either `0` or a code from [](#timenumbers) or [](#timestamps). `0` specifies that the elements of `Y` are to be validated; a non-zero value specifies the datetime representation to which the elements of `Y` are to be converted. When <code>X<sub>R</sub></code> is a pattern, the elements of `R` are character vectors, each derived by formatting the corresponding element of `Y` as text according to the pattern.
+When <code>X<sub>R</sub></code> is an integer it must be either `0` or a code from [](#timenumbers) or [](#timestamps). `0` specifies that the elements of `Y` are [to be validated](#validating-datetimes); a non-zero value specifies the datetime representation to which the elements of `Y` are to be converted. When <code>X<sub>R</sub></code> is a pattern, the elements of `R` are character vectors, each derived by formatting the corresponding element of `Y` as text according to the pattern.
 
 <code>X<sub>Y</sub></code> can be omitted only when the elements of `Y` are Dyalog Date Numbers, `⎕TS`-style timestamps, or military time zone characters. When <code>X<sub>Y</sub></code> is omitted, the numeric elements of `Y` are interpreted as follows:
 
@@ -89,7 +89,7 @@ Table: Time numbers { #timenumbers }
 |Misc. Operating Systems|||||
 | `70` |AmigaOS|Tick count 1&nbsp;ms ticks[^3]|1978-01-01 00:00|No|
 
-<h3 class="example">Example: Time number to time number</h3>
+<h3 class="example">Examples: Time number to time number</h3>
 
 ```apl
       2 1 ⎕DT 3⊃⎕FRDCI 1 1
@@ -101,7 +101,7 @@ Table: Time numbers { #timenumbers }
 ¯5
 ```
 
-<h3 class="example">Example: Time number to timestamp</h3>
+<h3 class="example">Examples: Time number to timestamp</h3>
 
 ```apl
       1 ¯1 ⎕DT 0 43508.42843
@@ -142,7 +142,7 @@ Table: Timestamps { #timestamps }
 | DateTimePicker ||||
 | `¯30` | DateTime format                              | 4            | International Day Number, hour, minute, second               | `0 0 0 0`                              |
 
-<h3 class="example">Example: Timestamp to time number</h3>
+<h3 class="example">Examples: Timestamp to time number</h3>
 
 ```apl
       ¯1 1 ⎕DT ⊂⎕TS
@@ -161,7 +161,7 @@ Table: Timestamps { #timestamps }
 
 ```
 
-<h3 class="example">Example: Timestamp to timestamp</h3>
+<h3 class="example">Examples: Timestamp to timestamp</h3>
 
 ```apl
       ¯30 ⎕DT ⊂⎕TS
@@ -444,7 +444,7 @@ If the namespace contains a definition that is supplied built into the interpret
 
 If a dictionary is incomplete (for example, is missing one of the expected named items, or one of the named items contains too few elements), an error is signalled if the missing content would be needed.
 
-<h4 class="example">Example: Creating a dictionary</h4>
+<h4 class="example">Example</h4>
 
 The following creates a dictionary defined by the namespace `dict`, used in the examples that follow.
 
@@ -499,16 +499,11 @@ In the above example:
 - There is no explicit definition of patterns or names for language region `en_GB`. If this language is selected, the definitions for `en` will be used.
 - There is an explicit definition for `ShortMonthNames` for language region `en_US`. If this language is selected, the definition of `ShortMonthNames` is as defined, and as for `en` for other names. As `en` is not defined in the dictionary, the built-in defaults are used.
 
-<h4 class="example">Example: Using a dictionary</h4>
-
 ```apl
       '%DateVerbose%'(⎕DT⍠'Dictionary'dict) dt
 ┌───────────────────────┐
 │the date is 13 Feb 2019│
 └───────────────────────┘
-```
-
-```apl
       '%DateVerbose%'(⎕DT⍠('Dictionary' dict)('Language' 'en_US')) dt
 ┌─────────────────────────┐
 │the date is Feb. 13, 2019│
@@ -524,6 +519,8 @@ In the above example:
 ```
 
 ## Validating Datetimes
+
+When <code>X<sub>R</sub></code> is `0`, `⎕DT` validates the elements of `Y` instead of converting them, interpreting each according to <code>X<sub>Y</sub></code> as described above. `R` is a Boolean with a `1` for each element of `Y` that represents a valid datetime and a `0` for each that does not.
 
 <h3 class="example">Examples</h3>
 

--- a/language-reference-guide/docs/system-functions/dt.md
+++ b/language-reference-guide/docs/system-functions/dt.md
@@ -338,11 +338,11 @@ Table: Predefined patterns built into the interpreter { #patterns }
 
 Additional predefined patterns can be defined using the [`Dictionary` variant option](#variant-option-dictionary). Predefined patterns must not contain references to other predefined patterns.
 
-## Pattern-matching Rules
+## Pattern-Matching Rules
 
 When <code>X<sub>Y</sub></code> is a pattern, the corresponding character vectors in `Y` are matched against it and decoded into datetime. The following additional rules apply to the matching.
 
-### Two-digit Years
+### Two-Digit Years
 
 Two digit years (that is, those corresponding to the formatting pattern elements `YY` and `WW`) are, by default, interpreted according to the same rules used for `⎕SM` and GUI edit fields, which are configurable using the [`YY_WINDOW`](../../windows-installation-and-configuration-guide/configuration-parameters/yy-window/) configuration parameter.
 
@@ -398,16 +398,16 @@ If a pattern is rejected, or a text-formatted datetime cannot be matched against
 
 ## Variant Options
 
-`⎕DT` supports the `Language` and `Dictionary` variant options, specified using the _variant_ operator [`⍠`](../primitive-operators/variant.md) and summarised in [](#variant-table). These only apply when <code>X<sub>Y</sub></code> and/or <code>X<sub>R</sub></code> are patterns.
+`⎕DT` supports the `Language` and `Dictionary` variant options, specified using the _variant_ operator [`⍠`](../primitive-operators/variant.md) and summarised in [](#variantoptionsfordt). These only apply when <code>X<sub>Y</sub></code> and/or <code>X<sub>R</sub></code> are patterns.
 
-Table: Variant options overview { #variant-table }
+Table: Variant options for `⎕DT` { #variantoptionsfordt }
 
 |Variant Option|Valid Values|Effect|
 |---|---|---|
 |[`Language`](#variant-option-language)|`'en'` (Default), or another two- or five-character language name such as `'en_GB'`|The language used for formatting and matching datetimes.|
 |[`Dictionary`](#variant-option-dictionary)|a namespace|Additional or replacement month names and predefined patterns.|
 
-### Variant Option: Language
+### Variant Option: `Language`
 
 The `Language` variant option specifies the language used for formatting and matching datetimes and defaults to `'en'` (English). A language is named by a two or five character value (for example `'en'` or `'en_GB'`). The value can be one of the following:
 
@@ -430,7 +430,7 @@ The setting can be explicitly overridden within a format pattern using the `__xx
 └──────────────────────────────────┘
 ```
 
-### Variant Option: Dictionary
+### Variant Option: `Dictionary`
 
 The `Dictionary` variant option specifies a namespace that contains additional or replacement names for the months (and so on) and/or predefined patterns, for languages and language regions. If <code>X<sub>Y</sub></code> and <code>X<sub>R</sub></code> are both patterns, the dictionary is applied to both.
 

--- a/language-reference-guide/docs/system-functions/dt.md
+++ b/language-reference-guide/docs/system-functions/dt.md
@@ -140,7 +140,7 @@ Table: Timestamps { #timestamps }
 | ISO components ||||
 | `¯10` | ISO day-of-year components                   | 6            | Year, day-of-year, hour, minute, second, microsecond         | `1 1 0 0 0 0`                            |
 | `¯11` | ISO day-of-week components                   | 7            | Year, week, day-of-week, hour, minute, second, microsecond   | `1 1 1 0 0 0 0`                              |
-| Decimal encoded[^3] ||||
+| Decimal encoded[^15] ||||
 | `¯20` | Decimal encoded date and time                | 2            | Decimal encoded date, decimal encoded time                   | `10101 0`                              |
 | DateTimePicker ||||
 | `¯30` | DateTime format                              | 4            | International Day Number, hour, minute, second               | `0 0 0 0`                              |
@@ -564,8 +564,7 @@ When <code>X<sub>R</sub></code> is `0`, `⎕DT` validates the elements of `Y` in
 [^12]: Natural sentence case, which can be specified for `M` (month name) and `d` (day name) only, causes the text to be substituted in the case which is natural for the language; some languages (for example, English) always capitalise the first letter of day and month names whereas others (for example, French) do not.
 [^13]: Dates at the start of the year can be in the final week of the previous year, and dates at the end of the year can be in the first week of the following year.
 [^14]: An ordinal indicator is a character or group of characters following a numeral, such as (in English) the suffixes -st, -nd, -rd, -th as in 1st, 2nd, 3rd, 4th.
-[^15]: For negative numbers, the integral part counts backward from 1899-12-30 and the fractional part counts forward from  the date so reached.
-[^16]: Decimal encoded formats encode human-readable dates and times into a single number with the most significant part in the most significant decimal digit, for example 2020-01-23 is encoded as 20200123, and 13:17:56 is encoded as 131756.
+[^15]: Decimal encoded formats encode human-readable dates and times into a single number with the most significant part in the most significant decimal digit, for example 2020-01-23 is encoded as 20200123, and 13:17:56 is encoded as 131756.
 
 <!-- Hidden search keywords -->
 <div style="display: none;">

--- a/language-reference-guide/docs/system-functions/dt.md
+++ b/language-reference-guide/docs/system-functions/dt.md
@@ -402,10 +402,10 @@ If a pattern is rejected, or a text-formatted datetime cannot be matched against
 
 Table: Variant options overview { #variant-table }
 
-|Variant Option|Valid Values|Default|Effect|
-|---|---|---|---|
-|[`Language`](#variant-option-language)|`'en'`, or another two- or five-character language name such as `'en_GB'`|`'en'`|The language used for formatting and matching datetimes.|
-|[`Dictionary`](#variant-option-dictionary)|a namespace||Additional or replacement month names and predefined patterns.|
+|Variant Option|Valid Values|Effect|
+|---|---|---|
+|[`Language`](#variant-option-language)|`'en'` (Default), or another two- or five-character language name such as `'en_GB'`|The language used for formatting and matching datetimes.|
+|[`Dictionary`](#variant-option-dictionary)|a namespace|Additional or replacement month names and predefined patterns.|
 
 ### Variant Option: Language
 

--- a/language-reference-guide/docs/system-functions/dt.md
+++ b/language-reference-guide/docs/system-functions/dt.md
@@ -212,6 +212,15 @@ Table: Military time zones { #timezones }
 
 The resolutions of system clocks vary by platform.
 
+<h3 class="example">Example</h3>
+
+The following expression returns UTC in `⎕TS`-form (`⎕TS` gives local time):
+
+```apl
+      ⊃¯1 ⎕DT 'Z'
+2026 8 10 19 9 12 120
+```
+
 ## Formatting Patterns
 
 Either or both of <code>X<sub>R</sub></code> and <code>X<sub>Y</sub></code> can be a character vector containing a *pattern* which describes how a datetime is, or is to be, formatted as text.

--- a/language-reference-guide/docs/system-functions/dt.md
+++ b/language-reference-guide/docs/system-functions/dt.md
@@ -89,6 +89,39 @@ Table: Time numbers { #timenumbers }
 |Misc. Operating Systems|||||
 | `70` |AmigaOS|Tick count 1&nbsp;ms ticks[^3]|1978-01-01 00:00|No|
 
+### Time Number to Time Number { .example }
+
+```apl
+      2 1 ⎕DT 3⊃⎕FRDCI 1 1
+43886.48188
+      1 ⎕DT 'J'
+43886.48371
+      ⍝ Local time is UTC-05:00
+      3600÷⍨-/20 ⎕DT 'JZ'
+¯5
+```
+
+### Time Number to Timestamp { .example }
+
+```apl
+      1 ¯1 ⎕DT 0 43508.42843
+┌──────────────────┬──────────────────────┐
+│1899 12 31 0 0 0 0│2019 2 13 10 16 56 352│
+└──────────────────┴──────────────────────┘
+      ¯1 ⎕DT 0 43508.42843
+┌──────────────────┬──────────────────────┐
+│1899 12 31 0 0 0 0│2019 2 13 10 16 56 352│
+└──────────────────┴──────────────────────┘
+      2 ¯1 ⎕DT 3⊃⎕FRDCI 1 1
+┌──────────────────────┐
+│2020 2 26 11 33 54 466│
+└──────────────────────┘
+      1 ¯30 ⎕DT 44217.63465
+┌──────────────┐
+│44217 15 13 53│
+└──────────────┘
+```
+
 ## Timestamps
 
 If a value in `X` is negative it indicates that a timestamp type is expected in `Y` or generated in `R`, as follows:
@@ -108,6 +141,39 @@ Table: Timestamps { #timestamps }
 | `¯20` | Decimal encoded date and time                | 2            | Decimal encoded date, decimal encoded time                   | `10101 0`                              |
 | DateTimePicker ||||
 | `¯30` | DateTime format                              | 4            | International Day Number, hour, minute, second               | `0 0 0 0`                              |
+
+### Timestamp to Time Number { .example }
+
+```apl
+      ¯1 1 ⎕DT ⊂⎕TS
+43886.48039
+      1 ⎕DT ⊂⎕TS
+43886.48039
+      1 ⎕DT ⎕TS 'J'
+43886.48039 43886.48039
+
+      1 ⎕DT ⊂⍬ ⍝ cf Elided element implicit values
+¯693594
+      1 ⎕DT ⊂1 1 1 0 0 0 0
+¯693594
+       ¯30 1 ⎕DT⊂44217 15 13 54
+44217.63465
+
+```
+
+### Timestamp to Timestamp { .example }
+
+```apl
+      ¯30 ⎕DT ⊂⎕TS
+┌─────────────┐
+│44216 16 5 46│
+└─────────────┘
+      
+      ¯30 ¯1 ⎕DT⊂32000 15 10 0
+┌───────────────────┐
+│1987 8 12 15 10 0 0│
+└───────────────────┘
+```
 
 ## Military Time Zone Characters
 
@@ -201,9 +267,29 @@ The upper and lower case letters, underscore `_`, dollar `$`, and percent `%` ar
 !!! Info "Information"
     The characters `AaaaBbbb` consist of two adjacent format sequences because there is a sequence of As followed by a sequence of Bs. The characters `AaaaAaaa` consist of one format sequence because it only contains `A`s. It can be separated into two format sequences by inserting an empty `"` or `'` - delimited string, for example, `Aaaa""Aaaa`.
 
+### Formatting Datetimes { .example }
+
+```apl
+      dt←1 ⎕DT ⊂2019 2 13 10 16 56
+      dt
+43508.42843
+      'Dddd, DDoo Mmmm YYYY; hh:mm:ss' ⎕DT dt
+┌───────────────────────────────────────┐
+│Wednesday, 13th February 2019; 10:16:56│
+└───────────────────────────────────────┘
+      '__en__Dddd, DDoo Mmmm YYYY; hh:mm:ss' ⎕DT dt
+┌───────────────────────────────────────┐
+│Wednesday, 13th February 2019; 10:16:56│
+└───────────────────────────────────────┘
+      '"ISO date": %ISO%' ⎕DT dt
+┌─────────────────────────────┐
+│ISO date: 2019-02-13T10:16:56│
+└─────────────────────────────┘
+```
+
 ## Language
 
-Unless overridden, English is used for text substitutions. Different languages can be selected using the [`Language` variant option](#language-variant-option) and/or the use of language specifiers within the format pattern. In either case, the language is specified as either a two letter [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) language code in lower case (for example, `en`) or as a five character language with an additional underscore and two character region in upper case (for example, `en_GB`). Within the format pattern, `__xx__` (where `xx` is the two or five character specifier) will switch the language of the subsequent generated or matched text. { #languages } shows the languages that are built into the interpreter.
+Unless overridden, English is used for text substitutions. Different languages can be selected using the [`Language` variant option](#variant-option-language) and/or the use of language specifiers within the format pattern. In either case, the language is specified as either a two letter [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) language code in lower case (for example, `en`) or as a five character language with an additional underscore and two character region in upper case (for example, `en_GB`). Within the format pattern, `__xx__` (where `xx` is the two or five character specifier) will switch the language of the subsequent generated or matched text. { #languages } shows the languages that are built into the interpreter.
 
 Table: Built-in languages { #languages }
 
@@ -241,7 +327,7 @@ Table: Predefined patterns built into the interpreter { #patterns }
 | ---  | ---            |
 | `ISO`  | `YYYY-MM-DD"T"hh:mm:ss` |
 
-Additional predefined patterns can be defined using the [`Dictionary` variant option](#dictionary-variant-option). Predefined patterns must not contain references to other predefined patterns.
+Additional predefined patterns can be defined using the [`Dictionary` variant option](#variant-option-dictionary). Predefined patterns must not contain references to other predefined patterns.
 
 ## Pattern-matching Rules
 
@@ -284,6 +370,23 @@ The formatted text is parsed and used to compute a datetime according to the giv
 
 If a pattern is rejected, or a text-formatted datetime cannot be matched against the pattern for any of the reasons above, a `DOMAIN ERROR` is signalled and an explanatory message is included.
 
+### Parsing Text Formats { .example }
+
+```apl
+      'DD/MM/YYYY' 1 ⎕DT ⊂'13/02/2019'
+43508
+      'DD/MM/YYYY' ¯1 ⎕DT ⊂'13/02/2019'
+┌─────────────────┐
+│2019 2 13 0 0 0 0│
+└─────────────────┘
+      'Dddd, DDoo Mmmm YYYY; hh:mm:ss' ¯1 ⎕DT ⊂'Wednesday, 13th February 2019; 10:16:56'
+┌────────────────────┐
+│2019 2 13 10 16 56 0│
+└────────────────────┘
+      '__da__Dddd, DDoo mmmm YYYY' 1 ⎕DT ⊂'Onsdag, 13. februar 2019'
+43508
+```
+
 ## Variant Options
 
 `⎕DT` supports the `Language` and `Dictionary` variant options, specified using the _variant_ operator [`⍠`](../primitive-operators/variant.md) and summarised in [](#variant-table). These only apply when <code>X<sub>Y</sub></code> and/or <code>X<sub>R</sub></code> are patterns.
@@ -303,6 +406,20 @@ The `Language` variant option specifies the language used for formatting and mat
 - A 2-element vector of two character vectors, which apply to <code>X<sub>Y</sub></code> and <code>X<sub>R</sub></code> respectively (each is used only if the corresponding value is a pattern).
 
 The setting can be explicitly overridden within a format pattern using the `__xx__` specifier described under [Language](#language).
+
+<h4 class="example">Examples</h4>
+
+```apl
+      '__da__Dddd, DDoo mmmm YYYY; hh:mm:ss' ⎕DT dt
+┌──────────────────────────────────┐
+│Onsdag, 13. februar 2019; 10:16:56│
+└──────────────────────────────────┘
+      fmt←'Dddd, DDoo mmmm YYYY; hh:mm:ss'
+      fmt(⎕DT⍠'Language' 'da') dt
+┌──────────────────────────────────┐
+│Onsdag, 13. februar 2019; 10:16:56│
+└──────────────────────────────────┘
+```
 
 ### Variant Option: Dictionary
 
@@ -327,13 +444,9 @@ If the namespace contains a definition that is supplied built into the interpret
 
 If a dictionary is incomplete (for example, is missing one of the expected named items, or one of the named items contains too few elements), an error is signalled if the missing content would be needed.
 
-See the [Dictionary example](#dictionary).
+<h4 class="example">Creating a Dictionary</h4>
 
-## Examples
-
-### Creating a Dictionary { .example }
-
-The following creates a dictionary defined by the namespace `dict`. See [formatting examples](#formatting-datetimes) for uses of this dictionary.
+The following creates a dictionary defined by the namespace `dict`, used in the examples that follow.
 
 ```apl
 dict←(
@@ -386,118 +499,16 @@ In the above example:
 - There is no explicit definition of patterns or names for language region `en_GB`. If this language is selected, the definitions for `en` will be used.
 - There is an explicit definition for `ShortMonthNames` for language region `en_US`. If this language is selected, the definition of `ShortMonthNames` is as defined, and as for `en` for other names. As `en` is not defined in the dictionary, the built-in defaults are used.
 
-### Time Number to Time Number { .example }
+<h4 class="example">Using a Dictionary</h4>
+
 ```apl
-      2 1 ⎕DT 3⊃⎕FRDCI 1 1
-43886.48188
-      1 ⎕DT 'J'
-43886.48371
-      ⍝ Local time is UTC-05:00
-      3600÷⍨-/20 ⎕DT 'JZ'
-¯5
-```
-
-### Time Number to Timestamp { .example }
-```apl
-      1 ¯1 ⎕DT 0 43508.42843
-┌──────────────────┬──────────────────────┐
-│1899 12 31 0 0 0 0│2019 2 13 10 16 56 352│
-└──────────────────┴──────────────────────┘
-      ¯1 ⎕DT 0 43508.42843
-┌──────────────────┬──────────────────────┐
-│1899 12 31 0 0 0 0│2019 2 13 10 16 56 352│
-└──────────────────┴──────────────────────┘
-      2 ¯1 ⎕DT 3⊃⎕FRDCI 1 1
-┌──────────────────────┐
-│2020 2 26 11 33 54 466│
-└──────────────────────┘
-      1 ¯30 ⎕DT 44217.63465
-┌──────────────┐
-│44217 15 13 53│
-└──────────────┘
-```
-
-### Timestamp to Time Number { .example }
-```apl
-      ¯1 1 ⎕DT ⊂⎕TS
-43886.48039
-      1 ⎕DT ⊂⎕TS
-43886.48039
-      1 ⎕DT ⎕TS 'J'
-43886.48039 43886.48039
-
-      1 ⎕DT ⊂⍬ ⍝ cf Elided element implicit values
-¯693594
-      1 ⎕DT ⊂1 1 1 0 0 0 0
-¯693594
-       ¯30 1 ⎕DT⊂44217 15 13 54
-44217.63465
-
-```
-
-### Timestamp to Timestamp { .example }
-```apl
-      ¯30 ⎕DT ⊂⎕TS
-┌─────────────┐
-│44216 16 5 46│
-└─────────────┘
-      
-      ¯30 ¯1 ⎕DT⊂32000 15 10 0
-┌───────────────────┐
-│1987 8 12 15 10 0 0│
-└───────────────────┘
-```
-
-### Formatting Datetimes { .example }
-```apl
-      dt←1 ⎕DT ⊂2019 2 13 10 16 56
-      dt
-43508.42843
-      'Dddd, DDoo Mmmm YYYY; hh:mm:ss' ⎕DT dt
-┌───────────────────────────────────────┐
-│Wednesday, 13th February 2019; 10:16:56│
-└───────────────────────────────────────┘
-      '__en__Dddd, DDoo Mmmm YYYY; hh:mm:ss' ⎕DT dt
-┌───────────────────────────────────────┐
-│Wednesday, 13th February 2019; 10:16:56│
-└───────────────────────────────────────┘
-      '"ISO date": %ISO%' ⎕DT dt
-┌─────────────────────────────┐
-│ISO date: 2019-02-13T10:16:56│
-└─────────────────────────────┘
       '%DateVerbose%'(⎕DT⍠'Dictionary'dict) dt
 ┌───────────────────────┐
 │the date is 13 Feb 2019│
 └───────────────────────┘
 ```
 
-### Parsing Text Formats { .example }
 ```apl
-      'DD/MM/YYYY' 1 ⎕DT ⊂'13/02/2019'
-43508
-      'DD/MM/YYYY' ¯1 ⎕DT ⊂'13/02/2019'
-┌─────────────────┐
-│2019 2 13 0 0 0 0│
-└─────────────────┘
-      'Dddd, DDoo Mmmm YYYY; hh:mm:ss' ¯1 ⎕DT ⊂'Wednesday, 13th February 2019; 10:16:56'
-┌────────────────────┐
-│2019 2 13 10 16 56 0│
-└────────────────────┘
-      '__da__Dddd, DDoo mmmm YYYY' 1 ⎕DT ⊂'Onsdag, 13. februar 2019'
-43508
-```
-
-### Languages and Dictionaries { .example }
-```apl
-      '__da__Dddd, DDoo mmmm YYYY; hh:mm:ss' ⎕DT dt
-┌──────────────────────────────────┐
-│Onsdag, 13. februar 2019; 10:16:56│
-└──────────────────────────────────┘
-      fmt←'Dddd, DDoo mmmm YYYY; hh:mm:ss'
-      fmt(⎕DT⍠'Language' 'da') dt
-┌──────────────────────────────────┐
-│Onsdag, 13. februar 2019; 10:16:56│
-└──────────────────────────────────┘
       '%DateVerbose%'(⎕DT⍠('Dictionary' dict)('Language' 'en_US')) dt
 ┌─────────────────────────┐
 │the date is Feb. 13, 2019│
@@ -512,7 +523,8 @@ In the above example:
 └───────────────────────┘
 ```
 
-### Validating Datetimes { .example }
+## Validating Datetimes
+
 ```apl
       0 ⎕DT ⎕TS (2020 13 1) 'J' 'DT' #
 1 0 1 0 0

--- a/language-reference-guide/docs/system-functions/dt.md
+++ b/language-reference-guide/docs/system-functions/dt.md
@@ -5,7 +5,7 @@ search:
 
 # <span>Datetime</span> `R←X ⎕DT Y`{{key}}
 
-This function validates datetimes, converts datetimes between one representation and another, and converts datetimes to and from text.
+This function validates datetimes and converts datetimes between one representation and another, including textual representations.
 
 A *datetime* is a date and time of day represented by a *time number*, a *timestamp*, a *military time-zone character*, or a *text-formatted datetime*.
 
@@ -39,6 +39,9 @@ Character scalars in `Y` are always interpreted as meaning "now".
 `R` is an array of the same shape as `Y`, where each element is a timestamp, time number, character vector or Boolean value, as determined by <code>X<sub>R</sub></code> (the second or only element of `X`).
 
 Time numbers in `R` can be of type DECF even when [`⎕FR`](fr.md) is `645` if their magnitude could be too great to store precisely in a double. See [](#timenumbers) for the type numbers where this is so.
+
+!!! Warning "Warning"
+    Performing arithmetic on such time numbers while [`⎕FR`](fr.md) is `645` can lose precision or signal `DOMAIN ERROR`. To compute with them accurately, set `⎕FR` to `1287` (128-bit decimal) first.
 
 ## Time Numbers
 

--- a/language-reference-guide/docs/system-functions/dt.md
+++ b/language-reference-guide/docs/system-functions/dt.md
@@ -203,7 +203,7 @@ The upper and lower case letters, underscore `_`, dollar `$`, and percent `%` ar
 
 ## Language
 
-Unless overridden, English is used for text substitutions. Different languages can be selected using the [**Language** variant option](#language-variant-option) and/or the use of language specifiers within the format pattern. In either case, the language is specified as either a two letter [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) language code in lower case (for example, `en`) or as a five character language with an additional underscore and two character region in upper case (for example, `en_GB`). Within the format pattern, `__xx__` (where `xx` is the two or five character specifier) will switch the language of the subsequent generated or matched text. { #languages } shows the languages that are built into the interpreter.
+Unless overridden, English is used for text substitutions. Different languages can be selected using the [`Language` variant option](#language-variant-option) and/or the use of language specifiers within the format pattern. In either case, the language is specified as either a two letter [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) language code in lower case (for example, `en`) or as a five character language with an additional underscore and two character region in upper case (for example, `en_GB`). Within the format pattern, `__xx__` (where `xx` is the two or five character specifier) will switch the language of the subsequent generated or matched text. { #languages } shows the languages that are built into the interpreter.
 
 Table: Built-in languages { #languages }
 
@@ -241,7 +241,7 @@ Table: Predefined patterns built into the interpreter { #patterns }
 | ---  | ---            |
 | `ISO`  | `YYYY-MM-DD"T"hh:mm:ss` |
 
-Additional predefined patterns can be defined using the [**Dictionary** variant option](#dictionary-variant-option). Predefined patterns must not contain references to other predefined patterns.
+Additional predefined patterns can be defined using the [`Dictionary` variant option](#dictionary-variant-option). Predefined patterns must not contain references to other predefined patterns.
 
 ## Pattern-matching Rules
 
@@ -286,11 +286,18 @@ If a pattern is rejected, or a text-formatted datetime cannot be matched against
 
 ## Variant Options
 
-`⎕DT` supports the **Language** and **Dictionary** variant options, specified using the _variant_ operator [`⍠`](../primitive-operators/variant.md). These only apply when <code>X<sub>Y</sub></code> and/or <code>X<sub>R</sub></code> are patterns.
+`⎕DT` supports the `Language` and `Dictionary` variant options, specified using the _variant_ operator [`⍠`](../primitive-operators/variant.md) and summarised in [](#variant-table). These only apply when <code>X<sub>Y</sub></code> and/or <code>X<sub>R</sub></code> are patterns.
+
+Table: Variant options overview { #variant-table }
+
+|Variant Option|Value|Effect|
+|---|---|---|
+|[`Language`](#variant-option-language)|`'en'` <small>(default)</small>, or another two- or five-character language name such as `'en_GB'`|The language used for formatting and matching datetimes.|
+|[`Dictionary`](#variant-option-dictionary)|a namespace|Additional or replacement month names and predefined patterns.|
 
 ### Variant Option: Language
 
-The **Language** variant option specifies the language used for formatting and matching datetimes and defaults to `'en'` (English). A language is named by a two or five character value (for example `'en'` or `'en_GB'`). The value can be one of the following:
+The `Language` variant option specifies the language used for formatting and matching datetimes and defaults to `'en'` (English). A language is named by a two or five character value (for example `'en'` or `'en_GB'`). The value can be one of the following:
 
 - a single character vector, which applies to whichever of <code>X<sub>Y</sub></code> and/or <code>X<sub>R</sub></code> are patterns.
 - A 2-element vector of two character vectors, which apply to <code>X<sub>Y</sub></code> and <code>X<sub>R</sub></code> respectively (each is used only if the corresponding value is a pattern).
@@ -299,7 +306,7 @@ The setting can be explicitly overridden within a format pattern using the `__xx
 
 ### Variant Option: Dictionary
 
-The **Dictionary** variant option specifies a namespace that contains additional or replacement names for the months (and so on) and/or predefined patterns, for languages and language regions. If <code>X<sub>Y</sub></code> and <code>X<sub>R</sub></code> are both patterns, the dictionary is applied to both.
+The `Dictionary` variant option specifies a namespace that contains additional or replacement names for the months (and so on) and/or predefined patterns, for languages and language regions. If <code>X<sub>Y</sub></code> and <code>X<sub>R</sub></code> are both patterns, the dictionary is applied to both.
 
 At the top level there can be zero or more sub-namespaces with two or five character names, according to the rules for language and language regions. Within each of these, month names (and so on) are defined as shown in [](#names).
 

--- a/language-reference-guide/docs/system-functions/ed.md
+++ b/language-reference-guide/docs/system-functions/ed.md
@@ -24,9 +24,9 @@ If `Y` names an existing object, the type specification for that name in `X` is 
 If `X` is `⋄`, `Y` must be undefined or an array.
 The Editor opens in array-notation mode; the resulting array can be of any type or structure.
 
-If `⎕ED` is called from the Session, it opens Edit windows for the object(s) named in `Y` and returns a null result.  The cursor is positioned in the first of the Edit windows opened by `⎕ED`, but may be moved to the Session or to any other window which is currently open.  The effect is almost identical to using `)ED`.
+If `⎕ED` is called from the Session, it opens Edit windows for the object(s) named in `Y` and returns a null result.  The cursor is positioned in the first of the Edit windows opened by `⎕ED`, but can be moved to the Session or to any other window which is currently open.  The effect is almost identical to using `)ED`.
 
-If `⎕ED` is called from a defined function or operator, its behaviour is different. On asynchronous terminals, the Edit windows are automatically displayed in "full-screen" mode (ZOOMED). In all implementations, the user is restricted to those windows named in `Y`. The user may not skip to the Session even though the Session may be visible.
+If `⎕ED` is called from a defined function or operator, its behaviour is different. On asynchronous terminals, the Edit windows are automatically displayed in "full-screen" mode (ZOOMED). In all implementations, the user is restricted to those windows named in `Y`. The user cannot skip to the Session even though the Session might be visible.
 
 `⎕ED` terminates and returns a result ONLY when the user explicitly closes all the windows for the named objects. In this case the result contains the names of any objects which have been newly (re)fixed in the workspace as a result of the `⎕ED`, and has the same structure as `Y`.
 
@@ -34,24 +34,24 @@ Objects named in `Y` that cannot be edited are silently ignored. Objects qualifi
 
 ## Variant Options
 
-`⎕ED` supports two variant options, `ReadOnly` and `EditName`, summarised in [](#variant-table) and described in detail beneath it. There is no principal option.
+`⎕ED` supports two variant options, `ReadOnly` and `EditName`, summarised in [](#variantoptionsfored) and described in detail beneath it. There is no principal option.
 
-Table: Variant options overview { #variant-table }
+Table: Variant options for `⎕ED` { #variantoptionsfored }
 
 |Variant Option|Valid Values|Default|Effect|
 |---|---|---|---|
 |[`ReadOnly`](#variant-option-readonly)|`0` or `1`|`0`|Whether the edit windows are read-only.|
-|[`EditName`](#variant-option-editname)|`'Default'`, `'Allow'` or `'Disallow'`|`'Default'`|Whether the user may open further edit windows by clicking a name.|
+|[`EditName`](#variant-option-editname)|`'Default'`, `'Allow'` or `'Disallow'`|`'Default'`|Whether the user can open further edit windows by clicking a name.|
 
-### Variant Option: ReadOnly
+### Variant Option: `ReadOnly`
 
 If `ReadOnly` is set to `1`, the edit window and all edit windows opened from it will be read-only. Note that setting `ReadOnly` to `0` will have no effect if the edit window is inherently read-only due to the nature of its content.
 
-### Variant Option: EditName
+### Variant Option: `EditName`
 
-The `EditName` option determines whether or not the user may open another edit window by clicking a name, and its values are interpreted as follows:
+The `EditName` option determines whether or not the user can open another edit window by clicking a name, and its values are interpreted as follows:
 
-|EditName    |`⎕ED` called from session|`⎕ED` called from function|
+|`EditName`|`⎕ED` called from session|`⎕ED` called from function|
 |------------|-------------------------|--------------------------|
 |`'Default'` <small>(default)</small>|Allow                    |Disallow                  |
 |`'Allow'`   |Allow                    |Allow                     |
@@ -62,7 +62,7 @@ The `EditName` option determines whether or not the user may open another edit w
       A←3 11⍴'Hello World'
 ```
 
-In the first example, `⎕ED` will display the contents of `A` as an editable character array which the user may change. The user can double-click on *Hello* to open an edit window on an object named `Hello` (which will be a new function if `Hello` is currently undefined). Furthermore, the user can enter any arbitrary name and double-click to edit it. This may be undesirable in an application.
+In the first example, `⎕ED` will display the contents of `A` as an editable character array which the user can change. The user can double-click on *Hello* to open an edit window on an object named `Hello` (which will be a new function if `Hello` is currently undefined). Furthermore, the user can enter any arbitrary name and double-click to edit it. This might be undesirable in an application.
 ```apl
       ⎕ED A
 ```

--- a/language-reference-guide/docs/system-functions/ed.md
+++ b/language-reference-guide/docs/system-functions/ed.md
@@ -32,24 +32,30 @@ If `⎕ED` is called from a defined function or operator, its behaviour is diffe
 
 Objects named in `Y` that cannot be edited are silently ignored. Objects qualified with a namespace path are (for example, `a.b.c.foo`) are silently ignored if the namespace does not exist.
 
-## Variants of Edit Object
+## Variant Options
 
-The behaviour of `⎕ED` may be modified using the variant operator `⍠` with the following options:
+`⎕ED` supports two variant options, `ReadOnly` and `EditName`, summarised in [](#variant-table) and described in detail beneath it. There is no principal option.
 
-- `'ReadOnly'` - 0 or 1
-- `'EditName'` - `'Default'`, `'Allow'` or `'Disallow'`.
+Table: Variant options overview { #variant-table }
 
-If `ReadOnly` is set to 1, the edit window and all edit windows opened from it will be read-only. Note that setting `ReadOnly` to 0 will have no effect if the edit window is inherently read-only due to the nature of its content.
+|Variant Option|Value|Effect|
+|---|---|---|
+|[`ReadOnly`](#variant-option-readonly)|`0` <small>(default)</small> or `1`|Whether the edit windows are read-only.|
+|[`EditName`](#variant-option-editname)|`'Default'` <small>(default)</small>, `'Allow'` or `'Disallow'`|Whether the user may open further edit windows by clicking a name.|
 
-The `'EditName'` option determines whether or not the user may open another edit window by clicking a name, and its values are interpreted as follows:
+### Variant Option: ReadOnly
+
+If `ReadOnly` is set to `1`, the edit window and all edit windows opened from it will be read-only. Note that setting `ReadOnly` to `0` will have no effect if the edit window is inherently read-only due to the nature of its content.
+
+### Variant Option: EditName
+
+The `EditName` option determines whether or not the user may open another edit window by clicking a name, and its values are interpreted as follows:
 
 |EditName    |`⎕ED` called from session|`⎕ED` called from function|
 |------------|-------------------------|--------------------------|
-|`'Default'` |Allow                    |Disallow                  |
+|`'Default'` <small>(default)</small>|Allow                    |Disallow                  |
 |`'Allow'`   |Allow                    |Allow                     |
 |`'Disallow'`|Disallow                 |Disallow                  |
-
-There is no Principal Option.
 
 <h2 class="example">Examples</h2>
 ```apl

--- a/language-reference-guide/docs/system-functions/ed.md
+++ b/language-reference-guide/docs/system-functions/ed.md
@@ -38,10 +38,10 @@ Objects named in `Y` that cannot be edited are silently ignored. Objects qualifi
 
 Table: Variant options overview { #variant-table }
 
-|Variant Option|Value|Effect|
-|---|---|---|
-|[`ReadOnly`](#variant-option-readonly)|`0` <small>(default)</small> or `1`|Whether the edit windows are read-only.|
-|[`EditName`](#variant-option-editname)|`'Default'` <small>(default)</small>, `'Allow'` or `'Disallow'`|Whether the user may open further edit windows by clicking a name.|
+|Variant Option|Valid Values|Default|Effect|
+|---|---|---|---|
+|[`ReadOnly`](#variant-option-readonly)|`0` or `1`|`0`|Whether the edit windows are read-only.|
+|[`EditName`](#variant-option-editname)|`'Default'`, `'Allow'` or `'Disallow'`|`'Default'`|Whether the user may open further edit windows by clicking a name.|
 
 ### Variant Option: ReadOnly
 

--- a/language-reference-guide/docs/system-functions/ed.md
+++ b/language-reference-guide/docs/system-functions/ed.md
@@ -24,11 +24,11 @@ If `Y` names an existing object, the type specification for that name in `X` is 
 If `X` is `⋄`, `Y` must be undefined or an array.
 The Editor opens in array-notation mode; the resulting array can be of any type or structure.
 
-If `⎕ED` is called from the Session, it opens Edit windows for the object(s) named in `Y` and returns a null result.  The cursor is positioned in the first of the Edit windows opened by `⎕ED`, but can be moved to the Session or to any other window which is currently open.  The effect is almost identical to using `)ED`.
+If `⎕ED` is called from the Session, it opens Edit windows for the object(s) named in `Y` and immediately returns a null result.  The cursor is positioned in the first of the Edit windows opened by `⎕ED`, but can be moved to the Session or to any other window which is currently open.  The effect is almost identical to using `)ED`.
 
 If `⎕ED` is called from a defined function or operator, its behaviour is different. On asynchronous terminals, the Edit windows are automatically displayed in "full-screen" mode (ZOOMED). In all implementations, the user is restricted to those windows named in `Y`. The user cannot skip to the Session even though the Session might be visible.
 
-`⎕ED` terminates and returns a result ONLY when the user explicitly closes all the windows for the named objects. In this case the result contains the names of any objects which have been newly (re)fixed in the workspace as a result of the `⎕ED`, and has the same structure as `Y`.
+In this case, `⎕ED` terminates and returns a result only when the user explicitly closes all the windows for the named objects. The result contains the names of any objects which have been newly (re)fixed in the workspace as a result of the `⎕ED`, and has the same structure as `Y`.
 
 Objects named in `Y` that cannot be edited are silently ignored. Objects qualified with a namespace path are (for example, `a.b.c.foo`) are silently ignored if the namespace does not exist.
 

--- a/language-reference-guide/docs/system-functions/fchk.md
+++ b/language-reference-guide/docs/system-functions/fchk.md
@@ -11,7 +11,7 @@ search:
 
 For files associated with external variables, any filename extension must be specified even if `⎕XT` would not require it. The file must exist and must not currently be associated with an external variable.
 
-Options for `⎕FCHK` are specified using the Variant operator `⍠` or by the optional left argument `X`. The former is recommended but the older mechanism using the left argument is still supported.
+Options for `⎕FCHK` are specified using the _variant_ operator `⍠` or by the optional left argument `X`. The former is recommended but the older mechanism using the left argument is still supported.
 
 In either case, the default behaviour is as follows:
 

--- a/language-reference-guide/docs/system-functions/fchk.md
+++ b/language-reference-guide/docs/system-functions/fchk.md
@@ -27,35 +27,37 @@ The result `R` is a vector of the numbers of missing or damaged components. `R` 
 
 Other negative numbers represent damage to the file metadata; this set may be extended in the future.
 
-## Specifying options using Variant
+## Variant Options
 
-Using Variant, the options are as follows:
+`⎕FCHK` supports three variant options, `Task`, `Repair` and `Force`, summarised in [](#variant-table) and described in detail beneath it. The principal option is `Repair`.
 
-- Task
-- Repair
-- Force
+Table: Variant options overview { #variant-table }
 
-*Rebuild* causes the *file indices* to be discarded and rebuilt. *Repair* only takes place on files which have been checked and found to be damaged. It involves a rebuild, but that only takes place if it is needed. Note that Repair and Force only apply if Task is `'Scan'`.
+|Variant Option|Value|Effect|
+|---|---|---|
+|[`Task`](#variant-option-task)|`'Scan'` <small>(default)</small> or `'Rebuild'`|Whether to check (and optionally repair) the file, or unconditionally rebuild it.|
+|[`Repair`](#variant-option-repair)<br><small>principal</small>|`0` <small>(default)</small> or `1`|Whether a damaged file is repaired.|
+|[`Force`](#variant-option-force)|`0` <small>(default)</small> or `1`|Whether to validate a file that appears to have been properly closed.|
 
-### Task
+The `'Rebuild'` task causes the *file indices* to be discarded and rebuilt. `Repair` only takes place on files which have been checked and found to be damaged. It involves a rebuild, but that only takes place if it is needed. Note that `Repair` and `Force` only apply if `Task` is `'Scan'`.
+
+### Variant Option: Task
 
 |---------|----------------------------------------------------------------------------|
-|Scan { .shaded } |causes the file to be checked and optionally repaired (see `'Repair'` below)|
-|`Rebuild`|causes the file to be unconditionally rebuilt                               |
+|`'Scan'` <small>(default)</small>|causes the file to be checked and optionally repaired (see [`Repair`](#variant-option-repair) below)|
+|`'Rebuild'`|causes the file to be unconditionally rebuilt                               |
 
-### Repair (principle option)
+### Variant Option: Repair
 
 |---|-------------------------------------------------|
-|0 { .shaded }  |do not repair                                    |
+|`0` <small>(default)</small>|do not repair                                    |
 |`1`|causes the file to be repaired if damage is found|
 
-### Force
+### Variant Option: Force
 
 |---|-------------------------------------------------------------------|
-|0 { .shaded }   |do not validate the file if it appears to have been properly closed|
+|`0` <small>(default)</small>|do not validate the file if it appears to have been properly closed|
 |`1`|validate the file even if it appears to have been properly closed  |
-
-Default values are highlighted thus{ .shaded }  in the above tables.
 
 <h2 class="example">Examples</h2>
 
@@ -69,13 +71,9 @@ To forcibly check a file and attempt to fix it if damage is found:
       (⎕FCHK ⍠ ('Repair' 1)('Force'1))'suspect.dcf'
 ```
 
-### Specifying options using a left argument
+## Specifying Options Using a Left Argument
 
 Using the optional left-argument, `X` must be a vector of zero or more character vectors from among `'force'`, `'repair'` and `'rebuild'`, which determine the detailed operation of the function. Note that these options are case-insensitive.
-
-- If `X` contains `'force'`, `⎕FCHK` will validate the file even if it appears to have been cleanly untied.
-- If `X` contains `'repair'`, `⎕FCHK` will repair the file, following validation, if it appears to be damaged. This option may be used in conjunction with `'force'`.
-- If `X` contains `'rebuild'`, `⎕FCHK` will repair the file unconditionally.
 
 - If `X` contains `'force'`, `⎕FCHK` will validate the file even if it appears to have been cleanly untied.
 - If `X` contains `'repair'`, `⎕FCHK` will repair the file, following validation, if it appears to be damaged. This option may be used in conjunction with `'force'`.

--- a/language-reference-guide/docs/system-functions/fchk.md
+++ b/language-reference-guide/docs/system-functions/fchk.md
@@ -9,7 +9,7 @@ search:
 
 `Y` must be a simple character scalar or vector which specifies the name of the file to be exclusively checked or repaired. For component files, the file must be named in accordance with the operating system's conventions, and can be a relative or absolute pathname. The file must exist and must not be tied. If no file extension is supplied, the set of extensions specified by the  **CFEXT** parameter are tried one after another until the file is found or the set of extensions is exhausted. See [CFEXT](../../../windows-installation-and-configuration-guide/configuration-parameters/configuration-parameters).
 
-For files associated with external variables, any filename extension must be specified even if `⎕XT` would not require it. The file must exist and must not currently be associated with an external variable.
+For files associated with external variables, any filename extension must be specified, even if `⎕XT` would not require it. The file must exist and must not currently be associated with an external variable.
 
 Options for `⎕FCHK` are specified using the _variant_ operator `⍠` or by the optional left argument `X`. The former is recommended but the older mechanism using the left argument is still supported.
 
@@ -57,7 +57,7 @@ The `'Rebuild'` task causes the *file indices* to be discarded and rebuilt. `Rep
 
 |---|-------------------------------------------------------------------|
 |`0` <small>(default)</small>|do not validate the file if it appears to have been properly closed|
-|`1`|validate the file even if it appears to have been properly closed  |
+|`1`|validate the file, even if it appears to have been properly closed  |
 
 <h2 class="example">Examples</h2>
 
@@ -75,7 +75,7 @@ To forcibly check a file and attempt to fix it if damage is found:
 
 Using the optional left-argument, `X` must be a vector of zero or more character vectors from among `'force'`, `'repair'` and `'rebuild'`, which determine the detailed operation of the function. Note that these options are case-insensitive.
 
-- If `X` contains `'force'`, `⎕FCHK` will validate the file even if it appears to have been cleanly untied.
+- If `X` contains `'force'`, `⎕FCHK` will validate the file, even if it appears to have been cleanly untied.
 - If `X` contains `'repair'`, `⎕FCHK` will repair the file, following validation, if it appears to be damaged. This option can be used in conjunction with `'force'`.
 - If `X` contains `'rebuild'`, `⎕FCHK` will repair the file unconditionally.
 

--- a/language-reference-guide/docs/system-functions/fchk.md
+++ b/language-reference-guide/docs/system-functions/fchk.md
@@ -33,11 +33,11 @@ Other negative numbers represent damage to the file metadata; this set may be ex
 
 Table: Variant options overview { #variant-table }
 
-|Variant Option|Value|Effect|
-|---|---|---|
-|[`Task`](#variant-option-task)|`'Scan'` <small>(default)</small> or `'Rebuild'`|Whether to check (and optionally repair) the file, or unconditionally rebuild it.|
-|[`Repair`](#variant-option-repair)<br><small>principal</small>|`0` <small>(default)</small> or `1`|Whether a damaged file is repaired.|
-|[`Force`](#variant-option-force)|`0` <small>(default)</small> or `1`|Whether to validate a file that appears to have been properly closed.|
+|Variant Option|Valid Values|Default|Effect|
+|---|---|---|---|
+|[`Task`](#variant-option-task)|`'Scan'` or `'Rebuild'`|`'Scan'`|Whether to check (and optionally repair) the file, or unconditionally rebuild it.|
+|[`Repair`](#variant-option-repair)<br><small>principal</small>|`0` or `1`|`0`|Whether a damaged file is repaired.|
+|[`Force`](#variant-option-force)|`0` or `1`|`0`|Whether to validate a file that appears to have been properly closed.|
 
 The `'Rebuild'` task causes the *file indices* to be discarded and rebuilt. `Repair` only takes place on files which have been checked and found to be damaged. It involves a rebuild, but that only takes place if it is needed. Note that `Repair` and `Force` only apply if `Task` is `'Scan'`.
 

--- a/language-reference-guide/docs/system-functions/fchk.md
+++ b/language-reference-guide/docs/system-functions/fchk.md
@@ -7,7 +7,7 @@ search:
 
 `⎕FCHK` validates and repairs component files, and validates files associated with external variables, following an abnormal termination of the APL process or operating system.
 
-`Y` must be a simple character scalar or vector which specifies the name of the file to be exclusively checked or repaired. For component files, the file must be named in accordance with the operating system's conventions, and may be a relative or absolute pathname. The file must exist and must not be tied. If no file extension is supplied, the set of extensions specified by the  **CFEXT** parameter are tried one after another until the file is found or the set of extensions is exhausted. See [CFEXT](../../../windows-installation-and-configuration-guide/configuration-parameters/configuration-parameters).
+`Y` must be a simple character scalar or vector which specifies the name of the file to be exclusively checked or repaired. For component files, the file must be named in accordance with the operating system's conventions, and can be a relative or absolute pathname. The file must exist and must not be tied. If no file extension is supplied, the set of extensions specified by the  **CFEXT** parameter are tried one after another until the file is found or the set of extensions is exhausted. See [CFEXT](../../../windows-installation-and-configuration-guide/configuration-parameters/configuration-parameters).
 
 For files associated with external variables, any filename extension must be specified even if `⎕XT` would not require it. The file must exist and must not currently be associated with an external variable.
 
@@ -18,20 +18,20 @@ In either case, the default behaviour is as follows:
 1. If the file appears to have been cleanly untied previously, return `⍬`, that is, report that the file is good.
 2. Otherwise, validate the file and return the appropriate result. If the file is corrupt, no attempt is made to repair it.
 
-The result `R` is a vector of the numbers of missing or damaged components. `R` may include non-positive numbers of "pseudo components" that indicate damage to parts of the file other than in specific components:
+The result `R` is a vector of the numbers of missing or damaged components. `R` can include non-positive numbers of "pseudo components" that indicate damage to parts of the file other than in specific components:
 
 |----|---------------------|
 |`0` |ACCESS MATRIX.       |
 |`¯1`|Free-block tree.     |
 |`¯2`|Component index tree.|
 
-Other negative numbers represent damage to the file metadata; this set may be extended in the future.
+Other negative numbers represent damage to the file metadata; this set might be extended in the future.
 
 ## Variant Options
 
-`⎕FCHK` supports three variant options, `Task`, `Repair` and `Force`, summarised in [](#variant-table) and described in detail beneath it. The principal option is `Repair`.
+`⎕FCHK` supports three variant options, `Task`, `Repair` and `Force`, summarised in [](#variantoptionsforfchk) and described in detail beneath it. The principal option is `Repair`.
 
-Table: Variant options overview { #variant-table }
+Table: Variant options for `⎕FCHK` { #variantoptionsforfchk }
 
 |Variant Option|Valid Values|Default|Effect|
 |---|---|---|---|
@@ -41,19 +41,19 @@ Table: Variant options overview { #variant-table }
 
 The `'Rebuild'` task causes the *file indices* to be discarded and rebuilt. `Repair` only takes place on files which have been checked and found to be damaged. It involves a rebuild, but that only takes place if it is needed. Note that `Repair` and `Force` only apply if `Task` is `'Scan'`.
 
-### Variant Option: Task
+### Variant Option: `Task`
 
 |---------|----------------------------------------------------------------------------|
 |`'Scan'` <small>(default)</small>|causes the file to be checked and optionally repaired (see [`Repair`](#variant-option-repair) below)|
 |`'Rebuild'`|causes the file to be unconditionally rebuilt                               |
 
-### Variant Option: Repair
+### Variant Option: `Repair`
 
 |---|-------------------------------------------------|
 |`0` <small>(default)</small>|do not repair                                    |
 |`1`|causes the file to be repaired if damage is found|
 
-### Variant Option: Force
+### Variant Option: `Force`
 
 |---|-------------------------------------------------------------------|
 |`0` <small>(default)</small>|do not validate the file if it appears to have been properly closed|
@@ -76,16 +76,16 @@ To forcibly check a file and attempt to fix it if damage is found:
 Using the optional left-argument, `X` must be a vector of zero or more character vectors from among `'force'`, `'repair'` and `'rebuild'`, which determine the detailed operation of the function. Note that these options are case-insensitive.
 
 - If `X` contains `'force'`, `⎕FCHK` will validate the file even if it appears to have been cleanly untied.
-- If `X` contains `'repair'`, `⎕FCHK` will repair the file, following validation, if it appears to be damaged. This option may be used in conjunction with `'force'`.
+- If `X` contains `'repair'`, `⎕FCHK` will repair the file, following validation, if it appears to be damaged. This option can be used in conjunction with `'force'`.
 - If `X` contains `'rebuild'`, `⎕FCHK` will repair the file unconditionally.
 
 Following a *check* of the file, a non-null result indicates that the file is damaged.
 
-Following a *repair* of the file, the result indicates those components that could not be recovered. Un-recovered components will give a `FILE COMPONENT DAMAGED` error if read but may be replaced without error.
+Following a *repair* of the file, the result indicates those components that could not be recovered. Un-recovered components will give a `FILE COMPONENT DAMAGED` error if read but can be replaced without error.
 
 Repair can recover only check-summed components from the file, that is, only those components that were written with the checksum option enabled (see [File Properties](fprops.md)).
 
-Following an operating system crash, repair may result in one or more individual components being rolled back to a previous version or not recovered at all, unless Journaling levels 2 or 3 were also set when these components were written.
+Following an operating system crash, repair might result in one or more individual components being rolled back to a previous version or not recovered at all, unless Journaling levels 2 or 3 were also set when these components were written.
 
 <!-- Hidden search keywords -->
 <div style="display: none;">

--- a/language-reference-guide/docs/system-functions/fcopy.md
+++ b/language-reference-guide/docs/system-functions/fcopy.md
@@ -45,13 +45,13 @@ If `X` specifies the name of an existing file, the operation fails with a `FILE 
 
 Table: Variant options overview { #variant-table }
 
-|Variant Option|Valid Values|Default|Effect|
-|---|---|---|---|
-|`'J'`|a journaling level|as source|Sets the journaling level.|
-|`'C'`|`0` or `1`|as source|Sets the checksum level.|
-|`'Z'`|`0` or `1`|as source|Sets compression.|
-|`'U'`|`0` or `1`|as source|Sets Unicode support.|
-|`'S'`|`64`|`64`|Sets the file size (span).|
+|Variant Option|Valid Values|Effect|
+|---|---|---|
+|`'J'`|a journaling level|Sets the journaling level.|
+|`'C'`|`0` or `1`|Sets the checksum level.|
+|`'Z'`|`0` or `1`|Sets compression.|
+|`'U'`|`0` or `1`|Sets Unicode support.|
+|`'S'`|`64`|Sets the file size (span).|
 
 The principal option is a number that sets journaling (`'J'`) and checksum (`'C'`) together:
 

--- a/language-reference-guide/docs/system-functions/fcopy.md
+++ b/language-reference-guide/docs/system-functions/fcopy.md
@@ -21,7 +21,7 @@ The result `R` is the file tie number associated with the new file `X`.
 
 Note that the Access Code is 4609, which is the sum of the Access Codes for `⎕FREAD` (1), `⎕FRDCI` (512) and `⎕FRDAC` (4096).
 
-Note also that although the file need not be tied exclusively, the `⎕FCOPY` function will not yield the file to other APL processes while it is running, and it may take some considerable time to run in the case of a large component file.
+Note also that although the file need not be tied exclusively, the `⎕FCOPY` function will not yield the file to other APL processes while it is running, and it might take some considerable time to run in the case of a large component file.
 
 <h2 class="example">Example</h2>
 ```apl
@@ -41,9 +41,9 @@ If `X` specifies the name of an existing file, the operation fails with a `FILE 
 
 ## Variant Options
 
-`⎕FCOPY` sets the properties of the new file through variant options, summarised in [](#variant-table). These are the file properties described in [File Properties](fprops.md). Unless a property is specified, the new file inherits it from the source, except `'S'` which is always `64`.
+`⎕FCOPY` sets the properties of the new file through variant options, summarised in [](#variantoptionsforfcopy). These are the file properties described in [File Properties](fprops.md). Unless a property is specified, the new file inherits it from the source, except `'S'` which is always `64`.
 
-Table: Variant options overview { #variant-table }
+Table: Variant options for `⎕FCOPY` { #variantoptionsforfcopy }
 
 |Variant Option|Valid Values|Effect|
 |---|---|---|
@@ -82,7 +82,7 @@ will name a variant of `⎕FCREATE` which will create component file with level 
 ```
 
 !!! note
-    Setting `('U' 0)` (no Unicode support) is discouraged as it may cause the copy to fail with a `TRANSLATION ERROR`. Similarly using a Classic interpreter to `⎕FCOPY` files may result in `TRANSLATION ERROR`s.
+    Setting `('U' 0)` (no Unicode support) is discouraged as it might cause the copy to fail with a `TRANSLATION ERROR`. Similarly using a Classic interpreter to `⎕FCOPY` files might result in `TRANSLATION ERROR`s.
 
 !!! Info "Information"
     Small-span (32-bit) component files are currently read-only; Dyalog Ltd recommends using `⎕FCOPY` to convert any such files to large-span (64-bit). This ability is scheduled for removal in a future release. For information on how to identify calls to small-span component files in your existing codebase, see the [Release Notes](../../../release-notes/announcements/deprecated-functionality/).

--- a/language-reference-guide/docs/system-functions/fcopy.md
+++ b/language-reference-guide/docs/system-functions/fcopy.md
@@ -41,7 +41,7 @@ If `X` specifies the name of an existing file, the operation fails with a `FILE 
 
 ## Variant Options
 
-`⎕FCOPY` sets the properties of the new file through variant options, summarised in [](#variant-table). These are the file properties described in [File Properties](fprops.md).
+`⎕FCOPY` sets the properties of the new file through variant options, summarised in [](#variant-table). These are the file properties described in [File Properties](fprops.md). Unless a property is specified, the new file inherits it from the source, except `'S'` which is always `64`.
 
 Table: Variant options overview { #variant-table }
 

--- a/language-reference-guide/docs/system-functions/fcopy.md
+++ b/language-reference-guide/docs/system-functions/fcopy.md
@@ -39,22 +39,28 @@ If `X` specifies the name of an existing file, the operation fails with a `FILE 
 !!! note
     This operation is atomic. If an error occurs during the copy operation (such as disk full) or if a strong interrupt is issued, the copy will be aborted and the new file `X` will not be created.
 
-## File Properties
+## Variant Options
 
-`⎕FCOPY` allows you to specify properties for the new file via the variant operator `⍠` used with the following options:
+`⎕FCOPY` sets the properties of the new file through variant options, summarised in [](#variant-table). These are the file properties described in [File Properties](fprops.md).
 
-- `'J'` - journaling level; a numeric value.
-- `'C'` - checksum level; 0 or 1.
-- `'Z'` - compression; 0 or 1.
-- `'U'` - Unicode; 0 or 1
-- `'S'` - File Size (span); 64
+Table: Variant options overview { #variant-table }
 
-The Principal Option is  as follows:
+|Variant Option|Value|Effect|
+|---|---|---|
+|`'J'`|a journaling level|Sets the journaling level.|
+|`'C'`|`0` or `1`|Sets the checksum level.|
+|`'Z'`|`0` or `1`|Sets compression.|
+|`'U'`|`0` or `1`|Sets Unicode support.|
+|`'S'`|`64`|Sets the file size (span).|
 
-- 0 - sets `('J' 0) ('C' 0)`
-- 1 - sets `('J' 1) ('C' 1)`
-- 2 - sets `('J' 2) ('C' 1)`
-- 3 - sets `('J' 3) ('C' 1)`
+The principal option is a number that sets journaling (`'J'`) and checksum (`'C'`) together:
+
+|Principal option|Effect|
+|---|---|
+|`0`|sets `('J' 0) ('C' 0)`|
+|`1`|sets `('J' 1) ('C' 1)`|
+|`2`|sets `('J' 2) ('C' 1)`|
+|`3`|sets `('J' 3) ('C' 1)`|
 
 <h2 class="example">Examples</h2>
 ```apl

--- a/language-reference-guide/docs/system-functions/fcopy.md
+++ b/language-reference-guide/docs/system-functions/fcopy.md
@@ -45,13 +45,13 @@ If `X` specifies the name of an existing file, the operation fails with a `FILE 
 
 Table: Variant options overview { #variant-table }
 
-|Variant Option|Value|Effect|
-|---|---|---|
-|`'J'`|a journaling level|Sets the journaling level.|
-|`'C'`|`0` or `1`|Sets the checksum level.|
-|`'Z'`|`0` or `1`|Sets compression.|
-|`'U'`|`0` or `1`|Sets Unicode support.|
-|`'S'`|`64`|Sets the file size (span).|
+|Variant Option|Valid Values|Default|Effect|
+|---|---|---|---|
+|`'J'`|a journaling level|as source|Sets the journaling level.|
+|`'C'`|`0` or `1`|as source|Sets the checksum level.|
+|`'Z'`|`0` or `1`|as source|Sets compression.|
+|`'U'`|`0` or `1`|as source|Sets Unicode support.|
+|`'S'`|`64`|`64`|Sets the file size (span).|
 
 The principal option is a number that sets journaling (`'J'`) and checksum (`'C'`) together:
 

--- a/language-reference-guide/docs/system-functions/fcreate.md
+++ b/language-reference-guide/docs/system-functions/fcreate.md
@@ -59,11 +59,11 @@ Table: Variant options overview { #variant-table }
 
 |Variant Option|Value|Effect|
 |---|---|---|
-|`'J'`|a journaling level|Sets the journaling level.|
-|`'C'`|`0` or `1`|Sets the checksum level.|
-|`'Z'`|`0` or `1`|Sets compression.|
-|`'U'`|`0` or `1`|Sets Unicode support.|
-|`'S'`|`64`|Sets the file size (span).|
+|`'J'`|`0`, `1` <small>(default)</small>, `2` or `3`|Sets the journaling level.|
+|`'C'`|`0` or `1` <small>(default)</small>|Sets the checksum level.|
+|`'Z'`|`0` <small>(default)</small> or `1`|Sets compression.|
+|`'U'`|`0` or `1` <small>(default)</small>|Sets Unicode support.|
+|`'S'`|`64` <small>(default)</small>|Sets the file size (span).|
 
 The principal option is a number that sets journaling (`'J'`) and checksum (`'C'`) together:
 

--- a/language-reference-guide/docs/system-functions/fcreate.md
+++ b/language-reference-guide/docs/system-functions/fcreate.md
@@ -53,9 +53,9 @@ to:
 
 ## Variant Options
 
-`⎕FCREATE` sets the properties of the newly created file through variant options, summarised in [](#variant-table). These are the file properties described in [File Properties](fprops.md).
+`⎕FCREATE` sets the properties of the newly created file through variant options, summarised in [](#variantoptionsforfcreate). These are the file properties described in [File Properties](fprops.md).
 
-Table: Variant options overview { #variant-table }
+Table: Variant options for `⎕FCREATE` { #variantoptionsforfcreate }
 
 |Variant Option|Valid Values|Default|Effect|
 |---|---|---|---|

--- a/language-reference-guide/docs/system-functions/fcreate.md
+++ b/language-reference-guide/docs/system-functions/fcreate.md
@@ -57,13 +57,13 @@ to:
 
 Table: Variant options overview { #variant-table }
 
-|Variant Option|Value|Effect|
-|---|---|---|
-|`'J'`|`0`, `1` <small>(default)</small>, `2` or `3`|Sets the journaling level.|
-|`'C'`|`0` or `1` <small>(default)</small>|Sets the checksum level.|
-|`'Z'`|`0` <small>(default)</small> or `1`|Sets compression.|
-|`'U'`|`0` or `1` <small>(default)</small>|Sets Unicode support.|
-|`'S'`|`64` <small>(default)</small>|Sets the file size (span).|
+|Variant Option|Valid Values|Default|Effect|
+|---|---|---|---|
+|`'J'`|`0`, `1`, `2` or `3`|`1`|Sets the journaling level.|
+|`'C'`|`0` or `1`|`1`|Sets the checksum level.|
+|`'Z'`|`0` or `1`|`0`|Sets compression.|
+|`'U'`|`0` or `1`|`1`|Sets Unicode support.|
+|`'S'`|`64`|`64`|Sets the file size (span).|
 
 The principal option is a number that sets journaling (`'J'`) and checksum (`'C'`) together:
 

--- a/language-reference-guide/docs/system-functions/fcreate.md
+++ b/language-reference-guide/docs/system-functions/fcreate.md
@@ -51,22 +51,28 @@ to:
 
 ```
 
-## File Properties
+## Variant Options
 
-`⎕FCREATE` allows you to specify properties for the newly created file via the variant operator `⍠` used with the following options:
+`⎕FCREATE` sets the properties of the newly created file through variant options, summarised in [](#variant-table). These are the file properties described in [File Properties](fprops.md).
 
-- `'J'` - journaling level; a numeric value
-- `'C'` - checksum level; 0 or 1
-- `'Z'` - compression; 0 or 1
-- `'U'` - Unicode; 0 or 1
-- `'S'` - File Size (span); 64
+Table: Variant options overview { #variant-table }
 
-The Principal Option is  as follows:
+|Variant Option|Value|Effect|
+|---|---|---|
+|`'J'`|a journaling level|Sets the journaling level.|
+|`'C'`|`0` or `1`|Sets the checksum level.|
+|`'Z'`|`0` or `1`|Sets compression.|
+|`'U'`|`0` or `1`|Sets Unicode support.|
+|`'S'`|`64`|Sets the file size (span).|
 
-- 0 - sets `('J' 0) ('C' 0)`
-- 1 - sets `('J' 1) ('C' 1)`
-- 2 - sets `('J' 2) ('C' 1)`
-- 3 - sets `('J' 3) ('C' 1)`
+The principal option is a number that sets journaling (`'J'`) and checksum (`'C'`) together:
+
+|Principal option|Effect|
+|---|---|
+|`0`|sets `('J' 0) ('C' 0)`|
+|`1`|sets `('J' 1) ('C' 1)`|
+|`2`|sets `('J' 2) ('C' 1)`|
+|`3`|sets `('J' 3) ('C' 1)`|
 
 See also: [File Properties ](fprops.md).
 

--- a/language-reference-guide/docs/system-functions/fix.md
+++ b/language-reference-guide/docs/system-functions/fix.md
@@ -109,37 +109,54 @@ DOMAIN ERROR: There were errors processing the script
 
 ## Variant Options
 
-`⎕FIX` may be applied using the  Variant operator with the options Quiet, FixWithErrors,  AllowLateBinding and InjectReferences. These options apply only to namespaces and classes specified by the script. There is no principal option.
+`⎕FIX` supports four variant options, `Quiet`, `FixWithErrors`, `AllowLateBinding` and `InjectReferences`, summarised in [](#variant-table) and described in detail beneath it. These options apply only to namespaces and classes specified by the script. There is no principal option.
 
-## Quiet Option
+Table: Variant options overview { #variant-table }
+
+|Variant Option|Value|Effect|
+|---|---|---|
+|[`Quiet`](#variant-option-quiet)|`0` <small>(default)</small> or `1`|Whether script errors are shown in the Status Window.|
+|[`FixWithErrors`](#variant-option-fixwitherrors)|`0` <small>(default)</small>, `1` or `2`|Whether namespaces and classes containing errors are fixed.|
+|[`AllowLateBinding`](#variant-option-allowlatebinding)|`0` <small>(default)</small> or `1`|Whether a Class with an undefined Base class is fixed.|
+|[`InjectReferences`](#variant-option-injectreferences)|`'All'`, `'InClasses'` or `'None'`|How internal references are inserted to implement lexical scope.|
+
+### Variant Option: Quiet
+
+Controls whether script errors are reported in the Status Window.
 
 |---|------------------------------------------------------------------------------|
-|0  |If the script contains errors, these are displayed in the Status Window.      |
+|`0` <small>(default)</small>|If the script contains errors, these are displayed in the Status Window.      |
 |`1`|If the script contains errors, the errors are not shown  in the Status Window.|
 
-## FixWithErrors Option
+### Variant Option: FixWithErrors
+
+Controls whether namespaces and classes that contain errors are fixed.
 
 |---|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|0  |If the script contains errors, `⎕FIX` fails with `DOMAIN ERROR` .                                                                                                      |
+|`0` <small>(default)</small>|If the script contains errors, `⎕FIX` fails with `DOMAIN ERROR`.                                                                                                      |
 |`1`|`⎕FIX` fixes all the namespaces and classes in the script regardless of any errors they may contain.                                                                   |
 |`2`|If the script contains errors, `⎕FIX` displays a message box prompting the user to choose whether or not to fix all the offending namespaces and classes in the script.|
 
-## AllowLateBinding Option
+### Variant Option: AllowLateBinding
+
+Controls whether a Class whose Base class is not yet defined can be fixed.
 
 |---|---------------------------------------------------------------------------------------------------------------------|
-|0  |`⎕FIX` will only fix a Class whose Base class (if specified) is defined in the script or is present in the workspace.|
+|`0` <small>(default)</small>|`⎕FIX` will only fix a Class whose Base class (if specified) is defined in the script or is present in the workspace.|
 |`1`|`⎕FIX` will fixes a Class whose Base class is neither defined in the script nor present in the workspace.            |
 
-## InjectReferences Option
+### Variant Option: InjectReferences
+
+Controls how internal references are inserted to implement lexical scope.
 
 |-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
 |`'All'`    |In order to implement lexical scope, `⎕FIX` will insert internal references into all objects in the script.                                          |
-|'InClasses'|In order to implement lexical scope, `⎕FIX` will insert internal references ONLY into Classes and sub-classes in the script, but not into namespaces.|
+|`'InClasses'`|In order to implement lexical scope, `⎕FIX` will insert internal references ONLY into Classes and sub-classes in the script, but not into namespaces.|
 |`'None'`   |No internal references are inserted and lexical scope does not apply.                                                                                |
 
 See [Lexical Scope in Scripts](../../../earlier-release-notes/release-notes-v19-0/introduction/lexical-scope-in-scripts).
 
-The following examples illustrate how different values of the InjectReferences option affect the scope of objects in scripts. The examples are based on the following family tree:
+The following examples illustrate how different values of the `InjectReferences` option affect the scope of objects in scripts. The examples are based on the following family tree:
 
 ![family tree for fix](../img/family-tree-for-fix.png)
 

--- a/language-reference-guide/docs/system-functions/fix.md
+++ b/language-reference-guide/docs/system-functions/fix.md
@@ -113,12 +113,12 @@ DOMAIN ERROR: There were errors processing the script
 
 Table: Variant options overview { #variant-table }
 
-|Variant Option|Value|Effect|
-|---|---|---|
-|[`Quiet`](#variant-option-quiet)|`0` <small>(default)</small> or `1`|Whether script errors are shown in the Status Window.|
-|[`FixWithErrors`](#variant-option-fixwitherrors)|`0` <small>(default)</small>, `1` or `2`|Whether namespaces and classes containing errors are fixed.|
-|[`AllowLateBinding`](#variant-option-allowlatebinding)|`0` <small>(default)</small> or `1`|Whether a Class with an undefined Base class is fixed.|
-|[`InjectReferences`](#variant-option-injectreferences)|`'All'`, `'InClasses'` <small>(default)</small> or `'None'`|How internal references are inserted to implement lexical scope.|
+|Variant Option|Valid Values|Default|Effect|
+|---|---|---|---|
+|[`Quiet`](#variant-option-quiet)|`0` or `1`|`0`|Whether script errors are shown in the Status Window.|
+|[`FixWithErrors`](#variant-option-fixwitherrors)|`0`, `1` or `2`|`1`|Whether namespaces and classes containing errors are fixed.|
+|[`AllowLateBinding`](#variant-option-allowlatebinding)|`0` or `1`|`1`|Whether a Class with an undefined Base class is fixed.|
+|[`InjectReferences`](#variant-option-injectreferences)|`'All'`, `'InClasses'` or `'None'`|`'InClasses'`|How internal references are inserted to implement lexical scope.|
 
 ### Variant Option: Quiet
 
@@ -133,8 +133,8 @@ Controls whether script errors are reported in the Status Window.
 Controls whether namespaces and classes that contain errors are fixed.
 
 |---|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|`0` <small>(default)</small>|If the script contains errors, `⎕FIX` fails with `DOMAIN ERROR`.                                                                                                      |
-|`1`|`⎕FIX` fixes all the namespaces and classes in the script regardless of any errors they may contain.                                                                   |
+|`0`|If the script contains errors, `⎕FIX` fails with `DOMAIN ERROR`.                                                                                                      |
+|`1` <small>(default)</small>|`⎕FIX` fixes all the namespaces and classes in the script regardless of any errors they may contain.                                                                   |
 |`2`|If the script contains errors, `⎕FIX` displays a message box prompting the user to choose whether or not to fix all the offending namespaces and classes in the script.|
 
 ### Variant Option: AllowLateBinding
@@ -142,8 +142,8 @@ Controls whether namespaces and classes that contain errors are fixed.
 Controls whether a Class whose Base class is not yet defined can be fixed.
 
 |---|---------------------------------------------------------------------------------------------------------------------|
-|`0` <small>(default)</small>|`⎕FIX` will only fix a Class whose Base class (if specified) is defined in the script or is present in the workspace.|
-|`1`|`⎕FIX` will fixes a Class whose Base class is neither defined in the script nor present in the workspace.            |
+|`0`|`⎕FIX` will only fix a Class whose Base class (if specified) is defined in the script or is present in the workspace.|
+|`1` <small>(default)</small>|`⎕FIX` will fix a Class whose Base class is neither defined in the script nor present in the workspace.            |
 
 ### Variant Option: InjectReferences
 

--- a/language-reference-guide/docs/system-functions/fix.md
+++ b/language-reference-guide/docs/system-functions/fix.md
@@ -118,7 +118,7 @@ Table: Variant options overview { #variant-table }
 |[`Quiet`](#variant-option-quiet)|`0` <small>(default)</small> or `1`|Whether script errors are shown in the Status Window.|
 |[`FixWithErrors`](#variant-option-fixwitherrors)|`0` <small>(default)</small>, `1` or `2`|Whether namespaces and classes containing errors are fixed.|
 |[`AllowLateBinding`](#variant-option-allowlatebinding)|`0` <small>(default)</small> or `1`|Whether a Class with an undefined Base class is fixed.|
-|[`InjectReferences`](#variant-option-injectreferences)|`'All'`, `'InClasses'` or `'None'`|How internal references are inserted to implement lexical scope.|
+|[`InjectReferences`](#variant-option-injectreferences)|`'All'`, `'InClasses'` <small>(default)</small> or `'None'`|How internal references are inserted to implement lexical scope.|
 
 ### Variant Option: Quiet
 
@@ -151,7 +151,7 @@ Controls how internal references are inserted to implement lexical scope.
 
 |-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
 |`'All'`    |In order to implement lexical scope, `⎕FIX` will insert internal references into all objects in the script.                                          |
-|`'InClasses'`|In order to implement lexical scope, `⎕FIX` will insert internal references ONLY into Classes and sub-classes in the script, but not into namespaces.|
+|`'InClasses'` <small>(default)</small>|In order to implement lexical scope, `⎕FIX` will insert internal references ONLY into Classes and sub-classes in the script, but not into namespaces.|
 |`'None'`   |No internal references are inserted and lexical scope does not apply.                                                                                |
 
 See [Lexical Scope in Scripts](../../../earlier-release-notes/release-notes-v19-0/introduction/lexical-scope-in-scripts).

--- a/language-reference-guide/docs/system-functions/fix.md
+++ b/language-reference-guide/docs/system-functions/fix.md
@@ -9,22 +9,22 @@ search:
 
 In this section, the term *namespace* covers scripted Namespaces, Classes and Interfaces.
 
-`Y` may be a simple character vector, or  a vector of character vectors or character scalars. The value of `X` determines what `Y` may contain.
+`Y` can be a simple character vector, or  a vector of character vectors or character scalars. The value of `X` determines what `Y` can contain.
 
 If `Y` is a simple character vector, it must start with `file://`, followed by the name of a file which must exist. The contents of the file must follow the same rules that apply to `Y` when `Y` is a vector of character vectors or scalars. The file name can be relative or absolute; when considering cross-platform portability, using "/" as the directory delimiter is recommended, although "\" is also valid under Windows.
 
-If specified, `X` must be a numeric scalar. It may currently take the value `0`, `1` or `2`. If not specified, the value is assumed to be `1`.
+If specified, `X` must be a numeric scalar. It can currently take the value `0`, `1` or `2`. If not specified, the value is assumed to be `1`.
 
-If `X` is `0`, `Y` must specify a single valid *namespace* which may or may not be named, or a file containing such a definition. If so, the [shy](../../../programming-reference-guide/introduction/results#shy-results) result `R` contains a reference to the *namespace*. Even if the *namespace* is named, it is not established *per se*, although it will exist for as long as at least one reference to it exists.
+If `X` is `0`, `Y` must specify a single valid *namespace* which might or might not be named, or a file containing such a definition. If so, the [shy](../../../programming-reference-guide/introduction/results#shy-results) result `R` contains a reference to the *namespace*. Even if the *namespace* is named, it is not established *per se*, although it will exist for as long as at least one reference to it exists.
 
-If `X` is `1`, `Y` must specify a single valid *namespace* which may or may not be named, or a file containing such a definition.  If so, the shy result `R` contains a reference to the *namespace*. If `Y` contains the definition of a named *namespace*, the *namespace* is established in the workspace.
+If `X` is `1`, `Y` must specify a single valid *namespace* which might or might not be named, or a file containing such a definition.  If so, the shy result `R` contains a reference to the *namespace*. If `Y` contains the definition of a named *namespace*, the *namespace* is established in the workspace.
 
 If `X` is `2`, `Y` is either a character vector containing the name of a script file, or a vector of character vectors that represents a script.
 
-`Y` may specify a series of **named** *namespaces* or function definitions,   or a combination of functions and namespaces.
+`Y` can specify a series of **named** *namespaces* or function definitions,   or a combination of functions and namespaces.
 
 - If the script contains more than one item,  tradfn definitions must be delimited by `∇`symbols.
-- Derived and assigned functions may be specified only within namespaces.
+- Derived and assigned functions can be specified only within namespaces.
 
 In this case,  the shy result `R` is a vector of character vectors, containing the names of all of the objects that have been established in the workspace; the order of the names in `R` is not defined. Currently `2 ⎕FIX` is not certain to be an atomic operation, although this might change in future versions.
 
@@ -109,9 +109,9 @@ DOMAIN ERROR: There were errors processing the script
 
 ## Variant Options
 
-`⎕FIX` supports four variant options, `Quiet`, `FixWithErrors`, `AllowLateBinding` and `InjectReferences`, summarised in [](#variant-table) and described in detail beneath it. These options apply only to namespaces and classes specified by the script. There is no principal option.
+`⎕FIX` supports four variant options, `Quiet`, `FixWithErrors`, `AllowLateBinding` and `InjectReferences`, summarised in [](#variantoptionsforfix) and described in detail beneath it. These options apply only to namespaces and classes specified by the script. There is no principal option.
 
-Table: Variant options overview { #variant-table }
+Table: Variant options for `⎕FIX` { #variantoptionsforfix }
 
 |Variant Option|Valid Values|Default|Effect|
 |---|---|---|---|
@@ -120,7 +120,7 @@ Table: Variant options overview { #variant-table }
 |[`AllowLateBinding`](#variant-option-allowlatebinding)|`0` or `1`|`1`|Whether a Class with an undefined Base class is fixed.|
 |[`InjectReferences`](#variant-option-injectreferences)|`'All'`, `'InClasses'` or `'None'`|`'InClasses'`|How internal references are inserted to implement lexical scope.|
 
-### Variant Option: Quiet
+### Variant Option: `Quiet`
 
 Controls whether script errors are reported in the Status Window.
 
@@ -128,16 +128,16 @@ Controls whether script errors are reported in the Status Window.
 |`0` <small>(default)</small>|If the script contains errors, these are displayed in the Status Window.      |
 |`1`|If the script contains errors, the errors are not shown  in the Status Window.|
 
-### Variant Option: FixWithErrors
+### Variant Option: `FixWithErrors`
 
 Controls whether namespaces and classes that contain errors are fixed.
 
 |---|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 |`0`|If the script contains errors, `⎕FIX` fails with `DOMAIN ERROR`.                                                                                                      |
-|`1` <small>(default)</small>|`⎕FIX` fixes all the namespaces and classes in the script regardless of any errors they may contain.                                                                   |
+|`1` <small>(default)</small>|`⎕FIX` fixes all the namespaces and classes in the script regardless of any errors they might contain.                                                                   |
 |`2`|If the script contains errors, `⎕FIX` displays a message box prompting the user to choose whether or not to fix all the offending namespaces and classes in the script.|
 
-### Variant Option: AllowLateBinding
+### Variant Option: `AllowLateBinding`
 
 Controls whether a Class whose Base class is not yet defined can be fixed.
 
@@ -145,7 +145,7 @@ Controls whether a Class whose Base class is not yet defined can be fixed.
 |`0`|`⎕FIX` will only fix a Class whose Base class (if specified) is defined in the script or is present in the workspace.|
 |`1` <small>(default)</small>|`⎕FIX` will fix a Class whose Base class is neither defined in the script nor present in the workspace.            |
 
-### Variant Option: InjectReferences
+### Variant Option: `InjectReferences`
 
 Controls how internal references are inserted to implement lexical scope.
 
@@ -206,8 +206,8 @@ Using the `Pete` Namespace, after executing the expression:
       2(⎕FIX⍠'InjectReferences' 'All')⎕SRC Pete
 ```
 
-- Code in `Pete` may refer to `Aisha`    , `Andy`     , `George`   , `Katherine`, and `Woody`
-- Code in `Andy` may refer to `Aisha`    and `Katherine`
+- Code in `Pete` can refer to `Aisha`    , `Andy`     , `George`   , `Katherine`, and `Woody`
+- Code in `Andy` can refer to `Aisha`    and `Katherine`
 - ... and so forth.
 
 But after executing:
@@ -215,8 +215,8 @@ But after executing:
       2(⎕FIX⍠'InjectReferences' 'InClasses')⎕SRC Pete
 ```
 
-- Code in `Pete` may refer only to `Andy` and  `Katherine`
-- Code in `Andy` may refer only to `Aisha`
+- Code in `Pete` can refer only to `Andy` and  `Katherine`
+- Code in `Andy` can refer only to `Aisha`
 - ... and so forth.
 
 The following tables show which objects in Namespace `Pete` can *see* (that is, refer to) which other objects representing members of the family, in each case; `All`, `InClasses` and `None`.

--- a/language-reference-guide/docs/system-functions/fstie.md
+++ b/language-reference-guide/docs/system-functions/fstie.md
@@ -35,6 +35,9 @@ to:
       '../budget/COSTS' ⎕FSTIE 2
 ```
 
+!!! Info "Information"
+    Small-span (32-bit) component files are currently read-only; this support is scheduled for removal in a future release, after which it will not be possible to tie small-span component files. Dyalog Ltd recommends using `⎕FCOPY` to convert any such files to large-span (64-bit). For information on how to identify calls to small-span component files in your existing codebase, see the [Release Notes](../../../release-notes/announcements/deprecated-functionality/).
+
 ## Variant Options
 
 `⎕FSTIE` supports a single variant option, `Mode`, specified using the _variant_ operator [`⍠`](../primitive-operators/variant.md).
@@ -60,8 +63,6 @@ FILE ACCESS ERROR: cf.dcf: File is not writable
                 ∧
 ```
 
-!!! Info "Information"
-    Small-span (32-bit) component files are currently read-only; this support is scheduled for removal in a future release, after which it will not be possible to tie small-span component files. Dyalog Ltd recommends using `⎕FCOPY` to convert any such files to large-span (64-bit). For information on how to identify calls to small-span component files in your existing codebase, see the [Release Notes](../../../release-notes/announcements/deprecated-functionality/).
 
 <!-- Hidden search keywords -->
 <div style="display: none;">

--- a/language-reference-guide/docs/system-functions/fstie.md
+++ b/language-reference-guide/docs/system-functions/fstie.md
@@ -7,7 +7,7 @@ search:
 
 `Y` must be 0 or a simple 1 or 2 element integer vector containing an available file tie number to be associated with the file for further file operations, and an optional passnumber.  If the passnumber is omitted it is assumed to be zero.  The tie number must not already be associated with a tied file.
 
-`X` must be a simple character scalar or vector which specifies the name of the file to be tied.  The file must be named in accordance with the operating system's conventions, and may be specified with a relative or absolute pathname. If no file extension is supplied, the set of extensions specified by the  **CFEXT** parameter are tried one after another until the file is found or the set of extensions is exhausted. See [ CFEXT](../../../windows-installation-and-configuration-guide/configuration-parameters/configuration-parameters).
+`X` must be a simple character scalar or vector which specifies the name of the file to be tied.  The file must be named in accordance with the operating system's conventions, and can be specified with a relative or absolute pathname. If no file extension is supplied, the set of extensions specified by the  **CFEXT** parameter are tried one after another until the file is found or the set of extensions is exhausted. See [ CFEXT](../../../windows-installation-and-configuration-guide/configuration-parameters/configuration-parameters).
 
 The file must exist and be accessible by the user.  If it is already tied by another task, it must not be tied exclusively.
 
@@ -42,7 +42,7 @@ to:
 
 `⎕FSTIE` supports a single variant option, `Mode`, specified using the _variant_ operator [`⍠`](../primitive-operators/variant.md).
 
-### Variant Option: Mode
+### Variant Option: `Mode`
 
 Writing to a component file is not always permitted. For example, restrictions on writing to a component file might be imposed by operating system permissions, the host filesystem, or individual component file property settings.
 

--- a/language-reference-guide/docs/system-functions/fstie.md
+++ b/language-reference-guide/docs/system-functions/fstie.md
@@ -35,20 +35,23 @@ to:
       '../budget/COSTS' ⎕FSTIE 2
 ```
 
-# Variant Options
-## Mode
+## Variant Options
+
+`⎕FSTIE` supports a single variant option, `Mode`, specified using the _variant_ operator [`⍠`](../primitive-operators/variant.md).
+
+### Variant Option: Mode
 
 Writing to a component file is not always permitted. For example, restrictions on writing to a component file might be imposed by operating system permissions, the host filesystem, or individual component file property settings.
 
-The **Mode** variant option specifies whether the file that is being tied will only be read or must be writeable. Possible values are:
+The `Mode` variant option specifies whether the file that is being tied will only be read or must be writeable. Possible values are:
 
 - `P` (tied as **p**ermitted) – the file will be tied for write access if possible, otherwise for read access only. If the file permissions do not allow the file to be written to, any subsequent attempt to write to it will fail. This is the default.
 - `R` (**r**ead mode) – the file will be tied for read access only; any subsequent attempt to write to it will fail.
 - `W` (**w**rite mode) – if the file permissions do not allow the file to be written to, the attempt to tie it will fail.
 
-The **Mode** variant option is independent of any [file access controls managed using an access matrix](../../../programming-reference-guide/component-files/component-files/#file-access-control).
+The `Mode` variant option is independent of any [file access controls managed using an access matrix](../../../programming-reference-guide/component-files/component-files/#file-access-control).
 
-<h3 class="example">Example</h3>
+<h4 class="example">Example</h4>
 
 ```apl
       'cf' (⎕FSTIE⍠'Mode' 'W') 1

--- a/language-reference-guide/docs/system-functions/fstie.md
+++ b/language-reference-guide/docs/system-functions/fstie.md
@@ -13,6 +13,9 @@ The file must exist and be accessible by the user.  If it is already tied by an
 
 The [shy](../../../programming-reference-guide/introduction/results#shy-results) result of `⎕FSTIE` is the tie number of the file.
 
+!!! Info "Information"
+    Small-span (32-bit) component files are currently read-only; this support is scheduled for removal in a future release, after which it will not be possible to tie small-span component files. Dyalog Ltd recommends using `⎕FCOPY` to convert any such files to large-span (64-bit). For information on how to identify calls to small-span component files in your existing codebase, see the [Release Notes](../../../release-notes/announcements/deprecated-functionality/).
+
 ## Automatic Tie Number Allocation
 
 A tie number of 0 as argument to a create, share tie or exclusive tie operation, allocates the first (closest to zero) available tie number and returns it as an explicit result. This allows you to simplify code. For example:
@@ -34,9 +37,6 @@ to:
  
       '../budget/COSTS' ⎕FSTIE 2
 ```
-
-!!! Info "Information"
-    Small-span (32-bit) component files are currently read-only; this support is scheduled for removal in a future release, after which it will not be possible to tie small-span component files. Dyalog Ltd recommends using `⎕FCOPY` to convert any such files to large-span (64-bit). For information on how to identify calls to small-span component files in your existing codebase, see the [Release Notes](../../../release-notes/announcements/deprecated-functionality/).
 
 ## Variant Options
 
@@ -62,7 +62,6 @@ FILE ACCESS ERROR: cf.dcf: File is not writable
       'cf'(⎕FSTIE⍠'Mode' 'W')1
                 ∧
 ```
-
 
 <!-- Hidden search keywords -->
 <div style="display: none;">

--- a/language-reference-guide/docs/system-functions/ftie.md
+++ b/language-reference-guide/docs/system-functions/ftie.md
@@ -40,20 +40,23 @@ The [shy](../../../programming-reference-guide/introduction/results#shy-results)
 3
 ```
 
-# Variant Options
-## Mode
+## Variant Options
+
+`⎕FTIE` supports a single variant option, `Mode`, specified using the _variant_ operator [`⍠`](../primitive-operators/variant.md).
+
+### Variant Option: Mode
 
 Writing to a component file is not always permitted. For example, restrictions on writing to a component file might be imposed by operating system permissions, the host filesystem, or individual component file property settings.
 
-The **Mode** variant option specifies whether the file that is being tied will only be read or must be writeable. Possible values are:
+The `Mode` variant option specifies whether the file that is being tied will only be read or must be writeable. Possible values are:
 
 - `P` (tied as **p**ermitted) – the file will be tied for write access if possible, otherwise for read access only. If the file permissions do not allow the file to be written to, any subsequent attempt to write to it will fail. This is the default.
 - `R` (**r**ead mode) – the file will be tied for read access only; any subsequent attempt to write to it will fail.
 - `W` (**w**rite mode) – if the file permissions do not allow the file to be written to, the attempt to tie it will fail.
 
-The **Mode** variant option is independent of any [file access controls managed using an access matrix](../../../programming-reference-guide/component-files/component-files/#file-access-control).
+The `Mode` variant option is independent of any [file access controls managed using an access matrix](../../../programming-reference-guide/component-files/component-files/#file-access-control).
 
-<h3 class="example">Example</h3>
+<h4 class="example">Example</h4>
 
 ```apl
       'cf' (⎕FTIE⍠'Mode' 'W') 1

--- a/language-reference-guide/docs/system-functions/ftie.md
+++ b/language-reference-guide/docs/system-functions/ftie.md
@@ -40,6 +40,9 @@ The [shy](../../../programming-reference-guide/introduction/results#shy-results)
 3
 ```
 
+!!! Info "Information"
+    Small-span (32-bit) component files are currently read-only; this support is scheduled for removal in a future release, after which it will not be possible to tie small-span component files. Dyalog Ltd recommends using `⎕FCOPY` to convert any such files to large-span (64-bit). For information on how to identify calls to small-span component files in your existing codebase, see the [Release Notes](../../../release-notes/announcements/deprecated-functionality/).
+
 ## Variant Options
 
 `⎕FTIE` supports a single variant option, `Mode`, specified using the _variant_ operator [`⍠`](../primitive-operators/variant.md).
@@ -65,8 +68,6 @@ FILE ACCESS ERROR: cf.dcf: File is not writable
                 ∧
 ```
 
-!!! Info "Information"
-    Small-span (32-bit) component files are currently read-only; this support is scheduled for removal in a future release, after which it will not be possible to tie small-span component files. Dyalog Ltd recommends using `⎕FCOPY` to convert any such files to large-span (64-bit). For information on how to identify calls to small-span component files in your existing codebase, see the [Release Notes](../../../release-notes/announcements/deprecated-functionality/).
 
 <!-- Hidden search keywords -->
 <div style="display: none;">

--- a/language-reference-guide/docs/system-functions/ftie.md
+++ b/language-reference-guide/docs/system-functions/ftie.md
@@ -13,6 +13,9 @@ search:
 
 The file must exist and  the user must have write access to it.  It may not already be tied by another user.
 
+!!! Info "Information"
+    Small-span (32-bit) component files are currently read-only; this support is scheduled for removal in a future release, after which it will not be possible to tie small-span component files. Dyalog Ltd recommends using `⎕FCOPY` to convert any such files to large-span (64-bit). For information on how to identify calls to small-span component files in your existing codebase, see the [Release Notes](../../../release-notes/announcements/deprecated-functionality/).
+
 ## Automatic Tie Number Allocation
 
 A tie number of 0 as argument to a create, share tie or exclusive tie operation, allocates the first (closest to zero) available tie number, and returns it as an explicit result. This allows you to simplify code. For example:
@@ -40,9 +43,6 @@ The [shy](../../../programming-reference-guide/introduction/results#shy-results)
 3
 ```
 
-!!! Info "Information"
-    Small-span (32-bit) component files are currently read-only; this support is scheduled for removal in a future release, after which it will not be possible to tie small-span component files. Dyalog Ltd recommends using `⎕FCOPY` to convert any such files to large-span (64-bit). For information on how to identify calls to small-span component files in your existing codebase, see the [Release Notes](../../../release-notes/announcements/deprecated-functionality/).
-
 ## Variant Options
 
 `⎕FTIE` supports a single variant option, `Mode`, specified using the _variant_ operator [`⍠`](../primitive-operators/variant.md).
@@ -67,7 +67,6 @@ FILE ACCESS ERROR: cf.dcf: File is not writable
       'cf'(⎕FTIE⍠'Mode' 'W')1
                 ∧
 ```
-
 
 <!-- Hidden search keywords -->
 <div style="display: none;">

--- a/language-reference-guide/docs/system-functions/ftie.md
+++ b/language-reference-guide/docs/system-functions/ftie.md
@@ -5,13 +5,13 @@ search:
 
 # <span>Exclusive File Tie</span> `{R}←X ⎕FTIE Y`{{key}}
 
-## Access code 2
+## Access Code 2
 
 `Y` must be 0 or a simple 1 or 2 element integer vector containing an available file tie number to be associated with the file for further file operations, and an optional passnumber.  If the passnumber is omitted it is assumed to be zero.  The tie number must not already be associated with a share tied or exclusively tied file.
 
-`X` must be a simple character scalar or vector which specifies the name of the file to be exclusively tied.  The file must be named in accordance with the operating system's conventions, and may be a relative or absolute pathname. If no file extension is supplied, the set of extensions specified by the  **CFEXT** parameter are tried one after another until the file is found or the set of extensions is exhausted. See [ CFEXT](../../../windows-installation-and-configuration-guide/configuration-parameters/configuration-parameters).
+`X` must be a simple character scalar or vector which specifies the name of the file to be exclusively tied.  The file must be named in accordance with the operating system's conventions, and can be a relative or absolute pathname. If no file extension is supplied, the set of extensions specified by the  **CFEXT** parameter are tried one after another until the file is found or the set of extensions is exhausted. See [ CFEXT](../../../windows-installation-and-configuration-guide/configuration-parameters/configuration-parameters).
 
-The file must exist and  the user must have write access to it.  It may not already be tied by another user.
+The file must exist and  the user must have write access to it.  It cannot already be tied by another user.
 
 !!! Info "Information"
     Small-span (32-bit) component files are currently read-only; this support is scheduled for removal in a future release, after which it will not be possible to tie small-span component files. Dyalog Ltd recommends using `⎕FCOPY` to convert any such files to large-span (64-bit). For information on how to identify calls to small-span component files in your existing codebase, see the [Release Notes](../../../release-notes/announcements/deprecated-functionality/).
@@ -47,7 +47,7 @@ The [shy](../../../programming-reference-guide/introduction/results#shy-results)
 
 `⎕FTIE` supports a single variant option, `Mode`, specified using the _variant_ operator [`⍠`](../primitive-operators/variant.md).
 
-### Variant Option: Mode
+### Variant Option: `Mode`
 
 Writing to a component file is not always permitted. For example, restrictions on writing to a component file might be imposed by operating system permissions, the host filesystem, or individual component file property settings.
 

--- a/language-reference-guide/docs/system-functions/json.md
+++ b/language-reference-guide/docs/system-functions/json.md
@@ -146,20 +146,20 @@ The above name translations are verified using `7162⌶`:
 
 Table: Variant options overview { #variant-table }
 
-| Variant Option                                                     | Value                                 | Effect on Import                                    | Effect on Export |
-|--------------------------------------------------------------------|:-------------------------------------:|-----------------------------------------------------|------------------|
-| [`Format`](#variant-option-format)<br><small>principal</small> | `'D'`<br><small>default</small>       | `R` is APL data corresponding to `Y`                | `Y` is APL data |
-|_-                                                                -_| `'M'`                                 | `R` is an APL matrix encoding of `Y`                | `Y` is a 4-column APL matrix as from import with `'M'` |
-| [`Dialect`](#variant-option-dialect)                           | `'JSON'`<br><small>default</small>    | Only strict JSON syntax is accepted                 | Only strict JSON syntax is produced |
-|_-                                                                -_| `'JSON5'`                             | [JSON5](https://json5.org/) extensions are accepted | JSON5 features are used to improve readability and editability, and/or shorten output |
-| [`Null`](#variant-option-null)                                 | `⊂'null'`<br><small>default</small>   | JSON <code class="language-nonAPL">null</code> becomes APL `⊂'null'`                   | APL `⊂'null'` becomes JSON <code class="language-nonAPL">null</code> |
-|_-                                                                -_| `⎕NULL`                               | JSON <code class="language-nonAPL">null</code> becomes APL `⎕NULL`                     | APL `⎕NULL` becomes JSON <code class="language-nonAPL">null</code> |
-| [`Compact`](#variant-option-compact)                           | `1`<br><small>default</small>         | None                                                | `R` has no whitespace outside quotes |
-|_-                                                                -_| `0`                                   | None                                                | `R` has whitespace for readability and, if `Dialect` is `'JSON5'`, trailing commas after final elements and members |
-| [`Charset`](#variant-option-charset)                           | `'Unicode'`<br><small>default</small> | None                                                | Unicode characters in `Y` are used when JSON standard allows |
-|_-                                                                -_| `'ASCII'`                             | None                                                | Non-ASCII characters are converted to the hexadecimal form `\uNNNN`, and if `Dialect` is `'JSON5'`, also `\xNN` |
-| [`HighRank`](#variant-option-highrank)                         | `'Error'`<br><small>default</small>   | None                                                | High-rank arrays are rejected |
-|_-                                                                -_| `'Split'`                             | None                                                | High-rank arrays are split and [inverted table wrappers](#dataset-wrappers) accept text columns as matrices |
+| Variant Option | Valid Values | Default | Effect on Import | Effect on Export |
+|---|:---:|:---:|---|---|
+| [`Format`](#variant-option-format)<br><small>principal</small> | `'D'` | `'D'` | `R` is APL data corresponding to `Y`                | `Y` is APL data |
+|_-                                                                -_| `'M'`                                 |  | `R` is an APL matrix encoding of `Y`                | `Y` is a 4-column APL matrix as from import with `'M'` |
+| [`Dialect`](#variant-option-dialect)                           | `'JSON'` | `'JSON'` | Only strict JSON syntax is accepted                 | Only strict JSON syntax is produced |
+|_-                                                                -_| `'JSON5'`                             |  | [JSON5](https://json5.org/) extensions are accepted | JSON5 features are used to improve readability and editability, and/or shorten output |
+| [`Null`](#variant-option-null)                                 | `⊂'null'` | `⊂'null'` | JSON <code class="language-nonAPL">null</code> becomes APL `⊂'null'`                   | APL `⊂'null'` becomes JSON <code class="language-nonAPL">null</code> |
+|_-                                                                -_| `⎕NULL`                               |  | JSON <code class="language-nonAPL">null</code> becomes APL `⎕NULL`                     | APL `⎕NULL` becomes JSON <code class="language-nonAPL">null</code> |
+| [`Compact`](#variant-option-compact)                           | `1` | `1` | None                                                | `R` has no whitespace outside quotes |
+|_-                                                                -_| `0`                                   |  | None                                                | `R` has whitespace for readability and, if `Dialect` is `'JSON5'`, trailing commas after final elements and members |
+| [`Charset`](#variant-option-charset)                           | `'Unicode'` | `'Unicode'` | None                                                | Unicode characters in `Y` are used when JSON standard allows |
+|_-                                                                -_| `'ASCII'`                             |  | None                                                | Non-ASCII characters are converted to the hexadecimal form `\uNNNN`, and if `Dialect` is `'JSON5'`, also `\xNN` |
+| [`HighRank`](#variant-option-highrank)                         | `'Error'` | `'Error'` | None                                                | High-rank arrays are rejected |
+|_-                                                                -_| `'Split'`                             |  | None                                                | High-rank arrays are split and [inverted table wrappers](#dataset-wrappers) accept text columns as matrices |
 
 ### Variant Option: Format
 

--- a/language-reference-guide/docs/system-functions/json.md
+++ b/language-reference-guide/docs/system-functions/json.md
@@ -32,7 +32,7 @@ If `X` is not specified (that is, `⎕JSON` is called monadically), its assumed 
 !!! Warning "Warning"
     Dyalog Ltd strongly recommends that `X` should always be specified to avoid code that seemingly works, only to fail on specific values.
 
-`⎕JSON` has six [variant options](#variant-options): **Format**, **Compact**, **Null**, **HighRank**, **Charset**, and **Dialect**, specified using [`⍠`](../primitive-operators/variant.md). The principal option is **Format**.
+`⎕JSON` has six [variant options](#variant-options): `Format`, `Compact`, `Null`, `HighRank`, `Charset`, and `Dialect`, specified using [`⍠`](../primitive-operators/variant.md). The principal option is `Format`.
 
 ## Limitations
 
@@ -52,9 +52,9 @@ If `X` is `0`, the JSON document `Y` is converted to the corresponding APL data 
 
 `Y` is a character scalar, vector, or matrix in JSON format. There is an implied newline character between each row of a matrix.
 
-By default, `R` is APL data, possibly containing sub-arrays and/or sub-namespaces. If the variant option [**Format**](#variant-option-format) is set to `'M'`, `R` is instead a matrix that represents the JSON structure.
+By default, `R` is APL data, possibly containing sub-arrays and/or sub-namespaces. If the variant option [`Format`](#variant-option-format) is set to `'M'`, `R` is instead a matrix that represents the JSON structure.
 
-The [JSON standard](https://www.rfc-editor.org/info/rfc8259/#section-4) states that members of a JSON object should have unique names and that implementations vary in how they treat duplicates. Dyalog does not error on duplicates, but their handling depends on the **Format** variant option.
+The [JSON standard](https://www.rfc-editor.org/info/rfc8259/#section-4) states that members of a JSON object should have unique names and that implementations vary in how they treat duplicates. Dyalog does not error on duplicates, but their handling depends on the `Format` variant option.
 
 <h3 class="example">Example</h3>
 
@@ -69,9 +69,9 @@ For details and more examples, see [Import to Data](#import-to-data) and [Import
 
 If `X` is `1`, the APL data `Y` is converted to a corresponding JSON document `R`.
 
-`Y` is the data to be exported. By default, `Y` must be APL data that can be represented as JSON (subject to the [**HighRank**](#variant-option-highrank) variant option). If the [**Format**](#variant-option-format) variant option is set to `'M'`, `Y` must instead be a matrix representation such as would have been produced by importing JSON with **Format** being `'M'`. `⎕JSON` will signal `DOMAIN ERROR` if `Y` is incompatible with the specified (or implied) value of **Format**.
+`Y` is the data to be exported. By default, `Y` must be APL data that can be represented as JSON (subject to the [`HighRank`](#variant-option-highrank) variant option). If the [`Format`](#variant-option-format) variant option is set to `'M'`, `Y` must instead be a matrix representation such as would have been produced by importing JSON with `Format` being `'M'`. `⎕JSON` will signal `DOMAIN ERROR` if `Y` is incompatible with the specified (or implied) value of `Format`.
 
-`R` is a character vector whose content depends upon the values of the [**Compact**](#variant-option-compact), [**Dialect**](#variant-option-dialect), and [**Charset**](#variant-option-charset) variant options.
+`R` is a character vector whose content depends upon the values of the [`Compact`](#variant-option-compact), [`Dialect`](#variant-option-dialect), and [`Charset`](#variant-option-charset) variant options.
 
 `⎕JSON` output is not affected by [`⎕PP`](pp); numbers are always represented with full precision.
 
@@ -148,31 +148,31 @@ Table: Variant options overview { #variant-table }
 
 | Variant Option                                                     | Value                                 | Effect on Import                                    | Effect on Export |
 |--------------------------------------------------------------------|:-------------------------------------:|-----------------------------------------------------|------------------|
-| [**Format**](#variant-option-format)<br><small>principal</small> | `'D'`<br><small>default</small>       | `R` is APL data corresponding to `Y`                | `Y` is APL data |
+| [`Format`](#variant-option-format)<br><small>principal</small> | `'D'`<br><small>default</small>       | `R` is APL data corresponding to `Y`                | `Y` is APL data |
 |_-                                                                -_| `'M'`                                 | `R` is an APL matrix encoding of `Y`                | `Y` is a 4-column APL matrix as from import with `'M'` |
-| [**Dialect**](#variant-option-dialect)                           | `'JSON'`<br><small>default</small>    | Only strict JSON syntax is accepted                 | Only strict JSON syntax is produced |
+| [`Dialect`](#variant-option-dialect)                           | `'JSON'`<br><small>default</small>    | Only strict JSON syntax is accepted                 | Only strict JSON syntax is produced |
 |_-                                                                -_| `'JSON5'`                             | [JSON5](https://json5.org/) extensions are accepted | JSON5 features are used to improve readability and editability, and/or shorten output |
-| [**Null**](#variant-option-null)                                 | `⊂'null'`<br><small>default</small>   | JSON <code class="language-nonAPL">null</code> becomes APL `⊂'null'`                   | APL `⊂'null'` becomes JSON <code class="language-nonAPL">null</code> |
+| [`Null`](#variant-option-null)                                 | `⊂'null'`<br><small>default</small>   | JSON <code class="language-nonAPL">null</code> becomes APL `⊂'null'`                   | APL `⊂'null'` becomes JSON <code class="language-nonAPL">null</code> |
 |_-                                                                -_| `⎕NULL`                               | JSON <code class="language-nonAPL">null</code> becomes APL `⎕NULL`                     | APL `⎕NULL` becomes JSON <code class="language-nonAPL">null</code> |
-| [**Compact**](#variant-option-compact)                           | `1`<br><small>default</small>         | None                                                | `R` has no whitespace outside quotes |
-|_-                                                                -_| `0`                                   | None                                                | `R` has whitespace for readability and, if **Dialect** is `'JSON5'`, trailing commas after final elements and members |
-| [**Charset**](#variant-option-charset)                           | `'Unicode'`<br><small>default</small> | None                                                | Unicode characters in `Y` are used when JSON standard allows |
-|_-                                                                -_| `'ASCII'`                             | None                                                | Non-ASCII characters are converted to the hexadecimal form `\uNNNN`, and if **Dialect** is `'JSON5'`, also `\xNN` |
-| [**HighRank**](#variant-option-highrank)                         | `'Error'`<br><small>default</small>   | None                                                | High-rank arrays are rejected |
+| [`Compact`](#variant-option-compact)                           | `1`<br><small>default</small>         | None                                                | `R` has no whitespace outside quotes |
+|_-                                                                -_| `0`                                   | None                                                | `R` has whitespace for readability and, if `Dialect` is `'JSON5'`, trailing commas after final elements and members |
+| [`Charset`](#variant-option-charset)                           | `'Unicode'`<br><small>default</small> | None                                                | Unicode characters in `Y` are used when JSON standard allows |
+|_-                                                                -_| `'ASCII'`                             | None                                                | Non-ASCII characters are converted to the hexadecimal form `\uNNNN`, and if `Dialect` is `'JSON5'`, also `\xNN` |
+| [`HighRank`](#variant-option-highrank)                         | `'Error'`<br><small>default</small>   | None                                                | High-rank arrays are rejected |
 |_-                                                                -_| `'Split'`                             | None                                                | High-rank arrays are split and [inverted table wrappers](#dataset-wrappers) accept text columns as matrices |
 
 ### Variant Option: Format
 
-The **Format** variant option, the principal option, determines whether `⎕JSON` works with a direct APL representation of the data (`'D'` for "Data", the default) or with a four-column matrix that encodes the JSON structure (`'M'` for "Matrix") as nodes with depth, name, value, and type.
+The `Format` variant option, the principal option, determines whether `⎕JSON` works with a direct APL representation of the data (`'D'` for "Data", the default) or with a four-column matrix that encodes the JSON structure (`'M'` for "Matrix") as nodes with depth, name, value, and type.
 
 #### Import to Data
 
-If **Format** is `'D'` (which stands for "Data", the default), the JSON document in `Y` is converted to the corresponding APL data `R`, possibly containing sub-arrays and/or sub-namespaces:
+If `Format` is `'D'` (which stands for "Data", the default), the JSON document in `Y` is converted to the corresponding APL data `R`, possibly containing sub-arrays and/or sub-namespaces:
 
 - JSON arrays are converted into APL vectors.
 - JSON objects are converted into APL namespaces.
-- JSON <code class="language-nonAPL">null</code> is converted into the specified (or implied) value of [**Null**](#variant-option-null) (`⊂'null'`, the default, or `⎕NULL`).
-- JSON <code class="language-nonAPL">true</code> and <code class="language-nonAPL">false</code> and, if the [**Dialect**](#variant-option-dialect) variant option is `'JSON5'`, the JSON5 numeric constants <code class="language-nonAPL">Infinity</code>, <code class="language-nonAPL">-Infinity</code>, and <code class="language-nonAPL">NaN</code>, are converted to enclosed character vectors `⊂'true'`, `⊂'false'`, and so on.
+- JSON <code class="language-nonAPL">null</code> is converted into the specified (or implied) value of [`Null`](#variant-option-null) (`⊂'null'`, the default, or `⎕NULL`).
+- JSON <code class="language-nonAPL">true</code> and <code class="language-nonAPL">false</code> and, if the [`Dialect`](#variant-option-dialect) variant option is `'JSON5'`, the JSON5 numeric constants <code class="language-nonAPL">Infinity</code>, <code class="language-nonAPL">-Infinity</code>, and <code class="language-nonAPL">NaN</code>, are converted to enclosed character vectors `⊂'true'`, `⊂'false'`, and so on.
 - If the JSON source contains object member names that are not valid APL names, they are converted to APL namespace members with [mangled names](#name-mangling). The original names can be obtained using [`7162⌶`](../primitive-operators/i-beam/json-translate-name.md).
 - If duplicate names are found, the last member encountered is used and all previous members with the same name are discarded.
 
@@ -249,7 +249,7 @@ The two ways to represent JSON <code class="language-nonAPL">null</code>s:
 
 #### Import to Matrix
 
-If **Format** is `'M'` (which stands for "Matrix"), the JSON document `Y` is converted to a corresponding APL matrix `R` whose columns are as follows:
+If `Format` is `'M'` (which stands for "Matrix"), the JSON document `Y` is converted to a corresponding APL matrix `R` whose columns are as follows:
 
 Table: Import matrix columns { #import-matrix-table }
 
@@ -270,14 +270,14 @@ Table: JSON types { #import-types-table }
 | `2`     | Empty (contents are in following rows) | Array                    |
 | `3`     | Number                                 | Number                   |
 | `4`     | Character vector                       | String                   |
-| `5`     | Specified by **Null** variant            | Null                     |
+| `5`     | Specified by `Null` variant            | Null                     |
 | `6`     | Enclosed character vector              | Lacking APL equivalent   |
 
 Note that:
 
-- JSON <code class="language-nonAPL">null</code> is converted into the specified (or implied) value of [**Null**](#variant-option-null); `⊂'null'` (the default) or `⎕NULL`.
-- JSON values that lack an APL equivalent, <code class="language-nonAPL">true</code> and <code class="language-nonAPL">false</code>, and, if **Dialect** is `'JSON5'`, the JSON5 numeric constants <code class="language-nonAPL">Infinity</code>, <code class="language-nonAPL">-Infinity</code>, and <code class="language-nonAPL">NaN</code>, are converted to enclosed character vectors `⊂'true'`, `⊂'false'`, and so on.
-- Object member names are reported as specified in the JSON text; they are not mangled as when **Format** is `'D'`.
+- JSON <code class="language-nonAPL">null</code> is converted into the specified (or implied) value of [`Null`](#variant-option-null); `⊂'null'` (the default) or `⎕NULL`.
+- JSON values that lack an APL equivalent, <code class="language-nonAPL">true</code> and <code class="language-nonAPL">false</code>, and, if `Dialect` is `'JSON5'`, the JSON5 numeric constants <code class="language-nonAPL">Infinity</code>, <code class="language-nonAPL">-Infinity</code>, and <code class="language-nonAPL">NaN</code>, are converted to enclosed character vectors `⊂'true'`, `⊂'false'`, and so on.
+- Object member names are reported as specified in the JSON text; they are not mangled as when `Format` is `'D'`.
 - If duplicate names are found, all duplicate members are recorded in the result matrix.
 
 <h5 class="example">Example</h5>
@@ -341,10 +341,10 @@ This example uses the character vector `json` from the previous example:
 
 #### Export from Data
 
-If **Format** is `'D'` (which stands for "Data"), the APL value `Y` is converted to a corresponding JSON document `R` as follows:
+If `Format` is `'D'` (which stands for "Data"), the APL value `Y` is converted to a corresponding JSON document `R` as follows:
 
 - APL vectors are converted to JSON arrays.
-- APL arrays of higher rank are recursively split if [**HighRank**](#variant-option-highrank) is `'Split'`, otherwise `⎕JSON` will signal `DOMAIN ERROR`.
+- APL arrays of higher rank are recursively split if [`HighRank`](#variant-option-highrank) is `'Split'`, otherwise `⎕JSON` will signal `DOMAIN ERROR`.
 - APL namespaces are converted to JSON objects.
 - Enclosed vectors whose leading element is a wrapper code are interpreted as [wrappers](#wrappers) (mechanisms for special handling).
 - If a namespace member name appears to be mangled (has a form that would have been produced by [name mangling](#name-mangling)), it is demangled.
@@ -376,7 +376,7 @@ If **Format** is `'D'` (which stands for "Data"), the APL value `Y` is converted
 
 #### Export from Matrix
 
-If **Format** is `'M'` (which stands for "Matrix"), the APL array `Y` is converted to a corresponding JSON document `R` and `Y` must be a matrix whose columns are as follows:
+If `Format` is `'M'` (which stands for "Matrix"), the APL array `Y` is converted to a corresponding JSON document `R` and `Y` must be a matrix whose columns are as follows:
 
 Table: Export matrix columns { #export-matrix-table }
 
@@ -441,11 +441,11 @@ DOMAIN ERROR: JSON export: value does not match the specified type in row 3 (⎕
 
 ### Variant Option: Dialect
 
-If the **Dialect** variant option (default: `'JSON'`) is `'JSON5'`, [JSON5](https://json5.org/) extensions are enabled on import and export.
+If the `Dialect` variant option (default: `'JSON'`) is `'JSON5'`, [JSON5](https://json5.org/) extensions are enabled on import and export.
 
 On import, all JSON5 extensions are accepted.
 
-On export, the result is shortened by usage of identifiers without quotes, single quotes (`'`), and character escapes `\v` and of the form `\xNN` (for values less than hexadecimal 100, that is, `⎕UCS 256`). If [**Compact**](#variant-option-compact) is `0`, a trailing comma (`,`) is added after the last array element and object member.
+On export, the result is shortened by usage of identifiers without quotes, single quotes (`'`), and character escapes `\v` and of the form `\xNN` (for values less than hexadecimal 100, that is, `⎕UCS 256`). If [`Compact`](#variant-option-compact) is `0`, a trailing comma (`,`) is added after the last array element and object member.
 
 <h4 class="example">Examples</h4>
 
@@ -477,10 +477,10 @@ On export, the result is shortened by usage of identifiers without quotes, singl
 
 ### Variant Option: Null
 
-The **Null** variant option selects how JSON <code class="language-nonAPL">null</code> is represented in APL, and must be either `⊂'null'` (the default) or `⎕NULL`:
+The `Null` variant option selects how JSON <code class="language-nonAPL">null</code> is represented in APL, and must be either `⊂'null'` (the default) or `⎕NULL`:
 
-- If **Null** is `⊂'null'`, `⎕NULL` causes `DOMAIN ERROR`.
-- If **Null** is `⎕NULL`, `⊂'null'` is still exported as <code class="language-nonAPL">null</code> because it is interpreted as [raw text](#raw-text-wrapper).
+- If `Null` is `⊂'null'`, `⎕NULL` causes `DOMAIN ERROR`.
+- If `Null` is `⎕NULL`, `⊂'null'` is still exported as <code class="language-nonAPL">null</code> because it is interpreted as [raw text](#raw-text-wrapper).
 
 <h4 class="example">Examples</h4>
 
@@ -504,14 +504,14 @@ DOMAIN ERROR: JSON export: item "[1]" of the right argument (⎕IO=1) cannot be 
 
 ### Variant Option: Compact
 
-The **Compact** variant option can be used to generate JSON that is either dense (`1`, the default) or optimised for humans to read and edit (`0`).
+The `Compact` variant option can be used to generate JSON that is either dense (`1`, the default) or optimised for humans to read and edit (`0`).
 
-If **Compact** is `0`:
+If `Compact` is `0`:
 
 - Line breaks are inserted after opening brackets `[` and `{` and before closing brackets `]` and `}`
 - Each array element and object member is on its own line, indented with two spaces relative to its container array or object
 - A space is inserted after `:` separating member name and value
-- If [**Dialect**](#variant-option-dialect) is `'JSON5'`, a trailing comma (`,`) is added after the last array element and object member
+- If [`Dialect`](#variant-option-dialect) is `'JSON5'`, a trailing comma (`,`) is added after the last array element and object member
 
 <h4 class="example">Example</h4>
 
@@ -570,7 +570,7 @@ Non-compact JSON takes more than twice as much space, but is more readable, and 
 
 ### Variant Option: Charset
 
-The **Charset** variant option can be used to either allow Unicode in the generated JSON (`'Unicode'`, the default) or restrict the output to ASCII characters (`'ASCII'`). When necessary, characters are converted to the hexadecimal form `\uNNNN`. If [**Dialect**](#variant-option-dialect) is `'JSON5'`, the form `\xNN` is used for values up to hexadecimal `FF` (`⎕UCS 255`).
+The `Charset` variant option can be used to either allow Unicode in the generated JSON (`'Unicode'`, the default) or restrict the output to ASCII characters (`'ASCII'`). When necessary, characters are converted to the hexadecimal form `\uNNNN`. If [`Dialect`](#variant-option-dialect) is `'JSON5'`, the form `\xNN` is used for values up to hexadecimal `FF` (`⎕UCS 255`).
 
 <h4 class="example">Example</h4>
 
@@ -586,7 +586,7 @@ DÉ
 
 ### Variant Option: HighRank
 
-If **HighRank** is `'Error'` (the default), `⎕JSON` will signal a `DOMAIN ERROR` upon encountering any arrays in `Y` of rank higher than 1. If **HighRank** is `'Split'`, `⎕JSON` will recursively split any such arrays as necessary; in addition, [datasets](#dataset-wrappers) as inverted tables can have text columns represented as matrices.
+If `HighRank` is `'Error'` (the default), `⎕JSON` will signal a `DOMAIN ERROR` upon encountering any arrays in `Y` of rank higher than 1. If `HighRank` is `'Split'`, `⎕JSON` will recursively split any such arrays as necessary; in addition, [datasets](#dataset-wrappers) as inverted tables can have text columns represented as matrices.
 
 <h4 class="example">Example</h4>
 
@@ -727,7 +727,7 @@ Table: Wrapper codes { #wrapper-codes-table }
 | `3`          | Two-element nested vector: value matrix and header vector                              | Allows indexing into the rows and columns of the data |
 | `4`          | Two-element nested vector: inverted table (vector of column vectors) and header vector | Less memory and faster lookups |
 
-For wrapper code `4`, if [**HighRank**](#variant-option-highrank) is `'Split'`, character columns can also be stored as character matrices rather than vectors of character vectors, providing even better performance, but `⎕JSON` will preserve trailing spaces.
+For wrapper code `4`, if [`HighRank`](#variant-option-highrank) is `'Split'`, character columns can also be stored as character matrices rather than vectors of character vectors, providing even better performance, but `⎕JSON` will preserve trailing spaces.
 
 <h4 class="example">Examples</h4>
 

--- a/language-reference-guide/docs/system-functions/json.md
+++ b/language-reference-guide/docs/system-functions/json.md
@@ -142,9 +142,9 @@ The above name translations are verified using `7162⌶`:
 
 ## Variant Options
 
-`⎕JSON` is controlled by six variant options. [](#variant-table) summarises each option's effect on import from JSON to APL (`X=0`) and export from APL to JSON (`X=1`). Each option is described in finer detail, with examples, below the table. Variant options specific to one direction are tolerated for the other direction even if they have no effect.
+`⎕JSON` is controlled by six variant options. [](#variantoptionsforjson) summarises each option's effect on import from JSON to APL (`X=0`) and export from APL to JSON (`X=1`). Each option is described in finer detail, with examples, below the table. Variant options specific to one direction are tolerated for the other direction even if they have no effect.
 
-Table: Variant options overview { #variant-table }
+Table: Variant options for `⎕JSON` { #variantoptionsforjson }
 
 | Variant Option | Valid Values | Default | Effect on Import | Effect on Export |
 |---|:---:|:---:|---|---|
@@ -161,7 +161,7 @@ Table: Variant options overview { #variant-table }
 | [`HighRank`](#variant-option-highrank)                         | `'Error'` | `'Error'` | None                                                | High-rank arrays are rejected |
 |_-                                                                -_| `'Split'`                             |  | None                                                | High-rank arrays are split and [inverted table wrappers](#dataset-wrappers) accept text columns as matrices |
 
-### Variant Option: Format
+### Variant Option: `Format`
 
 The `Format` variant option, the principal option, determines whether `⎕JSON` works with a direct APL representation of the data (`'D'` for "Data", the default) or with a four-column matrix that encodes the JSON structure (`'M'` for "Matrix") as nodes with depth, name, value, and type.
 
@@ -439,7 +439,7 @@ DOMAIN ERROR: JSON export: value does not match the specified type in row 3 (⎕
       ∧
 ```
 
-### Variant Option: Dialect
+### Variant Option: `Dialect`
 
 If the `Dialect` variant option (default: `'JSON'`) is `'JSON5'`, [JSON5](https://json5.org/) extensions are enabled on import and export.
 
@@ -475,7 +475,7 @@ On export, the result is shortened by usage of identifiers without quotes, singl
 └───┴───┴──┘
 ```
 
-### Variant Option: Null
+### Variant Option: `Null`
 
 The `Null` variant option selects how JSON <code class="language-nonAPL">null</code> is represented in APL, and must be either `⊂'null'` (the default) or `⎕NULL`:
 
@@ -502,7 +502,7 @@ DOMAIN ERROR: JSON export: item "[1]" of the right argument (⎕IO=1) cannot be 
 [null,null]
 ```
 
-### Variant Option: Compact
+### Variant Option: `Compact`
 
 The `Compact` variant option can be used to generate JSON that is either dense (`1`, the default) or optimised for humans to read and edit (`0`).
 
@@ -568,7 +568,7 @@ Non-compact JSON takes more than twice as much space, but is more readable, and 
 }
 ```
 
-### Variant Option: Charset
+### Variant Option: `Charset`
 
 The `Charset` variant option can be used to either allow Unicode in the generated JSON (`'Unicode'`, the default) or restrict the output to ASCII characters (`'ASCII'`). When necessary, characters are converted to the hexadecimal form `\uNNNN`. If [`Dialect`](#variant-option-dialect) is `'JSON5'`, the form `\xNN` is used for values up to hexadecimal `FF` (`⎕UCS 255`).
 
@@ -584,7 +584,7 @@ DÉ
 {"d\u00E9":"D\u00C9"}
 ```
 
-### Variant Option: HighRank
+### Variant Option: `HighRank`
 
 If `HighRank` is `'Error'` (the default), `⎕JSON` will signal a `DOMAIN ERROR` upon encountering any arrays in `Y` of rank higher than 1. If `HighRank` is `'Split'`, `⎕JSON` will recursively split any such arrays as necessary; in addition, [datasets](#dataset-wrappers) as inverted tables can have text columns represented as matrices.
 

--- a/language-reference-guide/docs/system-functions/json.md
+++ b/language-reference-guide/docs/system-functions/json.md
@@ -142,7 +142,7 @@ The above name translations are verified using `7162⌶`:
 
 ## Variant Options
 
-`⎕JSON` is controlled by six variant options. [](#variantoptionsforjson) summarises each option's effect on import from JSON to APL (`X=0`) and export from APL to JSON (`X=1`). Each option is described in finer detail, with examples, below the table. Variant options specific to one direction are tolerated for the other direction even if they have no effect.
+`⎕JSON` is controlled by six variant options. [](#variantoptionsforjson) summarises each option's effect on import from JSON to APL (`X=0`) and export from APL to JSON (`X=1`). Each option is described in finer detail, with examples, below the table. Variant options specific to one direction are tolerated for the other direction, even if they have no effect.
 
 Table: Variant options for `⎕JSON` { #variantoptionsforjson }
 

--- a/language-reference-guide/docs/system-functions/mkdir.md
+++ b/language-reference-guide/docs/system-functions/mkdir.md
@@ -9,11 +9,11 @@ This function creates new directories.
 
 `Y` is a character vector or scalar containing a single directory name, or a vector of character vectors containing zero or more directory names. Names must conform to the naming rules of the host Operating System.
 
-By default, for each name in `Y` the path must exist and the base name must not exist (see [File Name Parts](nparts.md)), otherwise an error is signalled. The optional left argument `X` and the variant option **Unique** can be used to amend this behaviour.
+By default, for each name in `Y` the path must exist and the base name must not exist (see [File Name Parts](nparts.md)), otherwise an error is signalled. The optional left argument `X` and the variant option `Unique` can be used to amend this behaviour.
 
-The result `R` depends on the value of the variant option **Unique**. If  **Unique** is not present, it is assumed to have a value of `0`.
+The result `R` depends on the value of the variant option `Unique`. If `Unique` is not present, it is assumed to have a value of `0`.
 
-| Unique | Result `R` |
+| `Unique` | Result `R` |
 |--------|------------|
 |` 0`    | If `Y` specifies a single name, the [shy](../../../programming-reference-guide/introduction/results#shy-results) result `R` is a scalar `1` if a directory was created or `0` if not. If `Y` is a vector of character vectors, `R` is a vector of `1`s and `0`s with the same length as `Y`. |
 | `1`    | If `Y` specifies a single name, the shy result `R` is a character vector containing the name of the directory that was created. If `Y` is a vector of character vectors, `R` is a vector of character vectors with the same length as `Y`. |
@@ -21,21 +21,22 @@ The result `R` depends on the value of the variant option **Unique**. If  **Uniq
 The optional left argument `X` is a numeric scalar that modifies the default behaviour when the base name in `Y` already exists and/or the path in `Y` does not already exist. If omitted, it is assumed to be 0. Possible values and the effect that they have on the default behaviour are:
 
 |---|---|
-| `0` {.shaded} | The base name in `Y` must not exist and the path in `Y` must exist, otherwise an error is signalled.                                                                           |
-|`1`|No action is taken if a directory specified by `Y` already exists (the return value indicates whether a new directory was created). Has no effect when the variant option **Unique** is set.|
+| `0` <small>(default)</small> | The base name in `Y` must not exist and the path in `Y` must exist, otherwise an error is signalled.                                                                           |
+|`1`|No action is taken if a directory specified by `Y` already exists (the return value indicates whether a new directory was created). Has no effect when the variant option `Unique` is set.|
 |`2`|Any part of the *paths* specified in `Y` which does not already exist will be created in preparation of creating the corresponding directory.                                               |
 |`3`|Combination of 1 and 2.                                                                                                                                                                     |
 
 ## Variant Options
 
-`⎕MKDIR` may be applied using the variant operator with the option **Unique**. There is no primary option.
+`⎕MKDIR` supports one variant option, `Unique`. There is no principal option.
 
-## Unique Option (Boolean)
-The **Unique** option specifies whether the base name (see [File Name Parts](nparts.md)) in `Y` is modified so that the name is unique (does not already exist).
+### Variant Option: Unique
 
-| Unique            | Effect on Behaviour  |
+The `Unique` variant option (a Boolean, `0` by default) specifies whether the base name (see [File Name Parts](nparts.md)) in `Y` is modified so that the name is unique (does not already exist).
+
+| `Unique` | Effect on Behaviour |
 |-------------------|----------------------|
-|` 0`   { .shaded } | The directory named in `Y` will be created. |
+|`0` <small>(default)</small> | The directory named in `Y` will be created. |
 | `1`               | The name in `Y` is modified by extending the base name with random characters and the directory is created. The name of the directory is returned in the result `R`. |
 
 If a directory cannot be created (for example, if a directory with that name already exists, or write access is denied) then an error is signalled.

--- a/language-reference-guide/docs/system-functions/mkdir.md
+++ b/language-reference-guide/docs/system-functions/mkdir.md
@@ -39,7 +39,7 @@ The `Unique` variant option (a Boolean, `0` by default) specifies whether the ba
 |`0` <small>(default)</small> | The directory named in `Y` will be created. |
 | `1`               | The name in `Y` is modified by extending the base name with random characters and the directory is created. The name of the directory is returned in the result `R`. |
 
-If a directory cannot be created (for example, if a directory with that name already exists, or write access is denied) then an error is signalled.
+If a directory cannot be created (for example, if a directory with that name already exists, or write access is denied), then an error is signalled.
 
 <h2 class="example">Examples</h2>
 ```apl

--- a/language-reference-guide/docs/system-functions/mkdir.md
+++ b/language-reference-guide/docs/system-functions/mkdir.md
@@ -30,7 +30,7 @@ The optional left argument `X` is a numeric scalar that modifies the default beh
 
 `⎕MKDIR` supports one variant option, `Unique`. There is no principal option.
 
-### Variant Option: Unique
+### Variant Option: `Unique`
 
 The `Unique` variant option (a Boolean, `0` by default) specifies whether the base name (see [File Name Parts](nparts.md)) in `Y` is modified so that the name is unique (does not already exist).
 
@@ -74,7 +74,7 @@ FILE NAME ERROR: /Users/Pete/Documents/temp/t1/t2: Already exists
 ```
 
 !!! note
-    When multiple names are specified they are processed in the order given. If an error occurs at any point whilst creating directories, processing will immediately stop and an error will be signalled. The operation is not atomic; some directories may be created before this happens. In the event of an error there will be no result and therefore no indication of how many directories were created before the error occurred.
+    When multiple names are specified they are processed in the order given. If an error occurs at any point whilst creating directories, processing will immediately stop and an error will be signalled. The operation is not atomic; some directories might be created before this happens. In the event of an error there will be no result and therefore no indication of how many directories were created before the error occurred.
 
 <!-- Hidden search keywords -->
 <div style="display: none;">

--- a/language-reference-guide/docs/system-functions/ncopy.md
+++ b/language-reference-guide/docs/system-functions/ncopy.md
@@ -23,12 +23,12 @@ The [shy](../../../programming-reference-guide/introduction/results#shy-results)
 
 Table: Variant options overview { #variant-table }
 
-|Variant Option|Value|Effect|
-|---|---|---|
-|[`Wildcard`](#variant-option-wildcard)<br><small>principal</small>|`0` <small>(default)</small> or `1`|Whether the names in `Y` are matched literally or as patterns.|
-|[`IfExists`](#variant-option-ifexists)|`'Error'` <small>(default)</small>, `'Skip'`, `'Replace'` or `'ReplaceIfNewer'`|What happens when a target file already exists.|
-|[`PreserveAttributes`](#variant-option-preserveattributes)|`0` <small>(default)</small> or `1`|Whether file attributes are preserved.|
-|[`ProgressCallback`](#variant-option-progresscallback)|a callback function|Reports progress during the copy.|
+|Variant Option|Valid Values|Default|Effect|
+|---|---|---|---|
+|[`Wildcard`](#variant-option-wildcard)<br><small>principal</small>|`0` or `1`|`0`|Whether the names in `Y` are matched literally or as patterns.|
+|[`IfExists`](#variant-option-ifexists)|`'Error'`, `'Skip'`, `'Replace'` or `'ReplaceIfNewer'`|`'Error'`|What happens when a target file already exists.|
+|[`PreserveAttributes`](#variant-option-preserveattributes)|`0` or `1`|`0`|Whether file attributes are preserved.|
+|[`ProgressCallback`](#variant-option-progresscallback)|a callback function||Reports progress during the copy.|
 
 ### Variant Option: Wildcard
 

--- a/language-reference-guide/docs/system-functions/ncopy.md
+++ b/language-reference-guide/docs/system-functions/ncopy.md
@@ -28,9 +28,6 @@ i:/Documents/Dyalog APL-64 17.0 Unicode Files/
  
 ⍝ Make a named back-up of the Session file
       ⊢'session.bak' ⎕NCOPY 'default.dlf'
-```
-```apl
-
 1
       ⊢ ⎕MKDIR 'backups' ⍝ Make a backups directory
 1
@@ -54,7 +51,6 @@ i:/Documents/Dyalog APL-64 17.0 Unicode Files/
       ↑⊃0 (⎕NINFO⍠1) 'backups\*'
 backups/default.dlf
 backups/def_uk.dse 
-
 ```
 
 ## Variant Options
@@ -90,15 +86,11 @@ i:/Documents/Dyalog APL-64 17.0 Unicode Files/
 ⍝ Copy all files to backups directory
       ⊢'backups'(⎕NCOPY⍠'Wildcard' 1)'*.*'
 3
-```
-```apl
 
       ↑⊃0 (⎕NINFO⍠1) 'backups\*'
 backups/default.dlf        
 backups/def_uk.dse         
 backups/UserCommand20.cache
-  
-
 ```
 
 The destination name must be an existing directory. Copies of each of the files and/or directories that match the patterns specified by the source names (if any) are made in the destination directory.

--- a/language-reference-guide/docs/system-functions/ncopy.md
+++ b/language-reference-guide/docs/system-functions/ncopy.md
@@ -13,53 +13,68 @@ This function copies native files and directories from one or more sources speci
 
 Source and destination path names may be full or relative (to the current working directory) path names which adhere to the operating system conventions.
 
-If `X` specifies an existent directory then each source in `Y` is copied into that directory, otherwise `X` specifies the name of the copy. `X` must specify an existent directory if the source contains multiple names or if the **Wildcard** option is set.
+If `X` specifies an existent directory then each source in `Y` is copied into that directory, otherwise `X` specifies the name of the copy. `X` must specify an existent directory if the source contains multiple names or if the `Wildcard` option is set.
 
 The [shy](../../../programming-reference-guide/introduction/results#shy-results) result `R` contains count(s) of top-level items copied. If `Y` is a single source name, `R` is a scalar otherwise it is a vector of the same length as `Y`.
 
 ## Variant Options
 
-`⎕NCOPY` may be applied using the _variant_ operator with the options **Wildcard** (the Principal option), **IfExists**, **PreserveAttributes** and **ProgressCallback**.
+`⎕NCOPY` supports four variant options, summarised in [](#variant-table) and described in detail beneath it. The principal option is `Wildcard`.
 
-## Wildcard Option (Boolean)
+Table: Variant options overview { #variant-table }
+
+|Variant Option|Value|Effect|
+|---|---|---|
+|[`Wildcard`](#variant-option-wildcard)<br><small>principal</small>|`0` <small>(default)</small> or `1`|Whether the names in `Y` are matched literally or as patterns.|
+|[`IfExists`](#variant-option-ifexists)|`'Error'` <small>(default)</small>, `'Skip'`, `'Replace'` or `'ReplaceIfNewer'`|What happens when a target file already exists.|
+|[`PreserveAttributes`](#variant-option-preserveattributes)|`0` <small>(default)</small> or `1`|Whether file attributes are preserved.|
+|[`ProgressCallback`](#variant-option-progresscallback)|a callback function|Reports progress during the copy.|
+
+### Variant Option: Wildcard
 
 |---|---|
-|0 { .shaded } |The name or names in `Y` identifies a specific file name.|
+|`0` <small>(default)</small>|The name or names in `Y` identifies a specific file name.|
 |`1`|The name or names in `Y` that specify the *base name* and *extension* (see [NParts](./nparts.md) ), may also contain the wildcard characters "?" and "*". An asterisk is a substitute for any 0 or more characters in a file name or extension; a question-mark is a substitute for any single character.|
 
-Note that when **Wildcard** is 1, element(s) of `R` can  be 0, 1 or `>1`. If **Wildcard** is 0, elements of `R` are always 1.
+Note that when `Wildcard` is `1`, element(s) of `R` can be `0`, `1` or `>1`. If `Wildcard` is `0`, elements of `R` are always `1`.
 
-## IfExists Option
+### Variant Option: IfExists
 
-The **IfExists** variant option determines what happens when a source file is to be copied to a target file that already exists. It does not apply to directories, only to the files within them.
+The `IfExists` variant option determines what happens when a source file is to be copied to a target file that already exists. It does not apply to directories, only to the files within them.
 
-|Value             |Description                                                                                        |
-|------------------|---------------------------------------------------------------------------------------------------|
-|'Error' { .shaded } |Existing files will not be overwritten and an error will be signalled. This is the default                                                                        |
+|Value|Description|
+|---|---|
+|`'Error'` <small>(default)</small>|Existing files will not be overwritten and an error will be signalled.|
 |`'Skip'`          |Existing files will not be overwritten but the corresponding copy operation will be skipped (ignored).                                                            |
 |`'Replace'`       |Existing files will be overwritten.                                                                                                                               |
 |`'ReplaceIfNewer'`|Existing files may be overwritten if, and only if, the corresponding source file is newer (more recently modified) than the existing one, otherwise it is skipped.|
 
-The following cases cause an error to be signalled regardless of the value of the **IfExists** variant.
+The following cases cause an error to be signalled regardless of the value of the `IfExists` variant.
 
 - If the source specifies a directory and the destination specifies an existing file.
 - If the source specifies a file and the same base name exists as a sub-directory in the destination.
 
-## PreserveAttributes Option (Boolean)
+### Variant Option: PreserveAttributes
 
-The **PreserveAttributes** variant option determines whether or not file attributes are preserved. It does not apply to directories, only to files.
+The `PreserveAttributes` variant option (a Boolean) determines whether or not file attributes are preserved. It does not apply to directories, only to files.
 
-|---|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|0 { .shaded } |file attributes are not preserved.                                                                                                                                                         |
+|---|---|
+|`0` <small>(default)</small>|file attributes are not preserved.                                                                                                                                                         |
 |`1`|where possible, copied files will be given at least the same modification time as the source. Other file attributes will be preserved as permitted by the operating system and file system.|
 
 Note also that when files are copied across file systems, the different file systems may have different timestamp granularity and the timestamps may not be exactly the same.
+
+### Variant Option: ProgressCallback
+
+The `ProgressCallback` variant option is described in the [Dyalog Programming Reference Guide](../../../programming-reference-guide/native-files#progress-callbacks). The following is specific to `⎕NCOPY`:
+
+* The first element of the right argument to the callback function is the character vector `'⎕NCOPY'`.
 
 <h2 class="example">Examples</h2>
 
 There are a number of possibilities which are illustrated below. In all cases,  if the source is a file, a copy of the file is created. If the source is a directory, a copy of the directory and all its contents is created.
 
-### Examples (single source, Wildcard is 0)
+### Examples: single source, `Wildcard` is `0` { .example }
 
 - The source name must be an existent file or directory.
 - If the destination name does not exist but its path name does exist, the source is copied to the destination name.
@@ -83,7 +98,7 @@ i:/Documents/Dyalog APL-64 17.0 Unicode Files/
 backups/default.dlf  
 ```
 
-### Examples (single source, Wildcard is 1)
+### Examples: single source, `Wildcard` is `1` { .example }
 
 - The source name may include wildcard characters which matches a number of existing files and/or directories. The destination name must be an existing directory.
 - The files and/or directories that match the pattern specified by the source name are copied into the destination directory. If there are no matches, zero copies are made.
@@ -107,7 +122,7 @@ backups/UserCommand20.cache
 
 ```
 
-### Examples (multiple sources, Wildcard is 0)
+### Examples: multiple sources, `Wildcard` is `0` { .example }
 
 - Each source name must specify a single file or directory which must exist. The destination name must be an existing directory.
 - Copies of each of the files and/or directories specified by the source base names are made in the destination directory.
@@ -126,7 +141,7 @@ backups/def_uk.dse
 
 ```
 
-### Examples (multiple sources, Wildcard is 1)
+### Examples: multiple sources, `Wildcard` is `1` { .example }
 
 - The destination name must be an existing directory.
 - Copies of each of the files and/or directories that match the patterns specified by the source names (if any) are made in the destination directory.
@@ -145,17 +160,11 @@ backups/def_uk.dse
 backups/UserCommand20.cache
 ```
 
-## ProgressCallback Option
-
-The **ProgressCallback** variant option is described in the [Dyalog Programming Reference Guide](../../../programming-reference-guide/native-files#progress-callbacks). following is specific to `⎕NCOPY`:
-
-* The first element of the right argument to the callback function is the character vector `'⎕NCOPY'`.
-
 ## Notes
 
 - The special directories `.` and `..` can never be copied into an existing directory.
 - If any source name is a symbolic link it is dereferenced; that is, the source or directory it references is copied rather than the link itself.
-- In the result `R`, a directory together with all its contents is counted once. A directory may be partially copied if the **IfExists** option is set to `'Replace'` or `'ReplaceIfNewer'`).
+- In the result `R`, a directory together with all its contents is counted once. A directory may be partially copied if the `IfExists` option is set to `'Replace'` or `'ReplaceIfNewer'`).
 - If an error occurs during the copy process then processing will immediately stop and an error will be signalled. The operation is not atomic; some items may be copied before this happens. In the event of an error there will be no result and therefore no indication of how many names were copied before the error occurred.
 
 <!-- Hidden search keywords -->

--- a/language-reference-guide/docs/system-functions/ncopy.md
+++ b/language-reference-guide/docs/system-functions/ncopy.md
@@ -21,11 +21,7 @@ The [shy](../../../programming-reference-guide/introduction/results#shy-results)
 
 There are a number of possibilities which are illustrated below. In all cases,  if the source is a file, a copy of the file is created. If the source is a directory, a copy of the directory and all its contents is created.
 
-### Examples: single source, `Wildcard` is `0` { .example }
-
-- The source name must be an existent file or directory.
-- If the destination name does not exist but its path name does exist, the source is copied to the destination name.
-- If the destination name is an existing directory the copy is created within that directory with the base name of the source.
+The source name must be an existent file or directory. If the destination name does not exist but its path name does exist, the source is copied to the destination name. If the destination name is an existing directory the copy is created within that directory with the base name of the source.
 ```apl
        ⊃1 ⎕NPARTS ''
 i:/Documents/Dyalog APL-64 17.0 Unicode Files/
@@ -45,10 +41,7 @@ i:/Documents/Dyalog APL-64 17.0 Unicode Files/
 backups/default.dlf  
 ```
 
-### Examples: multiple sources, `Wildcard` is `0` { .example }
-
-- Each source name must specify a single file or directory which must exist. The destination name must be an existing directory.
-- Copies of each of the files and/or directories specified by the source base names are made in the destination directory.
+Each source name must specify a single file or directory which must exist. The destination name must be an existing directory. Copies of each of the files and/or directories specified by the source base names are made in the destination directory.
 ```apl
        ⊃1 ⎕NPARTS ''
 i:/Documents/Dyalog APL-64 17.0 Unicode Files/
@@ -85,10 +78,9 @@ Table: Variant options overview { #variant-table }
 
 Note that when `Wildcard` is `1`, element(s) of `R` can be `0`, `1` or `>1`. If `Wildcard` is `0`, elements of `R` are always `1`.
 
-#### Examples: single source, `Wildcard` is `1` { .example }
+<h4 class="example">Examples</h4>
 
-- The source name may include wildcard characters which matches a number of existing files and/or directories. The destination name must be an existing directory.
-- The files and/or directories that match the pattern specified by the source name are copied into the destination directory. If there are no matches, zero copies are made.
+The source name may include wildcard characters which matches a number of existing files and/or directories. The destination name must be an existing directory. The files and/or directories that match the pattern specified by the source name are copied into the destination directory. If there are no matches, zero copies are made.
 ```apl
        ⊃1 ⎕NPARTS ''
 i:/Documents/Dyalog APL-64 17.0 Unicode Files/
@@ -109,10 +101,7 @@ backups/UserCommand20.cache
 
 ```
 
-#### Examples: multiple sources, `Wildcard` is `1` { .example }
-
-- The destination name must be an existing directory.
-- Copies of each of the files and/or directories that match the patterns specified by the source names (if any) are made in the destination directory.
+The destination name must be an existing directory. Copies of each of the files and/or directories that match the patterns specified by the source names (if any) are made in the destination directory.
 ```apl
       ⊃1 ⎕NPARTS ''
 i:/Documents/Dyalog APL-64 17.0 Unicode Files/

--- a/language-reference-guide/docs/system-functions/ncopy.md
+++ b/language-reference-guide/docs/system-functions/ncopy.md
@@ -17,6 +17,53 @@ If `X` specifies an existent directory then each source in `Y` is copied into th
 
 The [shy](../../../programming-reference-guide/introduction/results#shy-results) result `R` contains count(s) of top-level items copied. If `Y` is a single source name, `R` is a scalar otherwise it is a vector of the same length as `Y`.
 
+<h2 class="example">Examples</h2>
+
+There are a number of possibilities which are illustrated below. In all cases,  if the source is a file, a copy of the file is created. If the source is a directory, a copy of the directory and all its contents is created.
+
+### Examples: single source, `Wildcard` is `0` { .example }
+
+- The source name must be an existent file or directory.
+- If the destination name does not exist but its path name does exist, the source is copied to the destination name.
+- If the destination name is an existing directory the copy is created within that directory with the base name of the source.
+```apl
+       ⊃1 ⎕NPARTS ''
+i:/Documents/Dyalog APL-64 17.0 Unicode Files/
+ 
+⍝ Make a named back-up of the Session file
+      ⊢'session.bak' ⎕NCOPY 'default.dlf'
+```
+```apl
+
+1
+      ⊢ ⎕MKDIR 'backups' ⍝ Make a backups directory
+1
+ ⍝ Copy the Session file to backups directory
+      ⊢'backups'⎕NCOPY'default.dlf'
+1
+      ↑⊃0 (⎕NINFO⍠1) 'backups\*'
+backups/default.dlf  
+```
+
+### Examples: multiple sources, `Wildcard` is `0` { .example }
+
+- Each source name must specify a single file or directory which must exist. The destination name must be an existing directory.
+- Copies of each of the files and/or directories specified by the source base names are made in the destination directory.
+```apl
+       ⊃1 ⎕NPARTS ''
+i:/Documents/Dyalog APL-64 17.0 Unicode Files/
+
+      ⊢ ⎕MKDIR 'backups' ⍝ Make a backups directory
+1
+⍝ Copy 2 files to backups directory
+      ⊢'backups'⎕NCOPY'default.dlf' 'def_uk.dse'
+1 1
+      ↑⊃0 (⎕NINFO⍠1) 'backups\*'
+backups/default.dlf
+backups/def_uk.dse 
+
+```
+
 ## Variant Options
 
 `⎕NCOPY` supports four variant options, summarised in [](#variant-table) and described in detail beneath it. The principal option is `Wildcard`.
@@ -28,7 +75,7 @@ Table: Variant options overview { #variant-table }
 |[`Wildcard`](#variant-option-wildcard)<br><small>principal</small>|`0` or `1`|`0`|Whether the names in `Y` are matched literally or as patterns.|
 |[`IfExists`](#variant-option-ifexists)|`'Error'`, `'Skip'`, `'Replace'` or `'ReplaceIfNewer'`|`'Error'`|What happens when a target file already exists.|
 |[`PreserveAttributes`](#variant-option-preserveattributes)|`0` or `1`|`0`|Whether file attributes are preserved.|
-|[`ProgressCallback`](#variant-option-progresscallback)|a callback function||Reports progress during the copy.|
+|[`ProgressCallback`](#variant-option-progresscallback)|the name of a callback function|none|Reports progress during the copy.|
 
 ### Variant Option: Wildcard
 
@@ -37,6 +84,49 @@ Table: Variant options overview { #variant-table }
 |`1`|The name or names in `Y` that specify the *base name* and *extension* (see [NParts](./nparts.md) ), may also contain the wildcard characters "?" and "*". An asterisk is a substitute for any 0 or more characters in a file name or extension; a question-mark is a substitute for any single character.|
 
 Note that when `Wildcard` is `1`, element(s) of `R` can be `0`, `1` or `>1`. If `Wildcard` is `0`, elements of `R` are always `1`.
+
+#### Examples: single source, `Wildcard` is `1` { .example }
+
+- The source name may include wildcard characters which matches a number of existing files and/or directories. The destination name must be an existing directory.
+- The files and/or directories that match the pattern specified by the source name are copied into the destination directory. If there are no matches, zero copies are made.
+```apl
+       ⊃1 ⎕NPARTS ''
+i:/Documents/Dyalog APL-64 17.0 Unicode Files/
+
+      ⊢ ⎕MKDIR 'backups' ⍝ Make a backups directory
+1
+⍝ Copy all files to backups directory
+      ⊢'backups'(⎕NCOPY⍠'Wildcard' 1)'*.*'
+3
+```
+```apl
+
+      ↑⊃0 (⎕NINFO⍠1) 'backups\*'
+backups/default.dlf        
+backups/def_uk.dse         
+backups/UserCommand20.cache
+  
+
+```
+
+#### Examples: multiple sources, `Wildcard` is `1` { .example }
+
+- The destination name must be an existing directory.
+- Copies of each of the files and/or directories that match the patterns specified by the source names (if any) are made in the destination directory.
+```apl
+      ⊃1 ⎕NPARTS ''
+i:/Documents/Dyalog APL-64 17.0 Unicode Files/
+
+      ⊢ ⎕MKDIR 'backups' ⍝ Make a backups directory
+1
+⍝ Copy files to backups directory
+      ⊢'backups'(⎕NCOPY⍠1)'d*' 'UserCommand20.cache'
+2 1
+      ↑⊃0 (⎕NINFO⍠1) 'backups\*'
+backups/default.dlf
+backups/def_uk.dse
+backups/UserCommand20.cache
+```
 
 ### Variant Option: IfExists
 
@@ -69,96 +159,6 @@ Note also that when files are copied across file systems, the different file sys
 The `ProgressCallback` variant option is described in the [Dyalog Programming Reference Guide](../../../programming-reference-guide/native-files#progress-callbacks). The following is specific to `⎕NCOPY`:
 
 * The first element of the right argument to the callback function is the character vector `'⎕NCOPY'`.
-
-<h2 class="example">Examples</h2>
-
-There are a number of possibilities which are illustrated below. In all cases,  if the source is a file, a copy of the file is created. If the source is a directory, a copy of the directory and all its contents is created.
-
-### Examples: single source, `Wildcard` is `0` { .example }
-
-- The source name must be an existent file or directory.
-- If the destination name does not exist but its path name does exist, the source is copied to the destination name.
-- If the destination name is an existing directory the copy is created within that directory with the base name of the source.
-```apl
-       ⊃1 ⎕NPARTS ''
-i:/Documents/Dyalog APL-64 17.0 Unicode Files/
- 
-⍝ Make a named back-up of the Session file
-      ⊢'session.bak' ⎕NCOPY 'default.dlf'
-```
-```apl
-
-1
-      ⊢ ⎕MKDIR 'backups' ⍝ Make a backups directory
-1
- ⍝ Copy the Session file to backups directory
-      ⊢'backups'⎕NCOPY'default.dlf'
-1
-      ↑⊃0 (⎕NINFO⍠1) 'backups\*'
-backups/default.dlf  
-```
-
-### Examples: single source, `Wildcard` is `1` { .example }
-
-- The source name may include wildcard characters which matches a number of existing files and/or directories. The destination name must be an existing directory.
-- The files and/or directories that match the pattern specified by the source name are copied into the destination directory. If there are no matches, zero copies are made.
-```apl
-       ⊃1 ⎕NPARTS ''
-i:/Documents/Dyalog APL-64 17.0 Unicode Files/
-
-      ⊢ ⎕MKDIR 'backups' ⍝ Make a backups directory
-1
-⍝ Copy all files to backups directory
-      ⊢'backups'(⎕NCOPY⍠'Wildcard' 1)'*.*'
-3
-```
-```apl
-
-      ↑⊃0 (⎕NINFO⍠1) 'backups\*'
-backups/default.dlf        
-backups/def_uk.dse         
-backups/UserCommand20.cache
-  
-
-```
-
-### Examples: multiple sources, `Wildcard` is `0` { .example }
-
-- Each source name must specify a single file or directory which must exist. The destination name must be an existing directory.
-- Copies of each of the files and/or directories specified by the source base names are made in the destination directory.
-```apl
-       ⊃1 ⎕NPARTS ''
-i:/Documents/Dyalog APL-64 17.0 Unicode Files/
-
-      ⊢ ⎕MKDIR 'backups' ⍝ Make a backups directory
-1
-⍝ Copy 2 files to backups directory
-      ⊢'backups'⎕NCOPY'default.dlf' 'def_uk.dse'
-1 1
-      ↑⊃0 (⎕NINFO⍠1) 'backups\*'
-backups/default.dlf
-backups/def_uk.dse 
-
-```
-
-### Examples: multiple sources, `Wildcard` is `1` { .example }
-
-- The destination name must be an existing directory.
-- Copies of each of the files and/or directories that match the patterns specified by the source names (if any) are made in the destination directory.
-```apl
-      ⊃1 ⎕NPARTS ''
-i:/Documents/Dyalog APL-64 17.0 Unicode Files/
-
-      ⊢ ⎕MKDIR 'backups' ⍝ Make a backups directory
-1
-⍝ Copy files to backups directory
-      ⊢'backups'(⎕NCOPY⍠1)'d*' 'UserCommand20.cache'
-2 1
-      ↑⊃0 (⎕NINFO⍠1) 'backups\*'
-backups/default.dlf
-backups/def_uk.dse
-backups/UserCommand20.cache
-```
 
 ## Notes
 

--- a/language-reference-guide/docs/system-functions/ncopy.md
+++ b/language-reference-guide/docs/system-functions/ncopy.md
@@ -13,7 +13,7 @@ This function copies native files and directories from one or more sources speci
 
 Source and destination path names can be full or relative (to the current working directory) path names which adhere to the operating system conventions.
 
-If `X` specifies an existent directory then each source in `Y` is copied into that directory, otherwise `X` specifies the name of the copy. `X` must specify an existent directory if the source contains multiple names or if the `Wildcard` option is set.
+If `X` specifies an existent directory, then each source in `Y` is copied into that directory, otherwise `X` specifies the name of the copy. `X` must specify an existent directory if the source contains multiple names or if the `Wildcard` option is set.
 
 The [shy](../../../programming-reference-guide/introduction/results#shy-results) result `R` contains count(s) of top-level items copied. If `Y` is a single source name, `R` is a scalar otherwise it is a vector of the same length as `Y`.
 
@@ -146,7 +146,7 @@ The `ProgressCallback` variant option is described in the [Dyalog Programming Re
 - The special directories `.` and `..` can never be copied into an existing directory.
 - If any source name is a symbolic link it is dereferenced; that is, the source or directory it references is copied rather than the link itself.
 - In the result `R`, a directory together with all its contents is counted once. A directory might be partially copied if the `IfExists` option is set to `'Replace'` or `'ReplaceIfNewer'`).
-- If an error occurs during the copy process then processing will immediately stop and an error will be signalled. The operation is not atomic; some items might be copied before this happens. In the event of an error there will be no result and therefore no indication of how many names were copied before the error occurred.
+- If an error occurs during the copy process, then processing will immediately stop and an error will be signalled. The operation is not atomic; some items might be copied before this happens. In the event of an error there will be no result and therefore no indication of how many names were copied before the error occurred.
 
 <!-- Hidden search keywords -->
 <div style="display: none;">

--- a/language-reference-guide/docs/system-functions/ncopy.md
+++ b/language-reference-guide/docs/system-functions/ncopy.md
@@ -11,7 +11,7 @@ This function copies native files and directories from one or more sources speci
 
 `Y` is a character vector that specifies the name of the source, or a vector of character vectors containing zero or more sources.
 
-Source and destination path names may be full or relative (to the current working directory) path names which adhere to the operating system conventions.
+Source and destination path names can be full or relative (to the current working directory) path names which adhere to the operating system conventions.
 
 If `X` specifies an existent directory then each source in `Y` is copied into that directory, otherwise `X` specifies the name of the copy. `X` must specify an existent directory if the source contains multiple names or if the `Wildcard` option is set.
 
@@ -55,9 +55,9 @@ backups/def_uk.dse
 
 ## Variant Options
 
-`⎕NCOPY` supports four variant options, summarised in [](#variant-table) and described in detail beneath it. The principal option is `Wildcard`.
+`⎕NCOPY` supports four variant options, summarised in [](#variantoptionsforncopy) and described in detail beneath it. The principal option is `Wildcard`.
 
-Table: Variant options overview { #variant-table }
+Table: Variant options for `⎕NCOPY` { #variantoptionsforncopy }
 
 |Variant Option|Valid Values|Default|Effect|
 |---|---|---|---|
@@ -66,17 +66,17 @@ Table: Variant options overview { #variant-table }
 |[`PreserveAttributes`](#variant-option-preserveattributes)|`0` or `1`|`0`|Whether file attributes are preserved.|
 |[`ProgressCallback`](#variant-option-progresscallback)|the name of a callback function|none|Reports progress during the copy.|
 
-### Variant Option: Wildcard
+### Variant Option: `Wildcard`
 
 |---|---|
 |`0` <small>(default)</small>|The name or names in `Y` identifies a specific file name.|
-|`1`|The name or names in `Y` that specify the *base name* and *extension* (see [NParts](./nparts.md) ), may also contain the wildcard characters "?" and "*". An asterisk is a substitute for any 0 or more characters in a file name or extension; a question-mark is a substitute for any single character.|
+|`1`|The name or names in `Y` that specify the *base name* and *extension* (see [NParts](./nparts.md) ), can also contain the wildcard characters "?" and "*". An asterisk is a substitute for any 0 or more characters in a file name or extension; a question-mark is a substitute for any single character.|
 
 Note that when `Wildcard` is `1`, element(s) of `R` can be `0`, `1` or `>1`. If `Wildcard` is `0`, elements of `R` are always `1`.
 
 <h4 class="example">Examples</h4>
 
-The source name may include wildcard characters which matches a number of existing files and/or directories. The destination name must be an existing directory. The files and/or directories that match the pattern specified by the source name are copied into the destination directory. If there are no matches, zero copies are made.
+The source name can include wildcard characters which matches a number of existing files and/or directories. The destination name must be an existing directory. The files and/or directories that match the pattern specified by the source name are copied into the destination directory. If there are no matches, zero copies are made.
 ```apl
        ⊃1 ⎕NPARTS ''
 i:/Documents/Dyalog APL-64 17.0 Unicode Files/
@@ -109,7 +109,7 @@ backups/def_uk.dse
 backups/UserCommand20.cache
 ```
 
-### Variant Option: IfExists
+### Variant Option: `IfExists`
 
 The `IfExists` variant option determines what happens when a source file is to be copied to a target file that already exists. It does not apply to directories, only to the files within them.
 
@@ -118,14 +118,14 @@ The `IfExists` variant option determines what happens when a source file is to b
 |`'Error'` <small>(default)</small>|Existing files will not be overwritten and an error will be signalled.|
 |`'Skip'`          |Existing files will not be overwritten but the corresponding copy operation will be skipped (ignored).                                                            |
 |`'Replace'`       |Existing files will be overwritten.                                                                                                                               |
-|`'ReplaceIfNewer'`|Existing files may be overwritten if, and only if, the corresponding source file is newer (more recently modified) than the existing one, otherwise it is skipped.|
+|`'ReplaceIfNewer'`|Existing files can be overwritten if, and only if, the corresponding source file is newer (more recently modified) than the existing one, otherwise it is skipped.|
 
 The following cases cause an error to be signalled regardless of the value of the `IfExists` variant.
 
 - If the source specifies a directory and the destination specifies an existing file.
 - If the source specifies a file and the same base name exists as a sub-directory in the destination.
 
-### Variant Option: PreserveAttributes
+### Variant Option: `PreserveAttributes`
 
 The `PreserveAttributes` variant option (a Boolean) determines whether or not file attributes are preserved. It does not apply to directories, only to files.
 
@@ -133,9 +133,9 @@ The `PreserveAttributes` variant option (a Boolean) determines whether or not fi
 |`0` <small>(default)</small>|file attributes are not preserved.                                                                                                                                                         |
 |`1`|where possible, copied files will be given at least the same modification time as the source. Other file attributes will be preserved as permitted by the operating system and file system.|
 
-Note also that when files are copied across file systems, the different file systems may have different timestamp granularity and the timestamps may not be exactly the same.
+Note also that when files are copied across file systems, the different file systems might have different timestamp granularity and the timestamps might not be exactly the same.
 
-### Variant Option: ProgressCallback
+### Variant Option: `ProgressCallback`
 
 The `ProgressCallback` variant option is described in the [Dyalog Programming Reference Guide](../../../programming-reference-guide/native-files#progress-callbacks). The following is specific to `⎕NCOPY`:
 
@@ -145,8 +145,8 @@ The `ProgressCallback` variant option is described in the [Dyalog Programming Re
 
 - The special directories `.` and `..` can never be copied into an existing directory.
 - If any source name is a symbolic link it is dereferenced; that is, the source or directory it references is copied rather than the link itself.
-- In the result `R`, a directory together with all its contents is counted once. A directory may be partially copied if the `IfExists` option is set to `'Replace'` or `'ReplaceIfNewer'`).
-- If an error occurs during the copy process then processing will immediately stop and an error will be signalled. The operation is not atomic; some items may be copied before this happens. In the event of an error there will be no result and therefore no indication of how many names were copied before the error occurred.
+- In the result `R`, a directory together with all its contents is counted once. A directory might be partially copied if the `IfExists` option is set to `'Replace'` or `'ReplaceIfNewer'`).
+- If an error occurs during the copy process then processing will immediately stop and an error will be signalled. The operation is not atomic; some items might be copied before this happens. In the event of an error there will be no result and therefore no indication of how many names were copied before the error occurred.
 
 <!-- Hidden search keywords -->
 <div style="display: none;">

--- a/language-reference-guide/docs/system-functions/ncreate.md
+++ b/language-reference-guide/docs/system-functions/ncreate.md
@@ -7,22 +7,22 @@ search:
 
 This function creates a new file. Under Windows the file is opened with mode 66 (see [Native File Tie](ntie.md)). Under non-Windows operating systems the current umask will specify the file permissions. The name of the new file is specified by the left argument `X` which must be a simple character vector or scalar containing a valid pathname for the file.
 
-`Y` is 0 or a negative integer value that specifies an (unused) tie number by which the file may subsequently be referred. If `Y` is 0, the system allocates the first (closest to zero) available tie number which is returned as the result.
+`Y` is 0 or a negative integer value that specifies an (unused) tie number by which the file can subsequently be referred. If `Y` is 0, the system allocates the first (closest to zero) available tie number which is returned as the result.
 
 The [shy](../../../programming-reference-guide/introduction/results#shy-results) result of `⎕NCREATE` is the tie number of the new file.
 
 ## Variant Options
 
-`⎕NCREATE` supports two variant options, `Unique` and `IfExists`, summarised in [](#variant-table) and described in detail beneath it. There is no principal option.
+`⎕NCREATE` supports two variant options, `Unique` and `IfExists`, summarised in [](#variantoptionsforncreate) and described in detail beneath it. There is no principal option.
 
-Table: Variant options overview { #variant-table }
+Table: Variant options for `⎕NCREATE` { #variantoptionsforncreate }
 
 |Variant Option|Valid Values|Default|Effect|
 |---|---|---|---|
 |[`Unique`](#variant-option-unique)|`0` or `1`|`0`|Whether the created file is given a uniquely generated name.|
 |[`IfExists`](#variant-option-ifexists)|`'Error'` or `'Replace'`|`'Error'`|What happens when the named file already exists.|
 
-### Variant Option: Unique
+### Variant Option: `Unique`
 
 The `Unique` variant option (a Boolean) specifies whether a uniquely named file is created.
 
@@ -30,7 +30,7 @@ The `Unique` variant option (a Boolean) specifies whether a uniquely named file 
 |`0` <small>(default)</small>|the file named by `X` will be created|
 |`1`|a uniquely named file will be created by extending the base name (see [File Name Parts](nparts.md) ) with random characters. If a unique name cannot be created then an error will be signalled. The actual name of the file can be determined from `⎕NNAMES` or `⎕NINFO` .|
 
-### Variant Option: IfExists
+### Variant Option: `IfExists`
 
 The `IfExists` variant option (a character vector) specifies what happens when the named file already exists.
 

--- a/language-reference-guide/docs/system-functions/ncreate.md
+++ b/language-reference-guide/docs/system-functions/ncreate.md
@@ -13,18 +13,30 @@ The [shy](../../../programming-reference-guide/introduction/results#shy-results)
 
 ## Variant Options
 
-`⎕NCREATE` may be applied using the  Variant operator with the options Unique and IfExists. There is no primary option.
+`⎕NCREATE` supports two variant options, `Unique` and `IfExists`, summarised in [](#variant-table) and described in detail beneath it. There is no principal option.
 
-## Unique Option (Boolean)
+Table: Variant options overview { #variant-table }
+
+|Variant Option|Value|Effect|
+|---|---|---|
+|[`Unique`](#variant-option-unique)|`0` <small>(default)</small> or `1`|Whether the created file is given a uniquely generated name.|
+|[`IfExists`](#variant-option-ifexists)|`'Error'` <small>(default)</small> or `'Replace'`|What happens when the named file already exists.|
+
+### Variant Option: Unique
+
+The `Unique` variant option (a Boolean) specifies whether a uniquely named file is created.
 
 |---|---|
-|0 { .shaded } |the file named by `X` will be created|
+|`0` <small>(default)</small>|the file named by `X` will be created|
 |`1`|a uniquely named file will be created by extending the base name (see [File Name Parts](nparts.md) ) with random characters. If a unique name cannot be created then an error will be signalled. The actual name of the file can be determined from `⎕NNAMES` or `⎕NINFO` .|
 
-## IfExists Option (character vector)
+### Variant Option: IfExists
 
-|------------------|----------------------------------------------------------------------------|
-|Error { .shaded } |`⎕NCREATE` will generate a `FILE NAME ERROR` if the file already exists     |
+The `IfExists` variant option (a character vector) specifies what happens when the named file already exists.
+
+|Value|Description|
+|---|---|
+|`'Error'` <small>(default)</small>|`⎕NCREATE` will generate a `FILE NAME ERROR` if the file already exists|
 |`Replace`         |`⎕NCREATE` will replace an existing file with an empty one of the same name.|
 
 <h2 class="example">Examples</h2>
@@ -57,8 +69,8 @@ FILE NAME ERROR: myfile: Unable to create file ("The file exists.")
 
 ## Notes
 
-- Setting IfExists to `Replace` has no effect when Unique is 1, because the file cannot already exist.
-- The IfExists option does not affect the operation of *slippery ties*.
+- Setting `IfExists` to `'Replace'` has no effect when `Unique` is `1`, because the file cannot already exist.
+- The `IfExists` option does not affect the operation of *slippery ties*.
 
 <!-- Hidden search keywords -->
 <div style="display: none;">

--- a/language-reference-guide/docs/system-functions/ncreate.md
+++ b/language-reference-guide/docs/system-functions/ncreate.md
@@ -28,7 +28,7 @@ The `Unique` variant option (a Boolean) specifies whether a uniquely named file 
 
 |---|---|
 |`0` <small>(default)</small>|the file named by `X` will be created|
-|`1`|a uniquely named file will be created by extending the base name (see [File Name Parts](nparts.md) ) with random characters. If a unique name cannot be created then an error will be signalled. The actual name of the file can be determined from `⎕NNAMES` or `⎕NINFO` .|
+|`1`|a uniquely named file will be created by extending the base name (see [File Name Parts](nparts.md) ) with random characters. If a unique name cannot be created, then an error will be signalled. The actual name of the file can be determined from `⎕NNAMES` or `⎕NINFO` .|
 
 ### Variant Option: `IfExists`
 

--- a/language-reference-guide/docs/system-functions/ncreate.md
+++ b/language-reference-guide/docs/system-functions/ncreate.md
@@ -17,10 +17,10 @@ The [shy](../../../programming-reference-guide/introduction/results#shy-results)
 
 Table: Variant options overview { #variant-table }
 
-|Variant Option|Value|Effect|
-|---|---|---|
-|[`Unique`](#variant-option-unique)|`0` <small>(default)</small> or `1`|Whether the created file is given a uniquely generated name.|
-|[`IfExists`](#variant-option-ifexists)|`'Error'` <small>(default)</small> or `'Replace'`|What happens when the named file already exists.|
+|Variant Option|Valid Values|Default|Effect|
+|---|---|---|---|
+|[`Unique`](#variant-option-unique)|`0` or `1`|`0`|Whether the created file is given a uniquely generated name.|
+|[`IfExists`](#variant-option-ifexists)|`'Error'` or `'Replace'`|`'Error'`|What happens when the named file already exists.|
 
 ### Variant Option: Unique
 

--- a/language-reference-guide/docs/system-functions/ndelete.md
+++ b/language-reference-guide/docs/system-functions/ndelete.md
@@ -13,7 +13,7 @@ The optional left argument `X` is a numeric scalar; valid values are  shown in t
 
 |---|------------------------------------------------------------------------------------------|
 |`0` <small>(default)</small>|Each file or directory with the given name must exist.                                    |
-|`1`|If the file or directory with the given name does not exist then no action is taken. The result `R` may be used to determine whether the file or directory was deleted or not.|
+|`1`|If the file or directory with the given name does not exist then no action is taken. The result `R` can be used to determine whether the file or directory was deleted or not.|
 |`2`|If a name identifies a non-empty directory it, and all its contents, are to be deleted.   |
 |`3`|Combination of 1 and 2.                                                                   |
 
@@ -23,13 +23,13 @@ The optional left argument `X` is a numeric scalar; valid values are  shown in t
 
 `⎕NDELETE` supports one variant option, `Wildcard`, which is the principal option.
 
-### Variant Option: Wildcard
+### Variant Option: `Wildcard`
 
 The `Wildcard` variant option (a Boolean, `0` by default) determines whether the names in `Y` are matched literally or treated as patterns.
 
 |---|---|
 |`0` <small>(default)</small>|The name or names in `Y` identifies a specific file name.|
-|`1`|The name or names in `Y` that specify the *base name* and *extension* (see [File Name Parts](./nparts.md)), may also contain the wildcard characters "?" and "*". An asterisk is a substitute for any 0 or more characters in a file name or extension; a question-mark is a substitute for any single character.|
+|`1`|The name or names in `Y` that specify the *base name* and *extension* (see [File Name Parts](./nparts.md)), can also contain the wildcard characters "?" and "*". An asterisk is a substitute for any 0 or more characters in a file name or extension; a question-mark is a substitute for any single character.|
 
 Note that when `Wildcard` is `1`, element(s) of `R` can be `0` or `>1`. If `Wildcard` is `0`, elements of `R` are always `1`.
 
@@ -77,7 +77,7 @@ If the file is in use or the current user is not authorised to delete it, `⎕ND
 
 ## Note
 
-When multiple names are specified they are processed in the order given. If an error occurs at any point whilst deleting files or directories, processing will immediately stop and an error will be signalled. The operation is not atomic; the directory contents may be partially deleted before this happens. In the event of an error there will be no result and therefore no indication of how many files were deleted before the error occurred.
+When multiple names are specified they are processed in the order given. If an error occurs at any point whilst deleting files or directories, processing will immediately stop and an error will be signalled. The operation is not atomic; the directory contents might be partially deleted before this happens. In the event of an error there will be no result and therefore no indication of how many files were deleted before the error occurred.
 
 <!-- Hidden search keywords -->
 <div style="display: none;">

--- a/language-reference-guide/docs/system-functions/ndelete.md
+++ b/language-reference-guide/docs/system-functions/ndelete.md
@@ -13,7 +13,7 @@ The optional left argument `X` is a numeric scalar; valid values are  shown in t
 
 |---|------------------------------------------------------------------------------------------|
 |`0` <small>(default)</small>|Each file or directory with the given name must exist.                                    |
-|`1`|If the file or directory with the given name does not exist then no action is taken. The result `R` can be used to determine whether the file or directory was deleted or not.|
+|`1`|If the file or directory with the given name does not exist, then no action is taken. The result `R` can be used to determine whether the file or directory was deleted or not.|
 |`2`|If a name identifies a non-empty directory it, and all its contents, are to be deleted.   |
 |`3`|Combination of 1 and 2.                                                                   |
 

--- a/language-reference-guide/docs/system-functions/ndelete.md
+++ b/language-reference-guide/docs/system-functions/ndelete.md
@@ -12,7 +12,7 @@ This function deletes files and directories.
 The optional left argument `X` is a numeric scalar; valid values are  shown in the following table. If omitted, its default value is 0.
 
 |---|------------------------------------------------------------------------------------------|
-|0 { .shaded } |Each file or directory with the given name must exist.                                    |
+|`0` <small>(default)</small>|Each file or directory with the given name must exist.                                    |
 |`1`|If the file or directory with the given name does not exist then no action is taken. The result `R` may be used to determine whether the file or directory was deleted or not.|
 |`2`|If a name identifies a non-empty directory it, and all its contents, are to be deleted.   |
 |`3`|Combination of 1 and 2.                                                                   |
@@ -21,15 +21,17 @@ The optional left argument `X` is a numeric scalar; valid values are  shown in t
 
 ## Variant Options
 
-`⎕NDELETE` may be applied using the  Variant operator with the Wildcard option.
+`⎕NDELETE` supports one variant option, `Wildcard`, which is the principal option.
 
-## Wildcard Option (Boolean)
+### Variant Option: Wildcard
+
+The `Wildcard` variant option (a Boolean, `0` by default) determines whether the names in `Y` are matched literally or treated as patterns.
 
 |---|---|
-|0 { .shaded } |The name or names in `Y` identifies a specific file name.|
+|`0` <small>(default)</small>|The name or names in `Y` identifies a specific file name.|
 |`1`|The name or names in `Y` that specify the *base name* and *extension* (see [File Name Parts](./nparts.md)), may also contain the wildcard characters "?" and "*". An asterisk is a substitute for any 0 or more characters in a file name or extension; a question-mark is a substitute for any single character.|
 
-Note that when Wildcard is 1, element(s) of `R` can  be 0 or `>1`. If Wildcard is 0, elements of `R` are always 1.
+Note that when `Wildcard` is `1`, element(s) of `R` can be `0` or `>1`. If `Wildcard` is `0`, elements of `R` are always `1`.
 
 If `Y` specifies the name of a  symbolic link, `⎕NDELETE` deletes that symbolic link;   the target of the symbolic link is unaffected.
 

--- a/language-reference-guide/docs/system-functions/nexists.md
+++ b/language-reference-guide/docs/system-functions/nexists.md
@@ -15,13 +15,13 @@ If `Y` specifies a single name, the result `R` is a scalar 1 if a file or direct
 
 `⎕NEXISTS` supports one variant option, `Wildcard`, which is the principal option.
 
-### Variant Option: Wildcard
+### Variant Option: `Wildcard`
 
 The `Wildcard` variant option (a Boolean, `0` by default) determines whether the names in `Y` are matched literally or treated as patterns.
 
 |---|---|
 |`0` <small>(default)</small>|The name or names in `Y` identifies a specific file name.|
-|`1`|The name or names in `Y` that specify the *base name* and *extension* (see [NParts](./nparts.md) ), may also contain the wildcard characters "?" and "*". An asterisk is a substitute for any 0 or more characters in a file name or extension; a question-mark is a substitute for any single character.|
+|`1`|The name or names in `Y` that specify the *base name* and *extension* (see [NParts](./nparts.md) ), can also contain the wildcard characters "?" and "*". An asterisk is a substitute for any 0 or more characters in a file name or extension; a question-mark is a substitute for any single character.|
 
 If the `Wildcard` option is `1`, `R` indicates whether or not one or more matches to the corresponding pattern in `Y` exist.
 

--- a/language-reference-guide/docs/system-functions/nexists.md
+++ b/language-reference-guide/docs/system-functions/nexists.md
@@ -13,15 +13,17 @@ If `Y` specifies a single name, the result `R` is a scalar 1 if a file or direct
 
 ## Variant Options
 
-`⎕NEXISTS` may be applied using the  Variant operator with the Wildcard option.
+`⎕NEXISTS` supports one variant option, `Wildcard`, which is the principal option.
 
-## Wildcard Option (Boolean)
+### Variant Option: Wildcard
+
+The `Wildcard` variant option (a Boolean, `0` by default) determines whether the names in `Y` are matched literally or treated as patterns.
 
 |---|---|
-|0|The name or names in `Y` identifies a specific file name.|
+|`0` <small>(default)</small>|The name or names in `Y` identifies a specific file name.|
 |`1`|The name or names in `Y` that specify the *base name* and *extension* (see [NParts](./nparts.md) ), may also contain the wildcard characters "?" and "*". An asterisk is a substitute for any 0 or more characters in a file name or extension; a question-mark is a substitute for any single character.|
 
-If the Wildcard option is 1, `R` indicates whether or not one or more matches to the corresponding pattern in `Y` exist.
+If the `Wildcard` option is `1`, `R` indicates whether or not one or more matches to the corresponding pattern in `Y` exist.
 
 <h2 class="example">Example</h2>
 ```apl

--- a/language-reference-guide/docs/system-functions/ninfo.md
+++ b/language-reference-guide/docs/system-functions/ninfo.md
@@ -20,7 +20,7 @@ If `X` is not defined, it is assumed to be `0`.
 
 |`X`|Property|Default|Settable|
 |---|---|---|---|
-|`0`|Name of the file or directory, as a character vector. If `Y` is a tie number then this is the name which the file was tied.|&nbsp;|No|
+|`0`|Name of the file or directory, as a character vector. If `Y` is a tie number, then this is the name which the file was tied.|&nbsp;|No|
 |`1`|Type, as a numeric scalar: 0=Not known 1=Directory 2=Regular file 3=Character device 4=Symbolic link (only when `Follow` is `0`) 5=Block device 6=FIFO (not Windows) 7=Socket (not Windows)|`0`|No|
 |`2`|Size in bytes, as a numeric scalar|`0`|Yes|
 |`3`|Last modification time, as a timestamp in `⎕TS` format|`7⍴0`|No|
@@ -55,7 +55,7 @@ The returned value `R` has the same shape as `X` (if the `Wildcard` variant opti
 
 If a property value cannot be obtained, the default value (shown in the table above) is returned for that property.
 
-If the `Wildcard` option is not enabled (the default) then `Y` specifies exactly one file or directory and must exist. In this case each element in `R` is a single property value for that file. If the name in `Y` does not exist, the function signals an error. On non-Windows platforms "*" and "?" are treated as normal characters. On Microsoft Windows an error will be signalled since neither are valid characters for file or directory names.
+If the `Wildcard` option is not enabled (the default), then `Y` specifies exactly one file or directory and must exist. In this case each element in `R` is a single property value for that file. If the name in `Y` does not exist, the function signals an error. On non-Windows platforms "*" and "?" are treated as normal characters. On Microsoft Windows an error will be signalled since neither are valid characters for file or directory names.
 
 If the `Wildcard` option is enabled, zero or more files and/or directories might match the pattern in `Y`. In this case each element in `R` is a vector of property values for each of the files. Note that no error will be signalled if no files match the pattern.
 

--- a/language-reference-guide/docs/system-functions/ninfo.md
+++ b/language-reference-guide/docs/system-functions/ninfo.md
@@ -102,15 +102,15 @@ When using the `Wildcard` option, matching of names is done case insensitively o
 
 Table: Variant options overview { #variant-table }
 
-|Variant Option|Valid Values|Default|Effect|
-|---|---|---|---|
-|[`Wildcard`](#variant-option-wildcard)<br><small>principal</small>|`0`|`0`|The names in `Y` identify specific files.|
-|_-                                    -_|`1`||The names in `Y` can contain the wildcard characters `?` and `*`.|
-|[`Recurse`](#variant-option-recurse)|`0`|`0`|Only the specified directory is searched.|
-|_-                                    -_|`1`||The specified directory and its sub-directories are searched.|
-|[`Follow`](#variant-option-follow)|`1`|`1`|For a symbolic link, the target's properties are reported.|
-|_-                                    -_|`0`||The symbolic link's own properties are reported.|
-|[`ProgressCallback`](#variant-option-progresscallback)|&nbsp;||A function is called periodically during a long operation.|
+|Variant Option|Valid Values|Effect|
+|---|---|---|
+|[`Wildcard`](#variant-option-wildcard)<br><small>principal</small>|`0` (Default)|The names in `Y` identify specific files.|
+|_-                                    -_|`1`|The names in `Y` can contain the wildcard characters `?` and `*`.|
+|[`Recurse`](#variant-option-recurse)|`0` (Default)|Only the specified directory is searched.|
+|_-                                    -_|`1`|The specified directory and its sub-directories are searched.|
+|[`Follow`](#variant-option-follow)|`1` (Default)|For a symbolic link, the target's properties are reported.|
+|_-                                    -_|`0`|The symbolic link's own properties are reported.|
+|[`ProgressCallback`](#variant-option-progresscallback)|the name of a callback function|A function is called periodically during a long operation.|
 
 ### Variant Option: Wildcard
 

--- a/language-reference-guide/docs/system-functions/ninfo.md
+++ b/language-reference-guide/docs/system-functions/ninfo.md
@@ -5,7 +5,7 @@ search:
 
 # <span>Native File Information</span> `R←{X}⎕NINFO Y`{{key}}
 
-This function queries or sets information about one or more files or directories. `Y` may be:
+This function queries or sets information about one or more files or directories. `Y` can be:
 
 - a numeric scalar containing the tie number of a native file
 - a character vector or scalar containing a file or directory name that conforms to the naming rules of the host Operating System.
@@ -21,7 +21,7 @@ If `X` is not defined, it is assumed to be `0`.
 |`X`|Property|Default|Settable|
 |---|---|---|---|
 |`0`|Name of the file or directory, as a character vector. If `Y` is a tie number then this is the name which the file was tied.|&nbsp;|No|
-|`1`|Type, as a numeric scalar: 0=Not known 1=Directory 2=Regular file 3=Character device 4=Symbolic link (only when Follow is 0) 5=Block device 6=FIFO (not Windows) 7=Socket (not Windows)|`0`|No|
+|`1`|Type, as a numeric scalar: 0=Not known 1=Directory 2=Regular file 3=Character device 4=Symbolic link (only when `Follow` is `0`) 5=Block device 6=FIFO (not Windows) 7=Socket (not Windows)|`0`|No|
 |`2`|Size in bytes, as a numeric scalar|`0`|Yes|
 |`3`|Last modification time, as a timestamp in `⎕TS` format|`7⍴0`|No|
 |`4`|Owner user id, as a character vector – on Windows a SID, on other platforms a numeric userid converted to character format|`''`|No|
@@ -38,7 +38,7 @@ If `X` is not defined, it is assumed to be `0`.
 |`15`|Creation time if available, otherwise the time of the last file status change  as a UTC Dyalog Date  Number.|`0`|Windows only|
 
 !!! Info "Information"
-    Of the file timestamps which are reported by the operating system, only the last modification time should be considered reliable and portable. Neither the access time or creation time are well supported across all platforms. Furthermore, they may not accurately reflect the actual time that the operation occurred.
+    Of the file timestamps which are reported by the operating system, only the last modification time should be considered reliable and portable. Neither the access time or creation time are well supported across all platforms. Furthermore, they might not accurately reflect the actual time that the operation occurred.
 
 The values in `X` are processed in ravel order. Duplicates are allowed.
 
@@ -55,16 +55,16 @@ The returned value `R` has the same shape as `X` (if the `Wildcard` variant opti
 
 If a property value cannot be obtained, the default value (shown in the table above) is returned for that property.
 
-If the Wildcard option is not enabled (the default) then `Y` specifies exactly one file or directory and must exist. In this case each element in `R` is a single property value for that file. If the name in `Y` does not exist, the function signals an error. On non-Windows platforms "*" and "?" are treated as normal characters. On Microsoft Windows an error will be signalled since neither are valid characters for file or directory names.
+If the `Wildcard` option is not enabled (the default) then `Y` specifies exactly one file or directory and must exist. In this case each element in `R` is a single property value for that file. If the name in `Y` does not exist, the function signals an error. On non-Windows platforms "*" and "?" are treated as normal characters. On Microsoft Windows an error will be signalled since neither are valid characters for file or directory names.
 
-If the Wildcard option is enabled, zero or more files and/or directories may match the pattern in `Y`. In this case each element in `R` is a vector of property values for each of the files. Note that no error will be signalled if no files match the pattern.
+If the `Wildcard` option is enabled, zero or more files and/or directories might match the pattern in `Y`. In this case each element in `R` is a vector of property values for each of the files. Note that no error will be signalled if no files match the pattern.
 
 When using the `Wildcard` option, matching of names is done case insensitively on Windows and macOS, and case sensitively on other platforms. The names '.' and '..' are excluded from any matches. The order in which the names match is not defined.
 
 !!! Warning "Warning"
     On platforms other than Microsoft Windows, file names are exposed by the operating system using UTF-8 encoding, which Dyalog translates internally to characters.
     
-    In the Unicode Edition, if the UTF-8 encoding is invalid, Dyalog replaces each offending byte with a unique Unicode symbol (in the *Low Surrogate Area* of the Unicode charts) that is mapped back to the original byte by the other system functions (including `⎕NTIE` and `⎕NDELETE`) that take native file names as arguments. The display of a file name containing these mapped bytes may appear strange.
+    In the Unicode Edition, if the UTF-8 encoding is invalid, Dyalog replaces each offending byte with a unique Unicode symbol (in the *Low Surrogate Area* of the Unicode charts) that is mapped back to the original byte by the other system functions (including `⎕NTIE` and `⎕NDELETE`) that take native file names as arguments. The display of a file name containing these mapped bytes might appear strange.
     
     In the Classic Edition, offending bytes are replaced by the `?` symbol, which means that the names reported do not accurately identify the files.
 
@@ -98,9 +98,9 @@ When using the `Wildcard` option, matching of names is done case insensitively o
 
 ## Variant Options
 
-`⎕NINFO` is controlled by four variant options, summarised in [](#variant-table) and described in detail beneath it.
+`⎕NINFO` is controlled by four variant options, summarised in [](#variantoptionsforninfo) and described in detail beneath it.
 
-Table: Variant options overview { #variant-table }
+Table: Variant options for `⎕NINFO` { #variantoptionsforninfo }
 
 |Variant Option|Valid Values|Effect|
 |---|---|---|
@@ -112,14 +112,14 @@ Table: Variant options overview { #variant-table }
 |_-                                    -_|`0`|The symbolic link's own properties are reported.|
 |[`ProgressCallback`](#variant-option-progresscallback)|the name of a callback function|A function is called periodically during a long operation.|
 
-### Variant Option: Wildcard
+### Variant Option: `Wildcard`
 
 `Wildcard`, the principal option, is Boolean:
 
 |Value|Effect|
 |---|---|
 |`0` (default)|The name or names in `Y` identify a specific file name.|
-|`1`|The name or names in `Y` that specify the *base name* and *extension* (see [NParts](nparts.md)) may also contain the wildcard characters `?` and `*`. An asterisk is a substitute for any 0 or more characters in a file name or extension; a question-mark is a substitute for any single character.|
+|`1`|The name or names in `Y` that specify the *base name* and *extension* (see [NParts](nparts.md)) can also contain the wildcard characters `?` and `*`. An asterisk is a substitute for any 0 or more characters in a file name or extension; a question-mark is a substitute for any single character.|
 
 <h4 class="example">Examples</h4>
 
@@ -159,7 +159,7 @@ The following expression "touches" files, that is, it sets their last modificati
 └───────────────────────┘
 ```
 
-### Variant Option: Recurse
+### Variant Option: `Recurse`
 
 |Value|Effect|
 |---|---|
@@ -202,7 +202,7 @@ The following expression will return all Microsoft Word documents (`.docx` and `
      (⎕NINFO⍠('Recurse' 1)('Wildcard' 1))'*.docx' '*.doc'
 ```
 
-### Variant Option: Follow
+### Variant Option: `Follow`
 
 `Follow` is Boolean:
 
@@ -211,7 +211,7 @@ The following expression will return all Microsoft Word documents (`.docx` and `
 |`0`|The properties reported are those of the symbolic link itself.|
 |`1` (default)|The properties reported for a symbolic link are those of the target of the symbolic link.|
 
-### Variant Option: ProgressCallback
+### Variant Option: `ProgressCallback`
 
 The `ProgressCallback` variant option is described in the [Dyalog Programming Reference Guide](../../../programming-reference-guide/native-files#progress-callbacks). The following is specific to `⎕NINFO`:
 

--- a/language-reference-guide/docs/system-functions/ninfo.md
+++ b/language-reference-guide/docs/system-functions/ninfo.md
@@ -39,7 +39,7 @@ If `X` is not defined, it is assumed to be `0`.
 
 The values in `X` are processed in ravel order. Duplicates are allowed.
 
-The returned value `R` has the same shape as `X` (if the **Wildcard** variant option has been specified, the depth will change – see below). The content of `R` depends on whether properties were queried or set:
+The returned value `R` has the same shape as `X` (if the `Wildcard` variant option has been specified, the depth will change – see below). The content of `R` depends on whether properties were queried or set:
 
 - If properties were queried:
     - each element of `R` is the value of the property identified by the corresponding value of `X`.
@@ -56,35 +56,124 @@ If the Wildcard option is not enabled (the default) then `Y` specifies exactly o
 
 If the Wildcard option is enabled, zero or more files and/or directories may match the pattern in `Y`. In this case each element in `R` is a vector of property values for each of the files. Note that no error will be signalled if no files match the pattern.
 
-When using the **Wildcard** option, matching of names is done case insensitively on Windows and macOS, and case sensitively on other platforms. The names '.' and '..' are excluded from any matches. The order in which the names match is not defined.
+When using the `Wildcard` option, matching of names is done case insensitively on Windows and macOS, and case sensitively on other platforms. The names '.' and '..' are excluded from any matches. The order in which the names match is not defined.
 
 ## Variant Options
 
-`⎕NINFO` may be applied using the _variant_ operator with the options **Wildcard** (the Principal option), **Recurse**, **Follow** and **ProgressCallback**.
+`⎕NINFO` is controlled by four variant options, summarised in [](#variant-table) and described in detail beneath it.
 
-### Wildcard Option (Boolean)
+Table: Variant options overview { #variant-table }
 
+|Variant Option|Value|Effect|
+|---|:-:|---|
+|[`Wildcard`](#variant-option-wildcard)<br><small>principal</small>|`0` <small>(default)</small>|The names in `Y` identify specific files.|
+|_-                                    -_|`1`|The names in `Y` can contain the wildcard characters `?` and `*`.|
+|[`Recurse`](#variant-option-recurse)|`0` <small>(default)</small>|Only the specified directory is searched.|
+|_-                                    -_|`1`|The specified directory and its sub-directories are searched.|
+|[`Follow`](#variant-option-follow)|`1` <small>(default)</small>|For a symbolic link, the target's properties are reported.|
+|_-                                    -_|`0`|The symbolic link's own properties are reported.|
+|[`ProgressCallback`](#variant-option-progresscallback)|&nbsp;|A function is called periodically during a long operation.|
+
+### Variant Option: Wildcard
+
+`Wildcard`, the principal option, is Boolean:
+
+|Value|Effect|
 |---|---|
-|0 { .shaded } |The name or names in `Y` identifies a specific file name.|
-|`1`|The name or names in `Y` that specify the *base name* and *extension* (see [NParts](./nparts.md) ), may also contain the wildcard characters "?" and "*". An asterisk is a substitute for any 0 or more characters in a file name or extension; a question-mark is a substitute for any single character.|
+|`0` (default)|The name or names in `Y` identify a specific file name.|
+|`1`|The name or names in `Y` that specify the *base name* and *extension* (see [NParts](nparts.md)) may also contain the wildcard characters `?` and `*`. An asterisk is a substitute for any 0 or more characters in a file name or extension; a question-mark is a substitute for any single character.|
 
-### Recurse Option
+<h4 class="example">Examples</h4>
 
+```apl
+      ⊃1⎕NPARTS '' ⍝ current working directory
+c:/Users/Pete/
+      (⎕NINFO⍠1)'D*'
+┌─────────────────────────────────────┐
+│┌───────┬─────────┬─────────┬───────┐│
+││Desktop│Documents│Downloads│Dropbox││
+│└───────┴─────────┴─────────┴───────┘│
+└─────────────────────────────────────┘
+
+```
+
+```apl
+      (⎕NINFO⍠1)'Documents/*.zip'
+┌──────────────────────┐
+│┌────────────────────┐│
+││Documents/dyalog.zip││
+│└────────────────────┘│
+└──────────────────────┘
+
+```
+
+```apl
+      ⊃1⎕NPARTS '' ⍝ current working directory
+C:/Users/Pete/Documents/Dyalog APL-64 16.0 Unicode Files/
+      (⎕NINFO⍠1)'*.*'
+┌──────────────────────────────────────────────────────┐
+│┌───────────┬──────────┬─────────┬───────────────────┐│
+││default.dlf│def_uk.dse│jsonx.dws│UserCommand20.cache││
+│└───────────┴──────────┴─────────┴───────────────────┘│
+└──────────────────────────────────────────────────────┘
+
+```
+
+### Variant Option: Recurse
+
+|Value|Effect|
 |---|---|
-|0 { .shaded } |the name(s) in `Y` are searched for only in the corresponding specified directory.|
-|`1`|the name(s) in `Y` are searched for in the corresponding specified directory as well as all sub-directories. If **Wildcard** is also 1, the wild card search is performed recursively.|
-|`1 n`|the name(s) in `Y` are searched for in the corresponding specified directory as well as its sub-directories to the n <sup>th</sup> -level sub-directory. If n is 0, no sub-directories are searched. If n is `¯1` all sub-directories are searched.|
-|`2 (n)`|same as 1 but if any unreadable directories are encountered they are skipped (whereas if **Recurse** is `1 (n)` , `⎕NINFO` stops and generates an error).|
+|`0` (default)|The name(s) in `Y` are searched for only in the corresponding specified directory.|
+|`1`|The name(s) in `Y` are searched for in the corresponding specified directory as well as all sub-directories. If `Wildcard` is also `1`, the wildcard search is performed recursively.|
+|`1 n`|The name(s) in `Y` are searched for in the corresponding specified directory as well as its sub-directories to the `n`th-level sub-directory. If `n` is `0`, no sub-directories are searched. If `n` is `¯1`, all sub-directories are searched.|
+|`2 (n)`|Same as `1` but if any unreadable directories are encountered they are skipped (whereas if `Recurse` is `1 (n)`, `⎕NINFO` stops and generates an error).|
 
-### Follow Option (Boolean)
+<h4 class="example">Examples</h4>
 
-|---|----------------------------------------------------------------------------------------|
-|`0`|the properties reported are those of the symbolic link itself                           |
-|1 { .shaded } |the properties reported for a symbolic link are those of the target of the symbolic link|
+```apl
+      ⊢ ⎕MKDIR 'd1' 'd2'
+1 1
+      'a'∘⎕NPUT¨'find' 'd1/find' 'd1/nofind' 'd2/find'
+      (⎕NINFO⍠'Recurse' 1)'find'
+┌──────────────────────┐
+│┌───────┬───────┬────┐│
+││d1/find│d2/find│find││
+│└───────┴───────┴────┘│
+└──────────────────────┘
+```
 
-### ProgressCallback Option
+The next set of examples illustrates the use of the `Recurse` variant option to limit the sub-directory depth.
 
-The **ProgressCallback** variant option is described in the [Dyalog Programming Reference Guide](../../../programming-reference-guide/native-files#progress-callbacks). The following is specific to `⎕NINFO`:
+```apl
+      Y←'d:\bouzouki\*.*'
+      ⍴⊃0(⎕NINFO⍠('Wildcard' 1)('Recurse' 0))Y
+355
+      ⍴⊃0(⎕NINFO⍠('Wildcard' 1)('Recurse' (1 0)))Y
+355
+      ⍴⊃0(⎕NINFO⍠('Wildcard' 1)('Recurse' (1 1)))Y
+1333
+      ⍴⊃0(⎕NINFO⍠('Wildcard' 1)('Recurse' (1 3)))Y
+4223
+```
+
+The following expression will return all Microsoft Word documents (`.docx` and `.doc`) in the current directory, searching recursively through any sub-directories:
+
+```apl
+     (⎕NINFO⍠('Recurse' 1)('Wildcard' 1))'*.docx' '*.doc'
+```
+
+### Variant Option: Follow
+
+`Follow` is Boolean:
+
+|Value|Effect|
+|---|---|
+|`0`|The properties reported are those of the symbolic link itself.|
+|`1` (default)|The properties reported for a symbolic link are those of the target of the symbolic link.|
+
+### Variant Option: ProgressCallback
+
+The `ProgressCallback` variant option is described in the [Dyalog Programming Reference Guide](../../../programming-reference-guide/native-files#progress-callbacks). The following is specific to `⎕NINFO`:
 
 * The first element of the right argument to the callback function is the character vector `'⎕NINFO'`.
 * The third element of the right argument (the information namespace) contains an extra field named `Info`, which is a vector with the same length as the `Last` field. Each element of the `Info` vector contains the information requested by the `⎕NINFO` call for the corresponding filename in `Last`.
@@ -98,6 +187,7 @@ In the Unicode Edition, if the UTF-8 encoding is invalid, Dyalog replaces each o
 In the Classic Edition, offending bytes are replaced by the `?` symbol, which means that the names reported do not accurately identify the files.
 
 <h2 class="example">Examples</h2>
+
 ```apl
 
       (0 1 2) ⎕NINFO 'c:/Users/Pete/Documents'
@@ -108,26 +198,7 @@ In the Classic Edition, offending bytes are replaced by the `?` symbol, which me
 └∊───────────────────────────────────┘
 
 ```
-```apl
-      ⊃1⎕NPARTS '' ⍝ current working directory
-c:/Users/Pete/
-      (⎕NINFO⍠1)'D*'
-┌─────────────────────────────────────┐
-│┌───────┬─────────┬─────────┬───────┐│
-││Desktop│Documents│Downloads│Dropbox││
-│└───────┴─────────┴─────────┴───────┘│
-└─────────────────────────────────────┘
 
-```
-```apl
-      (⎕NINFO⍠1)'Documents/*.zip'
-┌──────────────────────┐
-│┌────────────────────┐│
-││Documents/dyalog.zip││
-│└────────────────────┘│
-└──────────────────────┘
-
-```
 ```apl
       ⍪ (0,⍳6) ⎕NINFO 'Documents/dyalog.zip'
 ┌──────────────────────────────────────────────┐
@@ -146,46 +217,6 @@ c:/Users/Pete/
 │0                                             │
 └──────────────────────────────────────────────┘
 
-```
-```apl
-      ⊃1⎕NPARTS '' ⍝ current working directory
-C:/Users/Pete/Documents/Dyalog APL-64 16.0 Unicode Files/
-      (⎕NINFO⍠1)'*.*'
-┌──────────────────────────────────────────────────────┐
-│┌───────────┬──────────┬─────────┬───────────────────┐│
-││default.dlf│def_uk.dse│jsonx.dws│UserCommand20.cache││
-│└───────────┴──────────┴─────────┴───────────────────┘│
-└──────────────────────────────────────────────────────┘
-
-```
-```apl
-      ⊢ ⎕MKDIR 'd1' 'd2'
-1 1
-      'a'∘⎕NPUT¨'find' 'd1/find' 'd1/nofind' 'd2/find'
-      (⎕NINFO⍠'Recurse' 1)'find'
-┌──────────────────────┐
-│┌───────┬───────┬────┐│
-││d1/find│d2/find│find││
-│└───────┴───────┴────┘│
-└──────────────────────┘
-```
-
-The next set of examples illustrates the use of the **Recurse** variant option to limit the sub-directory depth.
-```apl
-      Y←'d:\bouzouki\*.*'
-      ⍴⊃0(⎕NINFO⍠('Wildcard' 1)('Recurse' 0))Y
-355
-      ⍴⊃0(⎕NINFO⍠('Wildcard' 1)('Recurse' (1 0)))Y
-355
-      ⍴⊃0(⎕NINFO⍠('Wildcard' 1)('Recurse' (1 1)))Y
-1333
-      ⍴⊃0(⎕NINFO⍠('Wildcard' 1)('Recurse' (1 3)))Y
-4223
-```
-
-The following expression will return all Microsoft Word documents (`.docx` and `.doc`) in the current directory, searching recursively through any sub-directories:
-```apl
-     (⎕NINFO⍠('Recurse' 1)('Wildcard' 1))'*.docx' '*.doc'
 ```
 
 The following expression "touches" files, that is, it sets their last modification time to the current UTC time:

--- a/language-reference-guide/docs/system-functions/ninfo.md
+++ b/language-reference-guide/docs/system-functions/ninfo.md
@@ -37,6 +37,9 @@ If `X` is not defined, it is assumed to be `0`.
 |`14`|Last access time, as a UTC Dyalog Date Number, when available.|`0`|Yes|
 |`15`|Creation time if available, otherwise the time of the last file status change  as a UTC Dyalog Date  Number.|`0`|Windows only|
 
+!!! Info "Information"
+    Of the file timestamps which are reported by the operating system, only the last modification time should be considered reliable and portable. Neither the access time or creation time are well supported across all platforms. Furthermore, they may not accurately reflect the actual time that the operation occurred.
+
 The values in `X` are processed in ravel order. Duplicates are allowed.
 
 The returned value `R` has the same shape as `X` (if the `Wildcard` variant option has been specified, the depth will change – see below). The content of `R` depends on whether properties were queried or set:
@@ -57,6 +60,41 @@ If the Wildcard option is not enabled (the default) then `Y` specifies exactly o
 If the Wildcard option is enabled, zero or more files and/or directories may match the pattern in `Y`. In this case each element in `R` is a vector of property values for each of the files. Note that no error will be signalled if no files match the pattern.
 
 When using the `Wildcard` option, matching of names is done case insensitively on Windows and macOS, and case sensitively on other platforms. The names '.' and '..' are excluded from any matches. The order in which the names match is not defined.
+
+!!! Warning "Warning"
+    On platforms other than Microsoft Windows, file names are exposed by the operating system using UTF-8 encoding, which Dyalog translates internally to characters.
+    
+    In the Unicode Edition, if the UTF-8 encoding is invalid, Dyalog replaces each offending byte with a unique Unicode symbol (in the *Low Surrogate Area* of the Unicode charts) that is mapped back to the original byte by the other system functions (including `⎕NTIE` and `⎕NDELETE`) that take native file names as arguments. The display of a file name containing these mapped bytes may appear strange.
+    
+    In the Classic Edition, offending bytes are replaced by the `?` symbol, which means that the names reported do not accurately identify the files.
+
+<h2 class="example">Examples</h2>
+
+```apl
+      (0 1 2) ⎕NINFO 'c:/Users/Pete/Documents'
+┌→───────────────────────────────────┐
+│ ┌→──────────────────────┐          │
+│ │c:/Users/Pete/Documents│ 1 163840 │
+│ └───────────────────────┘          │
+└∊───────────────────────────────────┘
+
+      ⍪ (0,⍳6) ⎕NINFO 'Documents/dyalog.zip'
+┌──────────────────────────────────────────────┐
+│Documents/dyalog.zip                          │
+├──────────────────────────────────────────────┤
+│2                                             │
+├──────────────────────────────────────────────┤
+│3429284                                       │
+├──────────────────────────────────────────────┤
+│2016 1 22 16 43 58 0                          │
+├──────────────────────────────────────────────┤
+│S-1-5-21-2756282986-1198856910-2233986399-1001│
+├──────────────────────────────────────────────┤
+│HP/Pete                                       │
+├──────────────────────────────────────────────┤
+│0                                             │
+└──────────────────────────────────────────────┘
+```
 
 ## Variant Options
 
@@ -95,9 +133,6 @@ c:/Users/Pete/
 │└───────┴─────────┴─────────┴───────┘│
 └─────────────────────────────────────┘
 
-```
-
-```apl
       (⎕NINFO⍠1)'Documents/*.zip'
 ┌──────────────────────┐
 │┌────────────────────┐│
@@ -105,9 +140,6 @@ c:/Users/Pete/
 │└────────────────────┘│
 └──────────────────────┘
 
-```
-
-```apl
       ⊃1⎕NPARTS '' ⍝ current working directory
 C:/Users/Pete/Documents/Dyalog APL-64 16.0 Unicode Files/
       (⎕NINFO⍠1)'*.*'
@@ -116,7 +148,15 @@ C:/Users/Pete/Documents/Dyalog APL-64 16.0 Unicode Files/
 ││default.dlf│def_uk.dse│jsonx.dws│UserCommand20.cache││
 │└───────────┴──────────┴─────────┴───────────────────┘│
 └──────────────────────────────────────────────────────┘
+```
 
+The following expression "touches" files, that is, it sets their last modification time to the current UTC time:
+
+```apl
+      (⊂13(1 ⎕DT'Z'))(⎕NINFO⍠1)'*.txt'
+┌───────────────────────┐
+│45719.53226 45719.53226│
+└───────────────────────┘
 ```
 
 ### Variant Option: Recurse
@@ -177,59 +217,6 @@ The `ProgressCallback` variant option is described in the [Dyalog Programming Re
 
 * The first element of the right argument to the callback function is the character vector `'⎕NINFO'`.
 * The third element of the right argument (the information namespace) contains an extra field named `Info`, which is a vector with the same length as the `Last` field. Each element of the `Info` vector contains the information requested by the `⎕NINFO` call for the corresponding filename in `Last`.
-
-## Note
-
-On platforms other than Microsoft Windows, file names are exposed by the operating system using UTF-8 encoding, which Dyalog translates internally to characters.
-
-In the Unicode Edition, if the UTF-8 encoding is invalid, Dyalog replaces each offending byte with a unique Unicode symbol (in the *Low Surrogate Area* of the Unicode charts) that is mapped back to the original byte by the other system functions (including `⎕NTIE` and `⎕NDELETE`) that take native file names as arguments. The display of a file name containing these mapped bytes may appear strange.
-
-In the Classic Edition, offending bytes are replaced by the `?` symbol, which means that the names reported do not accurately identify the files.
-
-<h2 class="example">Examples</h2>
-
-```apl
-
-      (0 1 2) ⎕NINFO 'c:/Users/Pete/Documents'
-┌→───────────────────────────────────┐
-│ ┌→──────────────────────┐          │
-│ │c:/Users/Pete/Documents│ 1 163840 │
-│ └───────────────────────┘          │
-└∊───────────────────────────────────┘
-
-```
-
-```apl
-      ⍪ (0,⍳6) ⎕NINFO 'Documents/dyalog.zip'
-┌──────────────────────────────────────────────┐
-│Documents/dyalog.zip                          │
-├──────────────────────────────────────────────┤
-│2                                             │
-├──────────────────────────────────────────────┤
-│3429284                                       │
-├──────────────────────────────────────────────┤
-│2016 1 22 16 43 58 0                          │
-├──────────────────────────────────────────────┤
-│S-1-5-21-2756282986-1198856910-2233986399-1001│
-├──────────────────────────────────────────────┤
-│HP/Pete                                       │
-├──────────────────────────────────────────────┤
-│0                                             │
-└──────────────────────────────────────────────┘
-
-```
-
-The following expression "touches" files, that is, it sets their last modification time to the current UTC time:
-
-```apl
-      (⊂13(1 ⎕DT'Z'))(⎕NINFO⍠1)'*.txt'
-┌───────────────────────┐
-│45719.53226 45719.53226│
-└───────────────────────┘
-```
-
-!!! note
-    Of the file timestamps which are reported by the operating system, only the last modification time should be considered reliable and portable. Neither the access time or creation time are well supported across all platforms. Furthermore, they may not accurately reflect the actual time that the operation occurred.
 
 <!-- Hidden search keywords -->
 <div style="display: none;">

--- a/language-reference-guide/docs/system-functions/ninfo.md
+++ b/language-reference-guide/docs/system-functions/ninfo.md
@@ -102,15 +102,15 @@ When using the `Wildcard` option, matching of names is done case insensitively o
 
 Table: Variant options overview { #variant-table }
 
-|Variant Option|Value|Effect|
-|---|:-:|---|
-|[`Wildcard`](#variant-option-wildcard)<br><small>principal</small>|`0` <small>(default)</small>|The names in `Y` identify specific files.|
-|_-                                    -_|`1`|The names in `Y` can contain the wildcard characters `?` and `*`.|
-|[`Recurse`](#variant-option-recurse)|`0` <small>(default)</small>|Only the specified directory is searched.|
-|_-                                    -_|`1`|The specified directory and its sub-directories are searched.|
-|[`Follow`](#variant-option-follow)|`1` <small>(default)</small>|For a symbolic link, the target's properties are reported.|
-|_-                                    -_|`0`|The symbolic link's own properties are reported.|
-|[`ProgressCallback`](#variant-option-progresscallback)|&nbsp;|A function is called periodically during a long operation.|
+|Variant Option|Valid Values|Default|Effect|
+|---|---|---|---|
+|[`Wildcard`](#variant-option-wildcard)<br><small>principal</small>|`0`|`0`|The names in `Y` identify specific files.|
+|_-                                    -_|`1`||The names in `Y` can contain the wildcard characters `?` and `*`.|
+|[`Recurse`](#variant-option-recurse)|`0`|`0`|Only the specified directory is searched.|
+|_-                                    -_|`1`||The specified directory and its sub-directories are searched.|
+|[`Follow`](#variant-option-follow)|`1`|`1`|For a symbolic link, the target's properties are reported.|
+|_-                                    -_|`0`||The symbolic link's own properties are reported.|
+|[`ProgressCallback`](#variant-option-progresscallback)|&nbsp;||A function is called periodically during a long operation.|
 
 ### Variant Option: Wildcard
 

--- a/language-reference-guide/docs/system-functions/nmove.md
+++ b/language-reference-guide/docs/system-functions/nmove.md
@@ -25,12 +25,12 @@ The [shy](../../../programming-reference-guide/introduction/results#shy-results)
 
 Table: Variant options overview { #variant-table }
 
-|Variant Option|Value|Effect|
-|---|---|---|
-|[`Wildcard`](#variant-option-wildcard)<br><small>principal</small>|`0` <small>(default)</small> or `1`|Whether the names in `Y` are matched literally or as patterns.|
-|[`IfExists`](#variant-option-ifexists)|`'Error'` <small>(default)</small> or `'Skip'`|What happens when a target file already exists.|
-|[`RenameOnly`](#variant-option-renameonly)|`0` <small>(default)</small> or `1`|What happens when the source cannot be renamed.|
-|[`ProgressCallback`](#variant-option-progresscallback)|a callback function|Reports progress during the move.|
+|Variant Option|Valid Values|Default|Effect|
+|---|---|---|---|
+|[`Wildcard`](#variant-option-wildcard)<br><small>principal</small>|`0` or `1`|`0`|Whether the names in `Y` are matched literally or as patterns.|
+|[`IfExists`](#variant-option-ifexists)|`'Error'` or `'Skip'`|`'Error'`|What happens when a target file already exists.|
+|[`RenameOnly`](#variant-option-renameonly)|`0` or `1`|`0`|What happens when the source cannot be renamed.|
+|[`ProgressCallback`](#variant-option-progresscallback)|a callback function||Reports progress during the move.|
 
 ### Variant Option: Wildcard
 

--- a/language-reference-guide/docs/system-functions/nmove.md
+++ b/language-reference-guide/docs/system-functions/nmove.md
@@ -19,6 +19,45 @@ If `Y` specifies more than one source, `X` must be a character vector  that spec
 
 The [shy](../../../programming-reference-guide/introduction/results#shy-results) result `R` contains count(s) of top-level items moved. If `Y` is a single source name, `R` is a scalar otherwise it is a vector of the same length as `Y`.
 
+<h2 class="example">Examples</h2>
+
+A number of possibilities exist, illustrated by the following examples. In all cases, if the source is a file, the file is moved. If the source is a directory, the directory and all of its contents are moved.
+
+The source name must be an existent file or directory. If the destination name does not exist but its path name does exist, the source is moved to the destination name. If the destination name is an existing directory the source name is moved to that directory.
+
+```apl
+      ⊃1 ⎕NPARTS ''
+i:/Documents/Dyalog APL-64 17.0 Unicode Files/
+
+⍝ Rename the Session file
+      ⊢'session.dlf' ⎕NMOVE 'default.dlf'
+1
+      ⊢ ⎕MKDIR 'backups' ⍝ Make a backups directory
+1
+⍝ Move the Session file to backups directory
+      ⊢'backups'⎕NMOVE'default.dlf'
+1
+      ↑⊃0 (⎕NINFO⍠1) 'backups\*'
+backups/default.dlf  
+```
+
+Each source name must specify a single file or directory which must exist. The destination name must be an existing directory. Each of the files and/or directories specified by the source base names are moved to the destination directory.
+
+```apl
+       ⊃1 ⎕NPARTS ''
+i:/Documents/Dyalog APL-64 17.0 Unicode Files/
+
+      ⊢ ⎕MKDIR 'backups' ⍝ Make a backups directory
+1
+
+⍝ Move 2 files to backups directory
+      ⊢'backups'⎕NMOVE'default.dlf' 'def_uk.dse'
+1 1
+      ↑⊃0 (⎕NINFO⍠1) 'backups\*'
+backups/default.dlf
+backups/def_uk.dse 
+```
+
 ## Variant Options
 
 `⎕NMOVE` supports four variant options, summarised in [](#variant-table) and described in detail beneath it. The principal option is `Wildcard`.
@@ -39,6 +78,42 @@ Table: Variant options overview { #variant-table }
 |`1`|The name or names in `Y` that specify the *base name* and *extension* (see [NParts](./nparts.md) ), may also contain the wildcard characters "?" and "*". An asterisk is a substitute for any 0 or more characters in a file name or extension; a question-mark is a substitute for any single character.|
 
 Note that when `Wildcard` is `1`, element(s) of `R` can be `0` or `>1`. If `Wildcard` is `0`, elements of `R` are always `1`.
+
+<h4 class="example">Examples</h4>
+
+The source name may include wildcard characters which matches a number of existing files and/or directories. The destination name must be an existing directory. The files and/or directories that match the pattern specified by the source name are moved into the destination directory. If there are no matches, zero copies are made.
+
+```apl
+       ⊃1 ⎕NPARTS ''
+i:/Documents/Dyalog APL-64 17.0 Unicode Files/
+
+      ⊢ ⎕MKDIR 'backups' ⍝ Make a backups directory
+1
+⍝ Move all files to backups directory
+      ⊢'backups'(⎕NMOVE⍠'Wildcard' 1)'*.*'
+3
+      ↑⊃0 (⎕NINFO⍠1) 'backups\*'
+backups/default.dlf        
+backups/def_uk.dse         
+backups/UserCommand20.cache
+```
+
+The destination name must be an existing directory. Each of the files and/or directories that match the patterns specified by the source names (if any) are moved to the destination directory.
+
+```apl
+      ⊃1 ⎕NPARTS ''
+i:/Documents/Dyalog APL-64 17.0 Unicode Files/
+
+      ⊢ ⎕MKDIR 'backups' ⍝ Make a backups directory
+1
+⍝ Move files to backups directory
+      ⊢'backups'(⎕NMOVE⍠1)'d*' 'UserCommand20.cache'
+2 1
+      ↑⊃0 (⎕NINFO⍠1) 'backups\*'
+backups/default.dlf
+backups/def_uk.dse
+backups/UserCommand20.cache
+```
 
 ### Variant Option: IfExists
 
@@ -67,92 +142,6 @@ The `RenameOnly` variant option (a Boolean) determines what happens when it is n
 The `ProgressCallback` variant option is described in the [Dyalog Programming Reference Guide](../../../programming-reference-guide/native-files#progress-callbacks). The following is specific to `⎕NMOVE`:
 
 * The first element of the right argument to the callback function is the character vector `'⎕NMOVE'`.
-
-<h2 class="example">Examples</h2>
-
-A number of possibilities exist, illustrated by the following examples. In all cases, if the source is a file, the file is moved. If the source is a directory, the directory and all of its contents are moved.
-
-### Examples: single source, `Wildcard` is `0` { .example }
-
-- The source name must be an existent file or directory.
-- If the destination name does not exist but its path name does exist, the source is moved to the destination name.
-- If the destination name is an existing directory the source name is moved to that directory.
-
-```apl
-      ⊃1 ⎕NPARTS ''
-i:/Documents/Dyalog APL-64 17.0 Unicode Files/
-
-⍝ Rename the Session file
-      ⊢'session.dlf' ⎕NMOVE 'default.dlf'
-1
-      ⊢ ⎕MKDIR 'backups' ⍝ Make a backups directory
-1
-⍝ Move the Session file to backups directory
-      ⊢'backups'⎕NMOVE'default.dlf'
-1
-      ↑⊃0 (⎕NINFO⍠1) 'backups\*'
-backups/default.dlf  
-```
-
-### Examples: single source, `Wildcard` is `1` { .example }
-
-- The source name may include wildcard characters which matches a number of existing files and/or directories. The destination name must be an existing directory.
-- The files and/or directories that match the pattern specified by the source name are moved into the destination directory. If there are no matches, zero copies are made.
-
-```apl
-       ⊃1 ⎕NPARTS ''
-i:/Documents/Dyalog APL-64 17.0 Unicode Files/
-
-      ⊢ ⎕MKDIR 'backups' ⍝ Make a backups directory
-1
-⍝ Move all files to backups directory
-      ⊢'backups'(⎕NMOVE⍠'Wildcard' 1)'*.*'
-3
-      ↑⊃0 (⎕NINFO⍠1) 'backups\*'
-backups/default.dlf        
-backups/def_uk.dse         
-backups/UserCommand20.cache
-```
-
-### Examples: multiple sources, `Wildcard` is `0` { .example }
-
-- Each source name must specify a single file or directory which must exist. The destination name must be an existing directory.
-- Each of the files and/or directories specified by the source base names are moved to the destination directory.
-
-```apl
-       ⊃1 ⎕NPARTS ''
-i:/Documents/Dyalog APL-64 17.0 Unicode Files/
-
-      ⊢ ⎕MKDIR 'backups' ⍝ Make a backups directory
-1
-
-⍝ Move 2 files to backups directory
-      ⊢'backups'⎕NMOVE'default.dlf' 'def_uk.dse'
-1 1
-      ↑⊃0 (⎕NINFO⍠1) 'backups\*'
-backups/default.dlf
-backups/def_uk.dse 
-```
-
-### Examples: multiple sources, `Wildcard` is `1` { .example }
-
-- The destination name must be an existing directory.
-- Each of the files and/or directories that match the patterns specified by the source names (if any) are moved to the destination directory.
-
-```apl
-      ⊃1 ⎕NPARTS ''
-i:/Documents/Dyalog APL-64 17.0 Unicode Files/
-
-      ⊢ ⎕MKDIR 'backups' ⍝ Make a backups directory
-1
-⍝ Move files to backups directory
-      ⊢'backups'(⎕NMOVE⍠1)'d*' 'UserCommand20.cache'
-2 1
-      ↑⊃0 (⎕NINFO⍠1) 'backups\*'
-backups/default.dlf
-backups/def_uk.dse
-backups/UserCommand20.cache
-```
 
 ## Note
 

--- a/language-reference-guide/docs/system-functions/nmove.md
+++ b/language-reference-guide/docs/system-functions/nmove.md
@@ -13,7 +13,7 @@ When possible `⎕NMOVE` *renames* files and directories, which effects a fast m
 
 `Y` is a character vector that specifies the name of the source, or a vector of character vectors containing zero or more sources.
 
-Sources and destinations may be full or relative (to the current working directory) path names adhering to the operating system convention.
+Sources and destinations can be full or relative (to the current working directory) path names adhering to the operating system convention.
 
 If `Y` specifies more than one source, `X` must be a character vector  that specifies an existent directory to which each of the sources in `Y` is to be moved.
 
@@ -60,9 +60,9 @@ backups/def_uk.dse
 
 ## Variant Options
 
-`⎕NMOVE` supports four variant options, summarised in [](#variant-table) and described in detail beneath it. The principal option is `Wildcard`.
+`⎕NMOVE` supports four variant options, summarised in [](#variantoptionsfornmove) and described in detail beneath it. The principal option is `Wildcard`.
 
-Table: Variant options overview { #variant-table }
+Table: Variant options for `⎕NMOVE` { #variantoptionsfornmove }
 
 |Variant Option|Valid Values|Default|Effect|
 |---|---|---|---|
@@ -71,17 +71,17 @@ Table: Variant options overview { #variant-table }
 |[`RenameOnly`](#variant-option-renameonly)|`0` or `1`|`0`|What happens when the source cannot be renamed.|
 |[`ProgressCallback`](#variant-option-progresscallback)|the name of a callback function|none|Reports progress during the move.|
 
-### Variant Option: Wildcard
+### Variant Option: `Wildcard`
 
 |---|---|
 |`0` <small>(default)</small>|The name or names in `Y` identifies a specific file name.|
-|`1`|The name or names in `Y` that specify the *base name* and *extension* (see [NParts](./nparts.md) ), may also contain the wildcard characters "?" and "*". An asterisk is a substitute for any 0 or more characters in a file name or extension; a question-mark is a substitute for any single character.|
+|`1`|The name or names in `Y` that specify the *base name* and *extension* (see [NParts](./nparts.md) ), can also contain the wildcard characters "?" and "*". An asterisk is a substitute for any 0 or more characters in a file name or extension; a question-mark is a substitute for any single character.|
 
 Note that when `Wildcard` is `1`, element(s) of `R` can be `0` or `>1`. If `Wildcard` is `0`, elements of `R` are always `1`.
 
 <h4 class="example">Examples</h4>
 
-The source name may include wildcard characters which matches a number of existing files and/or directories. The destination name must be an existing directory. The files and/or directories that match the pattern specified by the source name are moved into the destination directory. If there are no matches, zero copies are made.
+The source name can include wildcard characters which matches a number of existing files and/or directories. The destination name must be an existing directory. The files and/or directories that match the pattern specified by the source name are moved into the destination directory. If there are no matches, zero copies are made.
 
 ```apl
        ⊃1 ⎕NPARTS ''
@@ -115,7 +115,7 @@ backups/def_uk.dse
 backups/UserCommand20.cache
 ```
 
-### Variant Option: IfExists
+### Variant Option: `IfExists`
 
 The `IfExists` variant option determines what happens when a source file is to be moved to a target file that already exists. It does not apply to directories, only to the files within them.
 
@@ -129,7 +129,7 @@ The following cases cause an error to be signalled regardless of the value of th
 - If the source specifies a directory and the destination specifies an existing file.
 - If the source specifies a file and the same base name exists as a sub-directory in the destination.
 
-### Variant Option: RenameOnly
+### Variant Option: `RenameOnly`
 
 The `RenameOnly` variant option (a Boolean) determines what happens when it is not possible to rename the source.
 
@@ -137,7 +137,7 @@ The `RenameOnly` variant option (a Boolean) determines what happens when it is n
 |`0` <small>(default)</small>|The source will be copied and the original deleted|
 |`1`|The move will fail                                |
 
-### Variant Option: ProgressCallback
+### Variant Option: `ProgressCallback`
 
 The `ProgressCallback` variant option is described in the [Dyalog Programming Reference Guide](../../../programming-reference-guide/native-files#progress-callbacks). The following is specific to `⎕NMOVE`:
 
@@ -148,9 +148,9 @@ The `ProgressCallback` variant option is described in the [Dyalog Programming Re
 When `⎕NMOVE` copies and deletes files:
 
 - The operation will take longer to complete.
-- File modification times will be preserved but other attributes such as file ownership may be changed.
+- File modification times will be preserved but other attributes such as file ownership might be changed.
 - Read permissions will be needed on all files within a directory which is moved.
-- If the operation fails at any point and an error is signalled it is possible that there may be files and/or directories left duplicated in both the source and destination. It is not possible that a file or directory may be removed from the source without having been copied to the destination.
+- If the operation fails at any point and an error is signalled it is possible that there might be files and/or directories left duplicated in both the source and destination. It is not possible that a file or directory might be removed from the source without having been copied to the destination.
 
 <!-- Hidden search keywords -->
 <div style="display: none;">

--- a/language-reference-guide/docs/system-functions/nmove.md
+++ b/language-reference-guide/docs/system-functions/nmove.md
@@ -7,7 +7,7 @@ search:
 
 This function moves native files and directories from one or more sources specified by `Y` to a destination specified by  `X`. `⎕NMOVE` is similar to `⎕NCOPY` (see [Native File Copy ](ncopy.md)).
 
-When possible `⎕NMOVE` *renames* files and directories, which effects a fast move when the source and destination are on the same file system. By default (see **RenameOnly** option below), if `⎕NMOVE` is unable to rename files or directories, it instead copies them and deletes the originals.
+When possible `⎕NMOVE` *renames* files and directories, which effects a fast move when the source and destination are on the same file system. By default (see the `RenameOnly` option below), if `⎕NMOVE` is unable to rename files or directories, it instead copies them and deletes the originals.
 
 `X` is a character vector that specifies the name of the destination.
 
@@ -21,43 +21,58 @@ The [shy](../../../programming-reference-guide/introduction/results#shy-results)
 
 ## Variant Options
 
-`⎕NMOVE` may be applied using the _variant_ operator with the options **Wildcard** (the Principal option), **IfExists**, **RenameOnly** and **ProgressCallback**.
+`⎕NMOVE` supports four variant options, summarised in [](#variant-table) and described in detail beneath it. The principal option is `Wildcard`.
 
-## Wildcard Option (Boolean)
+Table: Variant options overview { #variant-table }
+
+|Variant Option|Value|Effect|
+|---|---|---|
+|[`Wildcard`](#variant-option-wildcard)<br><small>principal</small>|`0` <small>(default)</small> or `1`|Whether the names in `Y` are matched literally or as patterns.|
+|[`IfExists`](#variant-option-ifexists)|`'Error'` <small>(default)</small> or `'Skip'`|What happens when a target file already exists.|
+|[`RenameOnly`](#variant-option-renameonly)|`0` <small>(default)</small> or `1`|What happens when the source cannot be renamed.|
+|[`ProgressCallback`](#variant-option-progresscallback)|a callback function|Reports progress during the move.|
+
+### Variant Option: Wildcard
 
 |---|---|
-|0 { .shaded } |The name or names in `Y` identifies a specific file name.|
+|`0` <small>(default)</small>|The name or names in `Y` identifies a specific file name.|
 |`1`|The name or names in `Y` that specify the *base name* and *extension* (see [NParts](./nparts.md) ), may also contain the wildcard characters "?" and "*". An asterisk is a substitute for any 0 or more characters in a file name or extension; a question-mark is a substitute for any single character.|
 
-Note that when **Wildcard** is 1, element(s) of `R` can  be 0 or `>1`. If **Wildcard** is 0, elements of `R` are always 1.
+Note that when `Wildcard` is `1`, element(s) of `R` can be `0` or `>1`. If `Wildcard` is `0`, elements of `R` are always `1`.
 
-## IfExists Option
+### Variant Option: IfExists
 
-The **IfExists** variant option determines what happens when a source file is to be copied to a target file that already exists. It does not apply to directories, only to the files within them.
+The `IfExists` variant option determines what happens when a source file is to be moved to a target file that already exists. It does not apply to directories, only to the files within them.
 
-|Value   |Description                                                                                           |
-|--------|------------------------------------------------------------------------------------------------------|
-|'Error' { .shaded } |Existing files will not be overwritten and an error will be signalled.                                |
+|Value|Description|
+|---|---|
+|`'Error'` <small>(default)</small>|Existing files will not be overwritten and an error will be signalled.|
 |`'Skip'`|Existing files will not be overwritten but the corresponding copy operation will be skipped (ignored).|
 
-The following cases cause an error to be signalled  regardless of the value of the **IfExists** variant.
+The following cases cause an error to be signalled regardless of the value of the `IfExists` variant.
 
 - If the source specifies a directory and the destination specifies an existing file.
 - If the source specifies a file and the same base name exists as a sub-directory in the destination.
 
-## RenameOnly Option (Boolean)
+### Variant Option: RenameOnly
 
-The **RenameOnly** option  determines what happens when it is not possible to rename the source.
+The `RenameOnly` variant option (a Boolean) determines what happens when it is not possible to rename the source.
 
-|---|--------------------------------------------------|
-|0 { .shaded }  |The source will be copied and the original deleted|
+|---|---|
+|`0` <small>(default)</small>|The source will be copied and the original deleted|
 |`1`|The move will fail                                |
 
-## Examples
+### Variant Option: ProgressCallback
+
+The `ProgressCallback` variant option is described in the [Dyalog Programming Reference Guide](../../../programming-reference-guide/native-files#progress-callbacks). The following is specific to `⎕NMOVE`:
+
+* The first element of the right argument to the callback function is the character vector `'⎕NMOVE'`.
+
+<h2 class="example">Examples</h2>
 
 A number of possibilities exist, illustrated by the following examples. In all cases, if the source is a file, the file is moved. If the source is a directory, the directory and all of its contents are moved.
 
-### Single source, Wildcard is 0
+### Examples: single source, `Wildcard` is `0` { .example }
 
 - The source name must be an existent file or directory.
 - If the destination name does not exist but its path name does exist, the source is moved to the destination name.
@@ -79,7 +94,7 @@ i:/Documents/Dyalog APL-64 17.0 Unicode Files/
 backups/default.dlf  
 ```
 
-### Single source, Wildcard is 1
+### Examples: single source, `Wildcard` is `1` { .example }
 
 - The source name may include wildcard characters which matches a number of existing files and/or directories. The destination name must be an existing directory.
 - The files and/or directories that match the pattern specified by the source name are moved into the destination directory. If there are no matches, zero copies are made.
@@ -99,7 +114,7 @@ backups/def_uk.dse
 backups/UserCommand20.cache
 ```
 
-### Multiple sources, Wildcard is 0
+### Examples: multiple sources, `Wildcard` is `0` { .example }
 
 - Each source name must specify a single file or directory which must exist. The destination name must be an existing directory.
 - Each of the files and/or directories specified by the source base names are moved to the destination directory.
@@ -119,7 +134,7 @@ backups/default.dlf
 backups/def_uk.dse 
 ```
 
-### Multiple sources, Wildcard is 1
+### Examples: multiple sources, `Wildcard` is `1` { .example }
 
 - The destination name must be an existing directory.
 - Each of the files and/or directories that match the patterns specified by the source names (if any) are moved to the destination directory.
@@ -138,12 +153,6 @@ backups/default.dlf
 backups/def_uk.dse
 backups/UserCommand20.cache
 ```
-
-## ProgressCallback Option
-
-The **ProgressCallback** variant option is described in the [Dyalog Programming Reference Guide](../../../programming-reference-guide/native-files#progress-callbacks). The following is specific to `⎕NMOVE`:
-
-* The first element of the right argument to the callback function is the character vector `'⎕NMOVE'`.
 
 ## Note
 

--- a/language-reference-guide/docs/system-functions/nmove.md
+++ b/language-reference-guide/docs/system-functions/nmove.md
@@ -30,7 +30,7 @@ Table: Variant options overview { #variant-table }
 |[`Wildcard`](#variant-option-wildcard)<br><small>principal</small>|`0` or `1`|`0`|Whether the names in `Y` are matched literally or as patterns.|
 |[`IfExists`](#variant-option-ifexists)|`'Error'` or `'Skip'`|`'Error'`|What happens when a target file already exists.|
 |[`RenameOnly`](#variant-option-renameonly)|`0` or `1`|`0`|What happens when the source cannot be renamed.|
-|[`ProgressCallback`](#variant-option-progresscallback)|a callback function||Reports progress during the move.|
+|[`ProgressCallback`](#variant-option-progresscallback)|the name of a callback function|none|Reports progress during the move.|
 
 ### Variant Option: Wildcard
 

--- a/language-reference-guide/docs/system-functions/nput.md
+++ b/language-reference-guide/docs/system-functions/nput.md
@@ -23,8 +23,8 @@ The left-argument `X` is comprised of 1, 2 or 3 items which identify `(content) 
 
 If specified, `encoding` is either:
 
-- a character vector from the first column in the table [File Encodings](nget.md). If `encoding` specifies a UTF format, it may be qualified with -BOM  (for example, UTF-8-BOM), which causes a Byte Order Mark (BOM) to be written at the beginning of the file or -NOBOM which does not. If the -BOM or -NOBOM suffix is omitted, UTF-8 defaults to UTF-8-NOBOM, while the other UTF formats default to -BOM.
-- a 256-element numeric vector that maps each possible byte value (0-255) to a  Unicode code point (1st element = Unicode code point corresponding to byte value 0, and so on). ¯1 indicates that the corresponding byte value is not mapped to any character. Apart from ¯1, no value may appear in the table more than once.
+- a character vector from the first column in the table [File Encodings](nget.md). If `encoding` specifies a UTF format, it can be qualified with -BOM  (for example, UTF-8-BOM), which causes a Byte Order Mark (BOM) to be written at the beginning of the file or -NOBOM which does not. If the -BOM or -NOBOM suffix is omitted, UTF-8 defaults to UTF-8-NOBOM, while the other UTF formats default to -BOM.
+- a 256-element numeric vector that maps each possible byte value (0-255) to a  Unicode code point (1st element = Unicode code point corresponding to byte value 0, and so on). ¯1 indicates that the corresponding byte value is not mapped to any character. Apart from ¯1, no value can appear in the table more than once.
 
 If  omitted, `encoding` defaults to UTF-8-NOBOM.
 
@@ -39,7 +39,7 @@ In all cases, `newline` is appended if required to a simple vector or to each ve
 
 If content contains anything other than a character vector or scalar (or these, nested) then a `DOMAIN ERROR` is signalled.
 
-If both `encoding` and `newline` are omitted `X` specifies only `content` and may be a simple character vector or a vector of character vectors.
+If both `encoding` and `newline` are omitted `X` specifies only `content` and can be a simple character vector or a vector of character vectors.
 
 The [shy](../../../programming-reference-guide/introduction/results#shy-results) result `R` is the number of bytes written to the file.
 
@@ -63,7 +63,7 @@ The [shy](../../../programming-reference-guide/introduction/results#shy-results)
 
 `⎕NPUT` supports one variant option, `NEOL`.
 
-### Variant Option: NEOL
+### Variant Option: `NEOL`
 
 The `NEOL` variant option specifies how embedded line separators are treated. The default is `1`.
 

--- a/language-reference-guide/docs/system-functions/nput.md
+++ b/language-reference-guide/docs/system-functions/nput.md
@@ -37,7 +37,7 @@ If specified, `newline` is numeric and is either  `⍬` or a scalar or vector  f
 
 In all cases, `newline` is appended if required to a simple vector or to each vector in a vector of vectors.
 
-If content contains anything other than a character vector or scalar (or these, nested) then a `DOMAIN ERROR` is signalled.
+If content contains anything other than a character vector or scalar (or these, nested), then a `DOMAIN ERROR` is signalled.
 
 If both `encoding` and `newline` are omitted `X` specifies only `content` and can be a simple character vector or a vector of character vectors.
 

--- a/language-reference-guide/docs/system-functions/nput.md
+++ b/language-reference-guide/docs/system-functions/nput.md
@@ -59,17 +59,21 @@ The [shy](../../../programming-reference-guide/introduction/results#shy-results)
 18                                         
 ```
 
-## NEOL Option
+## Variant Options
 
-The NEOL variant option specifies how embedded line separators are treated.
+`⎕NPUT` supports one variant option, `NEOL`.
+
+### Variant Option: NEOL
+
+The `NEOL` variant option specifies how embedded line separators are treated. The default is `1`.
 
 |----|-------------------------------------------------------------------------------------------------------------|
 |`0` |embedded line separator characters are preserved as is,and a `newline` is added to the last line if required.|
-|`1` {: .shaded} |every embedded LF is replaced by `newline`                                                                   |
+|`1` <small>(default)</small>|every embedded LF is replaced by `newline`                                                                   |
 |`2` |every embedded line separator character is replaced by `newline`                                             |
 |`¯1`|same as 0 except that a `newline` is not added to the last line                                              |
 
-## Embedded line-separator examples
+<h4 class="example">Examples</h4>
 
 ```apl
       LF CR←⎕UCS 10 13
@@ -85,7 +89,7 @@ The NEOL variant option specifies how embedded line separators are treated.
 
 `t` contains three lines each with different line endings: LF, CR and CRLF.
 
-In the first example (NEOL is by default 1), only the LF is normalised so the written file contains lines ending with CRLF, CR and CRLF.
+In the first example (`NEOL` is by default `1`), only the LF is normalised so the written file contains lines ending with CRLF, CR and CRLF.
 
 In the second example, none of the line endings are normalised so the written file contains lines ending with LF, CR and CRLF.
 

--- a/language-reference-guide/docs/system-functions/ns.md
+++ b/language-reference-guide/docs/system-functions/ns.md
@@ -145,7 +145,7 @@ If `Y` does not contain a reference to, or a `⎕OR` of, a *GUI* object, the res
 
 `⎕NS` supports one variant option, `Trigger`.
 
-### Variant Option: Trigger
+### Variant Option: `Trigger`
 
 The `Trigger` variant option specifies whether any [triggers](../../../programming-reference-guide/triggers/triggers) should be run for the modified variables in the target namespace that have triggers attached.
 The value must be a Boolean scalar. The default is `0`, meaning that triggers are not run.

--- a/language-reference-guide/docs/system-functions/ns.md
+++ b/language-reference-guide/docs/system-functions/ns.md
@@ -84,7 +84,7 @@ If `X` is specified, the result `R` is the full name (starting with `#.` or `⎕
  DATA
 ```
 
-## Case 2: Create or Populate Namespace from Object List
+### Case 2: Create or Populate Namespace from Object List
 
 `Y` is one or more references to, or `⎕OR`s of, namespaces.
 
@@ -141,10 +141,14 @@ If `Y` does not contain a reference to, or a `⎕OR` of, a *GUI* object, the res
 }
 
 ```
+## Variant Options
+
+`⎕NS` supports one variant option, `Trigger`.
+
 ### Variant Option: Trigger
 
 The `Trigger` variant option specifies whether any [triggers](../../../programming-reference-guide/triggers/triggers) should be run for the modified variables in the target namespace that have triggers attached.
-The value must be a Boolean scalar. The default is 0, meaning that triggers are not run.
+The value must be a Boolean scalar. The default is `0`, meaning that triggers are not run.
 
 <h4 class="example">Example</h4>
 

--- a/language-reference-guide/docs/system-functions/shell.md
+++ b/language-reference-guide/docs/system-functions/shell.md
@@ -106,9 +106,9 @@ When an APL thread running `⎕SHELL` is terminated by [`⎕TKILL`](tkill.md) or
 
 ## Variant Options
 
-`⎕SHELL` supports ten variant options, summarised in [](#variant-table) and described in detail beneath it. There is no principal option. They control certain parts of the program execution context.
+`⎕SHELL` supports ten variant options, summarised in [](#variantoptionsforshell) and described in detail beneath it. There is no principal option. They control certain parts of the program execution context.
 
-Table: Variant options overview { #variant-table }
+Table: Variant options for `⎕SHELL` { #variantoptionsforshell }
 
 |Variant Option|Valid Values|Default|Effect|
 |---|---|---|---|
@@ -123,7 +123,7 @@ Table: Variant options overview { #variant-table }
 |[`Signal`](#variant-option-signal)|a signal number|operating-system specific|Signal sent to the child process when it is abandoned.|
 |[`Window`](#variant-option-window)|`'Hidden'` or another window mode|`'Hidden'`|Initial window mode (Microsoft Windows only).|
 
-### Variant Option: Output
+### Variant Option: `Output`
 The `Output` variant option controls output stream redirections. The value must describe a set of redirections, in one of the following formats:
 
 - a two-column matrix.
@@ -178,8 +178,8 @@ The callback is invoked when:
 
 Depending on the type or encoding, some of these conditions could happen when the buffer contains a number of bytes that do not make up a full item, such as when the buffer is full and the last byte is only one of multiple bytes needed to encode a UTF-8 character.
 
-### Variant Option: Input
-The Input variant option controls input stream redirections. The value must describe a set of redirections, in one of the following formats:
+### Variant Option: `Input`
+The `Input` variant option controls input stream redirections. The value must describe a set of redirections, in one of the following formats:
 
 - a two-column matrix.
 - a two-element vector.
@@ -204,17 +204,17 @@ Any input the child process tries to read on its stream `Stream` will come from 
 
 The default is `0 2⍴0`, but see [Default Redirections](#default-redirections).
 
-### Variant Option: WorkingDir
+### Variant Option: `WorkingDir`
 The `WorkingDir` variant option sets the working directory of the child process. The value must be a character vector that refers to a valid directory, such as `'/tmp/somedir'` on Linux, or `'C:\tmp\somedir'` on Microsoft Windows.
 
 The default is the current working directory of the interpreter.
 
-### Variant Option: InheritEnv
+### Variant Option: `InheritEnv`
 The `InheritEnv` variant option specifies whether the set of environment variables from the interpreter should be inherited by the child process. The value must be a Boolean scalar.
 
 The default is `1`.
 
-### Variant Option: Env
+### Variant Option: `Env`
 The `Env` variant option specifies any additional environment variables and their values. If an environment variable that already exists in the set of inherited variables (see [`InheritEnv`](#variant-option-inheritenv)) is specified here, the value from `Env` takes precedence. The option value must be one of the following:
 
 - a two-column matrix.
@@ -247,7 +247,7 @@ All the environment variable names must be unique within the scope of the call t
 
 The default is `0 2⍴⍬`.
 
-### Variant Option: Shell
+### Variant Option: `Shell`
 The `Shell` variant option sets the shell to be used when `Y` is a character vector.
 
 The value must be a character vector or a vector of character vectors with a length of at least 1.
@@ -282,19 +282,19 @@ There is no difference between the following two calls; the `Shell` variant opti
       ⎕SHELL⍠'Shell' ('/bin/bash' '-c')⊢'a b c'
 ```
 
-### Variant Option: ExitCheck
+### Variant Option: `ExitCheck`
 The `ExitCheck` variant option specifies whether `⎕SHELL` should convert abnormal exit reasons and exit codes into a `DOMAIN ERORR`. The value must be a boolean scalar; if set to 1, a `DOMAIN ERROR` is reported if `ExitReason` and `ExitCode` are not both 0.
 
 The default `0`.
 
-### Variant Option: Timeout
+### Variant Option: `Timeout`
 The `Timeout` variant option specifies an upper limit for the duration of the `⎕SHELL` call.
 The value must be a non-negative numeric scalar representing the number of milliseconds.
 The value `0` allows the `⎕SHELL` call to run for as long as it needs.
 
 The default is `0`.
 
-### Variant Option: Signal
+### Variant Option: `Signal`
 The `Signal` variant option specifies a signal to send to the child process when it is being abandoned by `⎕SHELL`.
 The value must be either an integer representing a valid signal number, or `0` (which means no signal should be sent).
 
@@ -306,7 +306,7 @@ The default depends on the operating-system:
 - Microsoft Windows: `0`.
 - Linux, macOS, AIX: the numeric value of `SIGTERM` which is the signal that asks the child process to shut itself down.
 
-### Variant Option: Window
+### Variant Option: `Window`
 !!! windows "Dyalog on Microsoft Windows"
     This option only has an effect on Windows.
 

--- a/language-reference-guide/docs/system-functions/shell.md
+++ b/language-reference-guide/docs/system-functions/shell.md
@@ -110,18 +110,18 @@ When an APL thread running `⎕SHELL` is terminated by [`⎕TKILL`](tkill.md) or
 
 Table: Variant options overview { #variant-table }
 
-|Variant Option|Value|Effect|
-|---|---|---|
-|[`Output`](#variant-option-output)|a set of redirections|Output stream redirections.|
-|[`Input`](#variant-option-input)|a set of redirections|Input stream redirections.|
-|[`WorkingDir`](#variant-option-workingdir)|a character vector|The child process's working directory (default: the interpreter's current directory).|
-|[`InheritEnv`](#variant-option-inheritenv)|`1` <small>(default)</small> or `0`|Whether the interpreter's environment variables are inherited.|
-|[`Env`](#variant-option-env)|environment-variable definitions|Additional environment variables (default: none).|
-|[`Shell`](#variant-option-shell)|a shell specification|The shell used when `Y` is a character vector (default: operating-system specific).|
-|[`ExitCheck`](#variant-option-exitcheck)|`0` <small>(default)</small> or `1`|Whether abnormal exit reasons and codes raise `DOMAIN ERROR`.|
-|[`Timeout`](#variant-option-timeout)|`0` <small>(default)</small> or a number of milliseconds|Upper limit on the duration of the call (`0` means no limit).|
-|[`Signal`](#variant-option-signal)|a signal number|Signal sent to the child process when it is abandoned (default: operating-system specific).|
-|[`Window`](#variant-option-window)|`'Hidden'` <small>(default)</small> or another window mode|Initial window mode (Microsoft Windows only).|
+|Variant Option|Valid Values|Default|Effect|
+|---|---|---|---|
+|[`Output`](#variant-option-output)|a set of redirections|`0 2⍴0`|Output stream redirections.|
+|[`Input`](#variant-option-input)|a set of redirections|`0 2⍴0`|Input stream redirections.|
+|[`WorkingDir`](#variant-option-workingdir)|a character vector|the interpreter's current directory|The child process's working directory.|
+|[`InheritEnv`](#variant-option-inheritenv)|`1` or `0`|`1`|Whether the interpreter's environment variables are inherited.|
+|[`Env`](#variant-option-env)|environment-variable definitions|none|Additional environment variables.|
+|[`Shell`](#variant-option-shell)|a shell specification|operating-system specific|The shell used when `Y` is a character vector.|
+|[`ExitCheck`](#variant-option-exitcheck)|`0` or `1`|`0`|Whether abnormal exit reasons and codes raise `DOMAIN ERROR`.|
+|[`Timeout`](#variant-option-timeout)|`0` or a number of milliseconds|`0`|Upper limit on the duration of the call (`0` means no limit).|
+|[`Signal`](#variant-option-signal)|a signal number|operating-system specific|Signal sent to the child process when it is abandoned.|
+|[`Window`](#variant-option-window)|`'Hidden'` or another window mode|`'Hidden'`|Initial window mode (Microsoft Windows only).|
 
 ### Variant Option: Output
 The `Output` variant option controls output stream redirections. The value must describe a set of redirections, in one of the following formats:

--- a/language-reference-guide/docs/system-functions/shell.md
+++ b/language-reference-guide/docs/system-functions/shell.md
@@ -20,7 +20,10 @@ The shell being used can be changed using the [`Shell`](#variant-option-shell) v
 - Microsoft Windows: `PowerShell`
 - Linux, macOS, AIX: `/bin/sh`
 
-#### Example ( Microsoft Windows) { .example }
+<h4 class="example">Example</h4>
+
+The following example is for Microsoft Windows only.
+
 ```apl
       ↑⊃⊃⎕SHELL 'Get-ChildItem -path C:\tmp'
       
@@ -46,7 +49,7 @@ If the command does not depend on any shell features, then direct execution shou
     This difference in performance can be very significant, especially under Microsoft Windows where PowerShell is the default.
     Direct calls can be 5-10x faster.
     
-    See [the example below](#example-using-cmdexe-microsoft-windows) for information about how to use `cmd.exe` instead of PowerShell.
+    See the examples under [the `Shell` variant option](#variant-option-shell) for information about how to use `cmd.exe` instead of PowerShell.
 
 ## Return Value
 
@@ -93,7 +96,7 @@ The  reasons why a call to `⎕SHELL` ends are described in the table below. `Ex
 
 Returning the exit code (instead of `⎕SHELL` producing some trappable error) makes it possible to access the other parts of the result, such as the error messages that were printed on the standard error stream. However, it is possible to turn non-successful exits into trappable errors using the [`ExitCheck`](#variant-option-exitcheck) variant.
 
-When the `ExitReason` is 2 or 3, the child process had not stopped running before `⎕SHELL` stopped, which means it might still be running, and require some appropriate cleanup (see [8373⌶](../../primitive-operators/i-beam/shell-process-control)).
+When the `ExitReason` is 2 or 3, the child process had not stopped running before `⎕SHELL` stopped, which means it might still be running, and require some appropriate cleanup (see [`8373⌶`](../../primitive-operators/i-beam/shell-process-control)).
 In practice, the child process often closes shortly after without the need for intervention, either due to the default signal being sent to it on non-Windows platforms (see the [`Signal`](#variant-option-signal) option), or because the connected streams are closed on the `⎕SHELL` end.
 
 ## Thread Switching
@@ -116,7 +119,7 @@ Table: Variant options overview { #variant-table }
 |[`Env`](#variant-option-env)|environment-variable definitions|Additional environment variables (default: none).|
 |[`Shell`](#variant-option-shell)|a shell specification|The shell used when `Y` is a character vector (default: operating-system specific).|
 |[`ExitCheck`](#variant-option-exitcheck)|`0` <small>(default)</small> or `1`|Whether abnormal exit reasons and codes raise `DOMAIN ERROR`.|
-|[`TimeOut`](#variant-option-timeout)|`0` <small>(default)</small> or a number of milliseconds|Upper limit on the duration of the call (`0` means no limit).|
+|[`Timeout`](#variant-option-timeout)|`0` <small>(default)</small> or a number of milliseconds|Upper limit on the duration of the call (`0` means no limit).|
 |[`Signal`](#variant-option-signal)|a signal number|Signal sent to the child process when it is abandoned (default: operating-system specific).|
 |[`Window`](#variant-option-window)|`'Hidden'` <small>(default)</small> or another window mode|Initial window mode (Microsoft Windows only).|
 
@@ -220,7 +223,9 @@ The `Env` variant option specifies any additional environment variables and thei
 
 Each row or two-element vector consists of an environment variable name and its value, both specified as character vectors.
 
-Example: Add three environment variables: `DAY=monday`, `MONTH=december`, and `WEEK=50`.
+<h4 class="example">Example</h4>
+
+Add three environment variables: `DAY=monday`, `MONTH=december`, and `WEEK=50`.
 
 ```apl
       ⍝ Using a two-column matrix and array notation
@@ -250,24 +255,6 @@ The value must be a character vector or a vector of character vectors with a len
 !!! info
     Shells typically takes some argument which specify that the next argument is a command to run, such as `/bin/bash -c` on Linux, but since the argument differs from shell to shell, it must be specified manually.
 
-#### Example using cmd.exe (Microsoft Windows) { .example }
-```apl
-      ⎕SHELL⍠'Shell' ('cmd.exe' '/C')⊢'someCmd'
-...
-```
-
-#### Example using bash (Linux) { .example }
-```apl
-      ⎕SHELL⍠'Shell' ('/bin/bash' '-c')⊢'someCmd'
-...
-```
-
-There is no difference between the following two calls; the `Shell` variant option is simply a convenience.
-```apl
-      ⎕SHELL'/bin/bash' '-c' 'a b c'
-      ⎕SHELL⍠'Shell' ('/bin/bash' '-c')⊢'a b c'
-```
-
 When the right argument of `⎕SHELL` is a nested vector, the `Shell` option has no effect.
 
 The default depends on the operating-system:
@@ -275,13 +262,33 @@ The default depends on the operating-system:
 - Microsoft Windows: `('C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' '-Command')`.
 - Linux, macOS, AIX: `('/bin/sh' '-c')`.
 
+<h4 class="example">Examples</h4>
+
+Using `cmd.exe` on Microsoft Windows:
+```apl
+      ⎕SHELL⍠'Shell' ('cmd.exe' '/C')⊢'someCmd'
+...
+```
+
+Using `bash` on Linux:
+```apl
+      ⎕SHELL⍠'Shell' ('/bin/bash' '-c')⊢'someCmd'
+...
+```
+
+There is no difference between the following two calls; the `Shell` variant option is simply a convenience:
+```apl
+      ⎕SHELL'/bin/bash' '-c' 'a b c'
+      ⎕SHELL⍠'Shell' ('/bin/bash' '-c')⊢'a b c'
+```
+
 ### Variant Option: ExitCheck
 The `ExitCheck` variant option specifies whether `⎕SHELL` should convert abnormal exit reasons and exit codes into a `DOMAIN ERORR`. The value must be a boolean scalar; if set to 1, a `DOMAIN ERROR` is reported if `ExitReason` and `ExitCode` are not both 0.
 
 The default `0`.
 
-### Variant Option: TimeOut
-The `TimeOut` variant option specifies an upper limit for the duration of the `⎕SHELL` call.
+### Variant Option: Timeout
+The `Timeout` variant option specifies an upper limit for the duration of the `⎕SHELL` call.
 The value must be a non-negative numeric scalar representing the number of milliseconds.
 The value `0` allows the `⎕SHELL` call to run for as long as it needs.
 
@@ -307,7 +314,7 @@ The `Window` variant option specifies the initial window mode. The value must be
 
 The default is `'Hidden'`.
 
-See also [8373⌶](../../primitive-operators/i-beam/shell-process-control).
+See also [`8373⌶`](../../primitive-operators/i-beam/shell-process-control).
 
 ## Default Redirections
 Most programs assume that the three standard streams are configured when the program starts. For this reason, `⎕SHELL` always sets up some redirections for those three, even when variant options have explicitly only set up some of them. For example, when `⎕SHELL⍠'Output' (1 ('File' '/tmp/log.txt'))⊢cmd` is run, stream 0 and stream 2 are set up to their default values.

--- a/language-reference-guide/docs/system-functions/shell.md
+++ b/language-reference-guide/docs/system-functions/shell.md
@@ -15,7 +15,7 @@ In practice, many command line tools that are useful when building cross-platfor
 
 ### Using the System's Shell
 When `Y` is a character vector, the contents are executed using the system's shell.
-The shell being used can be changed using the [`Shell`](#shell) variant. The defaults are:
+The shell being used can be changed using the [`Shell`](#variant-option-shell) variant. The defaults are:
 
 - Microsoft Windows: `PowerShell`
 - Linux, macOS, AIX: `/bin/sh`
@@ -38,7 +38,7 @@ d-----        26-11-2024     12:56                ullu
 
 ### Direct Execution
 
-When `Y` is a vector of character vectors or an enclosed character vector, the first element of the array is treated as a program name, and the rest as individual arguments. The program is executed directly, without invoking the system's shell first. The program name can be an absolute path, a relative path, or the name of an executable in the current search path (operating-system specific). When the program is specified as a relative path, the name is resolved relative to the working directory, which can be set with the [`WorkingDir`](#workingdir) variant.
+When `Y` is a vector of character vectors or an enclosed character vector, the first element of the array is treated as a program name, and the rest as individual arguments. The program is executed directly, without invoking the system's shell first. The program name can be an absolute path, a relative path, or the name of an executable in the current search path (operating-system specific). When the program is specified as a relative path, the name is resolved relative to the working directory, which can be set with the [`WorkingDir`](#variant-option-workingdir) variant.
 
 If the command does not depend on any shell features, then direct execution should be used as it has lower overhead.
 
@@ -71,9 +71,9 @@ A stream is a connection between the process and some resource, such as a file, 
 | 1 | Standard output | Output | Used to print regular output data. |
 | 2 | Standard error | Output | Used to print error messages or other information that is not part of the main output. |
 
-`⎕SHELL` provides great flexibility in what the streams should point to, by using the [`Output`](#output) and [`Input`](#input) variants. By default, the two output streams, 1 and 2, are configured such that the output produced on standard error is redirected to standard output and effectively merged together, and then turned into an APL array representing the lines of text.
+`⎕SHELL` provides great flexibility in what the streams should point to, by using the [`Output`](#variant-option-output) and [`Input`](#variant-option-input) variants. By default, the two output streams, 1 and 2, are configured such that the output produced on standard error is redirected to standard output and effectively merged together, and then turned into an APL array representing the lines of text.
 
-The StreamData and StreamIds vectors have the same length. The StreamIds are always sorted in ascending order. Each index describes one collected output stream; StreamIds contains the integer stream IDs, and the elements of StreamData depend on how the output is collected (see the [`Output`](#output) variant).
+The StreamData and StreamIds vectors have the same length. The StreamIds are always sorted in ascending order. Each index describes one collected output stream; StreamIds contains the integer stream IDs, and the elements of StreamData depend on how the output is collected (see the [`Output`](#variant-option-output) variant).
 
 By default, `⊃⊃⎕SHELL cmd` returns a vector of character vectors representing the lines of the collected output text from the child process (both standard output and standard error).
 
@@ -85,16 +85,16 @@ The  reasons why a call to `⎕SHELL` ends are described in the table below. `Ex
 | --- | --- | --- |
 | 0 | The child process finished and exited normally. | The non-negative exit code. |
 | 1 | The child process was terminated by a signal. | The negated signal number that caused the termination. |
-| 2 | `⎕SHELL` timed out before the child process exited (see the [`Timeout`](#timeout) option). | The constant `¯1006`. |
+| 2 | `⎕SHELL` timed out before the child process exited (see the [`Timeout`](#variant-option-timeout) option). | The constant `¯1006`. |
 | 3 | `⎕SHELL` was interrupted by a weak interrupt in the IDE. | The constant `¯1002`. |
 
 !!! windows "Dyalog on Microsoft Windows"
     `ExitReason` cannot be 1 on Microsoft Windows.
 
-Returning the exit code (instead of `⎕SHELL` producing some trappable error) makes it possible to access the other parts of the result, such as the error messages that were printed on the standard error stream. However, it is possible to turn non-successful exits into trappable errors using the [`ExitCheck`](#exitcheck) variant.
+Returning the exit code (instead of `⎕SHELL` producing some trappable error) makes it possible to access the other parts of the result, such as the error messages that were printed on the standard error stream. However, it is possible to turn non-successful exits into trappable errors using the [`ExitCheck`](#variant-option-exitcheck) variant.
 
 When the `ExitReason` is 2 or 3, the child process had not stopped running before `⎕SHELL` stopped, which means it might still be running, and require some appropriate cleanup (see [8373⌶](../../primitive-operators/i-beam/shell-process-control)).
-In practice, the child process often closes shortly after without the need for intervention, either due to the default signal being sent to it on non-Windows platforms (see the [`Signal`](#signal) option), or because the connected streams are closed on the `⎕SHELL` end.
+In practice, the child process often closes shortly after without the need for intervention, either due to the default signal being sent to it on non-Windows platforms (see the [`Signal`](#variant-option-signal) option), or because the connected streams are closed on the `⎕SHELL` end.
 
 ## Thread Switching
 `⎕SHELL` is a thread switch point, which means the interpreter will run other APL threads while a long-running `⎕SHELL` call is in progress.
@@ -102,9 +102,25 @@ In practice, the child process often closes shortly after without the need for i
 When an APL thread running `⎕SHELL` is terminated by [`⎕TKILL`](tkill.md) or [`)RESET`](../system-commands/reset.md), the child process might be left running, as if `⎕SHELL` was interrupted.
 
 ## Variant Options
-`⎕SHELL` supports the following variant options to control certain parts of the program execution context.
 
-### Output
+`⎕SHELL` supports ten variant options, summarised in [](#variant-table) and described in detail beneath it. There is no principal option. They control certain parts of the program execution context.
+
+Table: Variant options overview { #variant-table }
+
+|Variant Option|Value|Effect|
+|---|---|---|
+|[`Output`](#variant-option-output)|a set of redirections|Output stream redirections.|
+|[`Input`](#variant-option-input)|a set of redirections|Input stream redirections.|
+|[`WorkingDir`](#variant-option-workingdir)|a character vector|The child process's working directory (default: the interpreter's current directory).|
+|[`InheritEnv`](#variant-option-inheritenv)|`1` <small>(default)</small> or `0`|Whether the interpreter's environment variables are inherited.|
+|[`Env`](#variant-option-env)|environment-variable definitions|Additional environment variables (default: none).|
+|[`Shell`](#variant-option-shell)|a shell specification|The shell used when `Y` is a character vector (default: operating-system specific).|
+|[`ExitCheck`](#variant-option-exitcheck)|`0` <small>(default)</small> or `1`|Whether abnormal exit reasons and codes raise `DOMAIN ERROR`.|
+|[`TimeOut`](#variant-option-timeout)|`0` <small>(default)</small> or a number of milliseconds|Upper limit on the duration of the call (`0` means no limit).|
+|[`Signal`](#variant-option-signal)|a signal number|Signal sent to the child process when it is abandoned (default: operating-system specific).|
+|[`Window`](#variant-option-window)|`'Hidden'` <small>(default)</small> or another window mode|Initial window mode (Microsoft Windows only).|
+
+### Variant Option: Output
 The `Output` variant option controls output stream redirections. The value must describe a set of redirections, in one of the following formats:
 
 - a two-column matrix.
@@ -159,7 +175,7 @@ The callback is invoked when:
 
 Depending on the type or encoding, some of these conditions could happen when the buffer contains a number of bytes that do not make up a full item, such as when the buffer is full and the last byte is only one of multiple bytes needed to encode a UTF-8 character.
 
-### Input
+### Variant Option: Input
 The Input variant option controls input stream redirections. The value must describe a set of redirections, in one of the following formats:
 
 - a two-column matrix.
@@ -185,18 +201,18 @@ Any input the child process tries to read on its stream `Stream` will come from 
 
 The default is `0 2⍴0`, but see [Default Redirections](#default-redirections).
 
-### WorkingDir
+### Variant Option: WorkingDir
 The `WorkingDir` variant option sets the working directory of the child process. The value must be a character vector that refers to a valid directory, such as `'/tmp/somedir'` on Linux, or `'C:\tmp\somedir'` on Microsoft Windows.
 
 The default is the current working directory of the interpreter.
 
-### InheritEnv
+### Variant Option: InheritEnv
 The `InheritEnv` variant option specifies whether the set of environment variables from the interpreter should be inherited by the child process. The value must be a Boolean scalar.
 
 The default is `1`.
 
-### Env
-The `Env` variant option specifies any additional environment variables and their values. If an environment variable that already exists in the set of inherited variables (see [`InheritEnv`](#inheritenv)) is specified here, the value from `Env` takes precedence. The option value must be one of the following:
+### Variant Option: Env
+The `Env` variant option specifies any additional environment variables and their values. If an environment variable that already exists in the set of inherited variables (see [`InheritEnv`](#variant-option-inheritenv)) is specified here, the value from `Env` takes precedence. The option value must be one of the following:
 
 - a two-column matrix.
 - a two-element vector.
@@ -226,7 +242,7 @@ All the environment variable names must be unique within the scope of the call t
 
 The default is `0 2⍴⍬`.
 
-### Shell
+### Variant Option: Shell
 The `Shell` variant option sets the shell to be used when `Y` is a character vector.
 
 The value must be a character vector or a vector of character vectors with a length of at least 1.
@@ -259,19 +275,19 @@ The default depends on the operating-system:
 - Microsoft Windows: `('C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' '-Command')`.
 - Linux, macOS, AIX: `('/bin/sh' '-c')`.
 
-### ExitCheck
+### Variant Option: ExitCheck
 The `ExitCheck` variant option specifies whether `⎕SHELL` should convert abnormal exit reasons and exit codes into a `DOMAIN ERORR`. The value must be a boolean scalar; if set to 1, a `DOMAIN ERROR` is reported if `ExitReason` and `ExitCode` are not both 0.
 
 The default `0`.
 
-### Timeout
+### Variant Option: TimeOut
 The `TimeOut` variant option specifies an upper limit for the duration of the `⎕SHELL` call.
 The value must be a non-negative numeric scalar representing the number of milliseconds.
 The value `0` allows the `⎕SHELL` call to run for as long as it needs.
 
 The default is `0`.
 
-### Signal
+### Variant Option: Signal
 The `Signal` variant option specifies a signal to send to the child process when it is being abandoned by `⎕SHELL`.
 The value must be either an integer representing a valid signal number, or `0` (which means no signal should be sent).
 
@@ -283,7 +299,7 @@ The default depends on the operating-system:
 - Microsoft Windows: `0`.
 - Linux, macOS, AIX: the numeric value of `SIGTERM` which is the signal that asks the child process to shut itself down.
 
-### Window
+### Variant Option: Window
 !!! windows "Dyalog on Microsoft Windows"
     This option only has an effect on Windows.
 

--- a/language-reference-guide/docs/system-functions/vset.md
+++ b/language-reference-guide/docs/system-functions/vset.md
@@ -84,7 +84,7 @@ Multiple names, with a single value:
 
 `⎕VSET` supports one variant option, `Trigger`.
 
-### Variant Option: Trigger
+### Variant Option: `Trigger`
 
 The `Trigger` variant option specifies whether any [triggers](../../../programming-reference-guide/triggers/triggers) should be run for the modified variables in the target namespace that have triggers attached.
 The value must be a Boolean scalar. The default is `1`, meaning that triggers are run.

--- a/language-reference-guide/docs/system-functions/vset.md
+++ b/language-reference-guide/docs/system-functions/vset.md
@@ -80,7 +80,11 @@ Multiple names, with a single value:
       name1 name2 name3
  APL  APL  APL
 ```
-## Variant Option: Trigger
+## Variant Options
+
+`⎕VSET` supports one variant option, `Trigger`.
+
+### Variant Option: Trigger
 
 The `Trigger` variant option specifies whether any [triggers](../../../programming-reference-guide/triggers/triggers) should be run for the modified variables in the target namespace that have triggers attached.
 The value must be a Boolean scalar. The default is `1`, meaning that triggers are run.

--- a/language-reference-guide/docs/system-functions/xml.md
+++ b/language-reference-guide/docs/system-functions/xml.md
@@ -7,7 +7,7 @@ search:
 
 `⎕XML` converts an XML string into an APL array or converts an APL array into an XML string.
 
-Options for `⎕XML` are specified using the Variant operator `⍠` or by the optional left argument `X`. The former is recommended but the older mechanism using the left argument is still supported.
+Options for `⎕XML` are specified using the _variant_ operator `⍠` or by the optional left argument `X`. The former is recommended but the older mechanism using the left argument is still supported.
 
 For conversion *from* XML, `Y` is a character vector containing an XML string. The result `R` is a 5 column matrix whose columns are made up as follows:
 
@@ -183,11 +183,11 @@ Table: Variant options for `⎕XML` { #variantoptionsforxml }
 |[`Markup`](#variant-option-markup)|`markup`|`Strip` or `Preserve`|`Strip`|Whether markup appears in the result (import only).|
 |[`UnknownEntity`](#variant-option-unknownentity)|`unknown-entity`|`Replace` or `Preserve`|`Replace`|Handling of unknown entity and character references.|
 
-The values of each option are tabulated below. In each case the value of the option for Variant is given first, followed by its equivalent for the optional left argument in brackets; for example, `Strip` `(strip)`.
+The values of each option are tabulated below. In each case the value of the option for _variant_ is given first, followed by its equivalent for the optional left argument in brackets; for example, `Strip` `(strip)`.
 
 Note that the default value is shown first, and that the option names and values are case-sensitive.
 
-If options are specified using the optional left argument,  `X` specifies a set of option/value pairs, each of which is a character vector. `X` can be a 2-element vector, or a vector of 2-element character vectors. In the examples below, this method is illustrated by the equivalent expression written as a comment, following the recommended approach using the Variant operator `⍠`:
+If options are specified using the optional left argument,  `X` specifies a set of option/value pairs, each of which is a character vector. `X` can be a 2-element vector, or a vector of 2-element character vectors. In the examples below, this method is illustrated by the equivalent expression written as a comment, following the recommended approach using the _variant_ operator `⍠`:
 ```apl
 
       ]Display (⎕XML⍠'Whitespace' 'Strip')eg

--- a/language-reference-guide/docs/system-functions/xml.md
+++ b/language-reference-guide/docs/system-functions/xml.md
@@ -113,7 +113,7 @@ Because certain markup which describes the format of allowable data (such as ele
 
 Attributes with names beginning **xml:** are reserved. Only **xml:space** is treated specially by `⎕XML`. When converting both from and to XML, the value for this attribute has the following effects on space normalization for the character data within this element and child elements within it (unless subsequently overridden):
 
-- **default** – space normalization is as determined by the **whitespace** option. 
+- **default** – space normalization is as determined by the `Whitespace` option. 
 - **preserve** - space normalization is disabled – all whitespace is preserved as given.
 - **any other value** – rejected.
 
@@ -146,7 +146,7 @@ The remainder of XML markup, including document type declarations,  XML declarat
 
 - The level number in the first column of the result `R` is 0 for the outermost level and subsequent levels are represented by an increase of 1 for each level. Thus, for "&lt;xml>&lt;document id="001">An introduction to XML &lt;/document>&lt;/xml>&lt;/code>" the _xml_ element is at level 0 and the _document id_ element is at level 1. The text within the _document id_ element is at level 2.
 - Each tag in the XML contains an element name and zero or more attribute name and value pairs, delimited by '<' and '>' characters. The delimiters are not included in the result matrix. The element name of a tag is stored in column 2 and the attribute(s) in column 4.
-- All XML markup other than tags are delimited by either '<!' and '>', or '<?' and '>' characters. By default these are not stored in the result matrix but the **markup** option may be used to specify that they are. The elements are stored in their entirety, except for the leading and trailing '<' and '>' characters, in column 2. Nested constructs are treated as a single block. Because the leading and trailing '<' and '>' characters are stripped, such entries will always have either '!' or '&' as the first character.
+- All XML markup other than tags are delimited by either '<!' and '>', or '<?' and '>' characters. By default these are not stored in the result matrix but the `Markup` option may be used to specify that they are. The elements are stored in their entirety, except for the leading and trailing '<' and '>' characters, in column 2. Nested constructs are treated as a single block. Because the leading and trailing '<' and '>' characters are stripped, such entries will always have either '!' or '&' as the first character.
 - Character data itself has no tag name or attributes. As an optimisation, when character data is the sole content of an element, it is included with its parent rather than as a separate row in the result. Note that when this happens, the level number stored is that of the parent; the data itself implicitly has a level number one greater.
 - Attribute name and value pairs associated with the element name are stored in the fourth column, in an (*n x 2*) matrix of character values, for the *n* (including zero) pairs.
 - Each row is further described in the fifth column as a convenience to simplify processing of the array (although this information could be deduced). Any given row may contain an entry for an element, character data, markup not otherwise defined, a comment or a processing instruction. Furthermore, an element will have zero or more of these as children. For all types except elements, the value in the fifth column is as shown above. For elements, the value is computed by adding together the value of the row itself (1) and those of its children. For example, the value for a row for an element which contains one or more sub-elements and character data is 7 – that is 1 (element) + 2 (child element) + 4 (character data). It should be noted that:
@@ -155,7 +155,7 @@ The remainder of XML markup, including document type declarations,  XML declarat
 - Only immediate children are considered when computing the value. For example, an element which contains a sub-element which in turn contains character data does not itself contain the character data.
 - The computed value is derived from what is actually preserved in the array. For example, if the source XML contains an element which contains a comment, but comments are being discarded, there will be no entry for the comment in the array and the fifth column for the element will not indicate that it has a child comment.
 
-### Conversion to XML
+## Conversion to XML
 
 Conversion to XML takes an array with the format described above and generates XML text from it. There are some simplifications to the array which are accepted:
 
@@ -171,17 +171,19 @@ The following validations are performed on the data in the array:
 
 Then, character references and entity references are emitted in place of characters where necessary, to ensure that valid XML is generated. However, markup, if present, is *not* validated and it is possible to generate invalid XML if care in not taken with markup constructs.
 
-### Options
+## Variant Options
 
-There are 3 options which may be specified using the Variant operator `⍠` (recommended) or by the optional left argument `X` (retained for backwards compatibility). The names are different and are case-sensitive; they must be spelled exactly as shown below.
+`⎕XML` supports three variant options, `Whitespace`, `Markup` and `UnknownEntity`, summarised in [](#variant-table) and described in detail beneath it. There is no principal option. Each option can also be specified through the optional left argument `X` (retained for backwards compatibility) using the alternative name shown in the table; the names are case-sensitive and must be spelled exactly as shown.
 
-|Option names for Variant|Option names for left argument|
-|------------------------|------------------------------|
-|Whitespace              |whitespace                    |
-|Markup                  |markup                        |
-|UnknownEntity           |unknown-entity                |
+Table: Variant options overview { #variant-table }
 
-The values of each option are tabulated below. In each case the value of the option for Variant is given first, followed by its equivalent for the optional left argument in brackets; for example, **UnknownEntity (unknown-entity)**.
+|Variant Option|Left-argument name|Values|Effect|
+|---|---|---|---|
+|[`Whitespace`](#variant-option-whitespace)|`whitespace`|`Strip` <small>(default)</small>, `Trim` or `Preserve`|Handling of white space in character data.|
+|[`Markup`](#variant-option-markup)|`markup`|`Strip` <small>(default)</small> or `Preserve`|Whether markup appears in the result (import only).|
+|[`UnknownEntity`](#variant-option-unknownentity)|`unknown-entity`|`Replace` <small>(default)</small> or `Preserve`|Handling of unknown entity and character references.|
+
+The values of each option are tabulated below. In each case the value of the option for Variant is given first, followed by its equivalent for the optional left argument in brackets; for example, `Strip` `(strip)`.
 
 Note that the default value is shown first, and that the option names and values are case-sensitive.
 
@@ -194,9 +196,9 @@ If options are specified using the optional left argument,  `X` specifies a set 
 
 Errors detected in the input arrays or options will all cause `DOMAIN ERROR`.
 
-### Whitespace (whitespace)
+### Variant Option: Whitespace
 
-When converting from XML `Whitespace` specifies the default handling of white space surrounding and within character data. When converting to XML `Whitespace` specifies the default formatting of the XML. Note that attribute values are not comprised of character data so white space in attribute values is always preserved.
+The left-argument name is `whitespace`. When converting from XML, `Whitespace` specifies the default handling of white space surrounding and within character data. When converting to XML `Whitespace` specifies the default formatting of the XML. Note that attribute values are not comprised of character data so white space in attribute values is always preserved.
 
 |Converting from XML||
 |---|---|
@@ -317,9 +319,9 @@ When converting from XML `Whitespace` specifies the default handling of white sp
 └∊──────────────────────────────────────┘
 ```
 
-### Markup (markup)
+### Variant Option: Markup
 
-When converting from XML, `Markup` determines whether markup (other than entity tags) appears in the output array or not. When converting to XML `Markup` has no effect.
+The left-argument name is `markup`. When converting from XML, `Markup` determines whether markup (other than entity tags) appears in the output array or not. When converting to XML `Markup` has no effect.
 
 |Converting from XML                                                                                                                       ||
 |--------------------|----------------------------------------------------------------------------------------------------------------------|
@@ -427,9 +429,9 @@ When converting from XML, `Markup` determines whether markup (other than entity 
 └∊──────────────────────────────────────────────┘
 ```
 
-### UnknownEntity (unknown-entity)
+### Variant Option: UnknownEntity
 
-When converting from XML, this option determines what happens when an unknown entity reference, or a character reference for a Unicode character which cannot be represented as an APL character, is encountered. In Classic versions of Dyalog APL that is any Unicode character which does not appear in `⎕AVU`. When converting to XML, this option determines what happens to Esc characters (`⎕UCS 27`) in data.
+The left-argument name is `unknown-entity`. When converting from XML, this option determines what happens when an unknown entity reference, or a character reference for a Unicode character which cannot be represented as an APL character, is encountered. In Classic versions of Dyalog APL that is any Unicode character which does not appear in `⎕AVU`. When converting to XML, this option determines what happens to Esc characters (`⎕UCS 27`) in data.
 
 |Converting from XML                                                                                                              ||
 |--------------------|-------------------------------------------------------------------------------------------------------------|

--- a/language-reference-guide/docs/system-functions/xml.md
+++ b/language-reference-guide/docs/system-functions/xml.md
@@ -69,7 +69,7 @@ XML is an open standard, designed to allow exchange of data between applications
 
 The `⎕XML` function is designed to handle XML to the extent required to import and export APL data. It favours speed over complexity - some markup is tolerated but largely ignored, and there are no XML query or validation features. APL applications which require processing, querying or validation will need to call external tools for this, and finally call `⎕XML` on the resulting XML to perform the transformation into APL arrays.
 
-XML grammar such as processing instructions, document type declarations etc. may optionally be stored in the APL array, but will not be processed or validated. This is principally to allow regeneration of XML from XML input which contains such structures, but an APL application could process the data if it chose to do so.
+XML grammar such as processing instructions, document type declarations etc. can optionally be stored in the APL array, but will not be processed or validated. This is principally to allow regeneration of XML from XML input which contains such structures, but an APL application could process the data if it chose to do so.
 
 The XML definition uses specific terminology to describe its component parts. The following is a summary of the terms used in this section:
 
@@ -97,17 +97,17 @@ An example pair of tags, named TagName is
 
 `<TagName></TagName>`
 
-This pair is shown with no content between the tags; this may be abbreviated as an empty element tag as
+This pair is shown with no content between the tags; this can be abbreviated as an empty element tag as
 
 `<TagName/>`
 
-Tags may be given zero or more attributes, which are specified as name/value pairs; for example
+Tags can be given zero or more attributes, which are specified as name/value pairs; for example
 
 `<TagName AttName="AttValue">`
 
-Attribute values may be delimited by either double quotes as shown or single quotes (apostrophes); they may not contain certain characters (the delimiting quote, '&' or '<') and these must be represented by entity or character references.
+Attribute values can be delimited by either double quotes as shown or single quotes (apostrophes); they cannot contain certain characters (the delimiting quote, '&' or '<') and these must be represented by entity or character references.
 
-The content of elements may be zero or more mixed occurrences of character data and nested elements. Tags and attribute names *describe* data, attribute values and the content within tags contain the data itself. Nesting of elements allows structure to be defined.
+The content of elements can be zero or more mixed occurrences of character data and nested elements. Tags and attribute names *describe* data, attribute values and the content within tags contain the data itself. Nesting of elements allows structure to be defined.
 
 Because certain markup which describes the format of allowable data (such as element type declarations and attribute-list declarations) is not processed, no error will be reported if element contents and attributes do not conform to their restricted declarations, nor are attributes automatically added to tags if not explicitly given.
 
@@ -125,15 +125,15 @@ Comments are fully supported markup. They are delimited by '<!--' and '-->' and 
 
 ### CDATA Sections
 
-CDATA Sections are fully supported markup. They are used to delimit text within character data which has, or may have, markup text in it which is not to be processed as such. They and are delimited by '<![CDATA[' and ']]>'. CDATA sections are never recorded in the APL array as markup when XML is processed – instead, that data appears as character data. Note that this means that if you convert XML to an APL array and then convert this back to XML, CDATA sections will not be regenerated. It is, however, *possible* to generate CDATA sections in XML by presenting them as markup.
+CDATA Sections are fully supported markup. They are used to delimit text within character data which has, or might have, markup text in it which is not to be processed as such. They and are delimited by '<![CDATA[' and ']]>'. CDATA sections are never recorded in the APL array as markup when XML is processed – instead, that data appears as character data. Note that this means that if you convert XML to an APL array and then convert this back to XML, CDATA sections will not be regenerated. It is, however, *possible* to generate CDATA sections in XML by presenting them as markup.
 
 ### Processing Instructions
 
 Processing Instructions are delimited by '<&' and '&>' but are otherwise treated as other markup, below.
 
-### Other markup
+### Other Markup
 
-The remainder of XML markup, including document type declarations,  XML declarations and text declarations are all delimited by '<!' and '>', and may contain nested markup. If markup is being preserved the text, including nested markup, will appear as a single row in the APL array.  `⎕XML` does not process the contents of such markup. This has varying effects, including but not limited to the following:
+The remainder of XML markup, including document type declarations,  XML declarations and text declarations are all delimited by '<!' and '>', and can contain nested markup. If markup is being preserved the text, including nested markup, will appear as a single row in the APL array.  `⎕XML` does not process the contents of such markup. This has varying effects, including but not limited to the following:
 
 - No validation is performed.
 - Constraints specified in markup such element type declarations will be ignored and therefore syntactically correct elements which fall outside their constraint will not be rejected.
@@ -146,10 +146,10 @@ The remainder of XML markup, including document type declarations,  XML declarat
 
 - The level number in the first column of the result `R` is 0 for the outermost level and subsequent levels are represented by an increase of 1 for each level. Thus, for "&lt;xml>&lt;document id="001">An introduction to XML &lt;/document>&lt;/xml>&lt;/code>" the _xml_ element is at level 0 and the _document id_ element is at level 1. The text within the _document id_ element is at level 2.
 - Each tag in the XML contains an element name and zero or more attribute name and value pairs, delimited by '<' and '>' characters. The delimiters are not included in the result matrix. The element name of a tag is stored in column 2 and the attribute(s) in column 4.
-- All XML markup other than tags are delimited by either '<!' and '>', or '<?' and '>' characters. By default these are not stored in the result matrix but the `Markup` option may be used to specify that they are. The elements are stored in their entirety, except for the leading and trailing '<' and '>' characters, in column 2. Nested constructs are treated as a single block. Because the leading and trailing '<' and '>' characters are stripped, such entries will always have either '!' or '&' as the first character.
+- All XML markup other than tags are delimited by either '<!' and '>', or '<?' and '>' characters. By default these are not stored in the result matrix but the `Markup` option can be used to specify that they are. The elements are stored in their entirety, except for the leading and trailing '<' and '>' characters, in column 2. Nested constructs are treated as a single block. Because the leading and trailing '<' and '>' characters are stripped, such entries will always have either '!' or '&' as the first character.
 - Character data itself has no tag name or attributes. As an optimisation, when character data is the sole content of an element, it is included with its parent rather than as a separate row in the result. Note that when this happens, the level number stored is that of the parent; the data itself implicitly has a level number one greater.
 - Attribute name and value pairs associated with the element name are stored in the fourth column, in an (*n x 2*) matrix of character values, for the *n* (including zero) pairs.
-- Each row is further described in the fifth column as a convenience to simplify processing of the array (although this information could be deduced). Any given row may contain an entry for an element, character data, markup not otherwise defined, a comment or a processing instruction. Furthermore, an element will have zero or more of these as children. For all types except elements, the value in the fifth column is as shown above. For elements, the value is computed by adding together the value of the row itself (1) and those of its children. For example, the value for a row for an element which contains one or more sub-elements and character data is 7 – that is 1 (element) + 2 (child element) + 4 (character data). It should be noted that:
+- Each row is further described in the fifth column as a convenience to simplify processing of the array (although this information could be deduced). Any given row can contain an entry for an element, character data, markup not otherwise defined, a comment or a processing instruction. Furthermore, an element will have zero or more of these as children. For all types except elements, the value in the fifth column is as shown above. For elements, the value is computed by adding together the value of the row itself (1) and those of its children. For example, the value for a row for an element which contains one or more sub-elements and character data is 7 – that is 1 (element) + 2 (child element) + 4 (character data). It should be noted that:
 - Odd values always represent elements. Odd values other than 1 indicate that there are children.
 - Elements which contain just character data (5) are combined into a single row as noted previously.
 - Only immediate children are considered when computing the value. For example, an element which contains a sub-element which in turn contains character data does not itself contain the character data.
@@ -159,9 +159,9 @@ The remainder of XML markup, including document type declarations,  XML declarat
 
 Conversion to XML takes an array with the format described above and generates XML text from it. There are some simplifications to the array which are accepted:
 
-- The fifth column is not needed for XML generation and is effectively ignored. Any numeric values are accepted, or the column may be omitted altogether. If the fifth column is omitted then the fourth column may also be omitted.
-- For the fourth column, if there are no attributes in a particular row then the `(0 2⍴⊂'')` may be abbreviated as `⍬` (zilde). If there is only one attribute then a 2-element vector can be specified.
-- Data in the third column and attribute values in the fourth column (if present) may be provided as either character vectors or numeric values. Numeric values are implicitly formatted as if `⎕PP` was set to 17.
+- The fifth column is not needed for XML generation and is effectively ignored. Any numeric values are accepted, or the column can be omitted altogether. If the fifth column is omitted then the fourth column can also be omitted.
+- For the fourth column, if there are no attributes in a particular row then the `(0 2⍴⊂'')` can be abbreviated as `⍬` (zilde). If there is only one attribute then a 2-element vector can be specified.
+- Data in the third column and attribute values in the fourth column (if present) can be provided as either character vectors or numeric values. Numeric values are implicitly formatted as if `⎕PP` was set to 17.
 
 The following validations are performed on the data in the array:
 
@@ -173,9 +173,9 @@ Then, character references and entity references are emitted in place of charact
 
 ## Variant Options
 
-`⎕XML` supports three variant options, `Whitespace`, `Markup` and `UnknownEntity`, summarised in [](#variant-table) and described in detail beneath it. There is no principal option. Each option can also be specified through the optional left argument `X` (retained for backwards compatibility) using the alternative name shown in the table; the names are case-sensitive and must be spelled exactly as shown.
+`⎕XML` supports three variant options, `Whitespace`, `Markup` and `UnknownEntity`, summarised in [](#variantoptionsforxml) and described in detail beneath it. There is no principal option. Each option can also be specified through the optional left argument `X` (retained for backwards compatibility) using the alternative name shown in the table; the names are case-sensitive and must be spelled exactly as shown.
 
-Table: Variant options overview { #variant-table }
+Table: Variant options for `⎕XML` { #variantoptionsforxml }
 
 |Variant Option|Left-argument name|Valid Values|Default|Effect|
 |---|---|---|---|---|
@@ -196,7 +196,7 @@ If options are specified using the optional left argument,  `X` specifies a set 
 
 Errors detected in the input arrays or options will all cause `DOMAIN ERROR`.
 
-### Variant Option: Whitespace
+### Variant Option: `Whitespace`
 
 The left-argument name is `whitespace`. When converting from XML, `Whitespace` specifies the default handling of white space surrounding and within character data. When converting to XML `Whitespace` specifies the default formatting of the XML. Note that attribute values are not comprised of character data so white space in attribute values is always preserved.
 
@@ -319,7 +319,7 @@ The left-argument name is `whitespace`. When converting from XML, `Whitespace` s
 └∊──────────────────────────────────────┘
 ```
 
-### Variant Option: Markup
+### Variant Option: `Markup`
 
 The left-argument name is `markup`. When converting from XML, `Markup` determines whether markup (other than entity tags) appears in the output array or not. When converting to XML `Markup` has no effect.
 
@@ -429,7 +429,7 @@ The left-argument name is `markup`. When converting from XML, `Markup` determine
 └∊──────────────────────────────────────────────┘
 ```
 
-### Variant Option: UnknownEntity
+### Variant Option: `UnknownEntity`
 
 The left-argument name is `unknown-entity`. When converting from XML, this option determines what happens when an unknown entity reference, or a character reference for a Unicode character which cannot be represented as an APL character, is encountered. In Classic versions of Dyalog APL that is any Unicode character which does not appear in `⎕AVU`. When converting to XML, this option determines what happens to Esc characters (`⎕UCS 27`) in data.
 

--- a/language-reference-guide/docs/system-functions/xml.md
+++ b/language-reference-guide/docs/system-functions/xml.md
@@ -159,8 +159,8 @@ The remainder of XML markup, including document type declarations,  XML declarat
 
 Conversion to XML takes an array with the format described above and generates XML text from it. There are some simplifications to the array which are accepted:
 
-- The fifth column is not needed for XML generation and is effectively ignored. Any numeric values are accepted, or the column can be omitted altogether. If the fifth column is omitted then the fourth column can also be omitted.
-- For the fourth column, if there are no attributes in a particular row then the `(0 2⍴⊂'')` can be abbreviated as `⍬` (zilde). If there is only one attribute then a 2-element vector can be specified.
+- The fifth column is not needed for XML generation and is effectively ignored. Any numeric values are accepted, or the column can be omitted altogether. If the fifth column is omitted, then the fourth column can also be omitted.
+- For the fourth column, if there are no attributes in a particular row, then the `(0 2⍴⊂'')` can be abbreviated as `⍬` (zilde). If there is only one attribute, then a 2-element vector can be specified.
 - Data in the third column and attribute values in the fourth column (if present) can be provided as either character vectors or numeric values. Numeric values are implicitly formatted as if `⎕PP` was set to 17.
 
 The following validations are performed on the data in the array:

--- a/language-reference-guide/docs/system-functions/xml.md
+++ b/language-reference-guide/docs/system-functions/xml.md
@@ -177,11 +177,11 @@ Then, character references and entity references are emitted in place of charact
 
 Table: Variant options overview { #variant-table }
 
-|Variant Option|Left-argument name|Values|Effect|
-|---|---|---|---|
-|[`Whitespace`](#variant-option-whitespace)|`whitespace`|`Strip` <small>(default)</small>, `Trim` or `Preserve`|Handling of white space in character data.|
-|[`Markup`](#variant-option-markup)|`markup`|`Strip` <small>(default)</small> or `Preserve`|Whether markup appears in the result (import only).|
-|[`UnknownEntity`](#variant-option-unknownentity)|`unknown-entity`|`Replace` <small>(default)</small> or `Preserve`|Handling of unknown entity and character references.|
+|Variant Option|Left-argument name|Valid Values|Default|Effect|
+|---|---|---|---|---|
+|[`Whitespace`](#variant-option-whitespace)|`whitespace`|`Strip`, `Trim` or `Preserve`|`Strip`|Handling of white space in character data.|
+|[`Markup`](#variant-option-markup)|`markup`|`Strip` or `Preserve`|`Strip`|Whether markup appears in the result (import only).|
+|[`UnknownEntity`](#variant-option-unknownentity)|`unknown-entity`|`Replace` or `Preserve`|`Replace`|Handling of unknown entity and character references.|
 
 The values of each option are tabulated below. In each case the value of the option for Variant is given first, followed by its equivalent for the optional left argument in brackets; for example, `Strip` `(strip)`.
 


### PR DESCRIPTION
Fixes #887 and #717

Note that ⎕CSV's page renders strangely due to it containing &lt;h1>s.This will be fixed separately.