### PR TITLE
Correct AplCoreName behaviour for multiple wild-cards (#884)

### DIFF
--- a/windows-installation-and-configuration-guide/docs/configuration-parameters/aplcorename.md
+++ b/windows-installation-and-configuration-guide/docs/configuration-parameters/aplcorename.md
@@ -1,6 +1,6 @@
 # AplCoreName
 
-This parameter specifies the directory and name of the file in which *aplcore* should be saved. The optional wild-card character (`*`) is replaced by a number when the file is written. If there is more than one `*` in **AplCoreName**, the string is used as is; no substitution is made. For more details, including how to prevent aplcore files from being generated, see [MaxAplCores](maxaplcores.md).
+This parameter specifies the directory and name of the file in which *aplcore* should be saved. The optional wild-card character (`*`) is replaced by a number when the file is written; only one `*` can be used. If **AplCoreName** contains more than one `*`, the setting is ignored and the aplcore is named `aplcore`. For more details, including how to prevent aplcore files from being generated, see [MaxAplCores](maxaplcores.md).
 
 Note that APL terminates with an exit code of 3 when an aplcore file is generated.
 


### PR DESCRIPTION
Only one * can be used. If AplCoreName contains more than one *, the setting is ignored and the aplcore is named aplcore, rather than the string being used as is.