### PR TITLE
Document VScroll and HScroll effects on UpDown objects (#759)

### DIFF
--- a/object-reference/docs/properties/hscroll.md
+++ b/object-reference/docs/properties/hscroll.md
@@ -16,6 +16,8 @@ For a [StatusBar](../objects/statusbar.md), [TabBar](../objects/tabbar.md) or [T
 
 For a [Grid](../objects/grid.md), HScroll may be `0` (no horizontal scrollbar), `¯1` (scrollbar is displayed when required), `¯2` (same as `¯1`) or `¯3` (scrollbar is always displayed).
 
+For an [UpDown](../objects/updown.md) object, a value of `¯1` makes the arrows horizontal (a left arrow beside a right arrow). See also [VScroll](vscroll.md).
+
 **Application**
 
 Objects: [Combo](../objects/combo.md), [ComboEx](../objects/comboex.md), [Edit](../objects/edit.md), [Form](../objects/form.md), [Grid](../objects/grid.md), [ListView](../objects/listview.md), [RichEdit](../objects/richedit.md), [Scroll](../objects/scroll.md), [StatusBar](../objects/statusbar.md), [SubForm](../objects/subform.md), [TabBar](../objects/tabbar.md), [ToolBar](../objects/toolbar.md), [TrackBar](../objects/trackbar.md), [UpDown](../objects/updown.md)

--- a/object-reference/docs/properties/vscroll.md
+++ b/object-reference/docs/properties/vscroll.md
@@ -22,6 +22,8 @@ For a [StatusBar](../objects/statusbar.md), [TabBar](../objects/tabbar.md) or [T
 
 For a [Grid](../objects/grid.md), VScroll may be 0 (no vertical scrollbar), `¯1` (scrollbar is displayed when required), `¯2` (same as `¯1`) or `¯3` (scrollbar is always displayed).
 
+For an [UpDown](../objects/updown.md) object, a value of `¯1` makes the arrows vertical (an up arrow above a down arrow). See also [HScroll](hscroll.md).
+
 **Application**
 
 Objects: [Combo](../objects/combo.md), [ComboEx](../objects/comboex.md), [Edit](../objects/edit.md), [Form](../objects/form.md), [Grid](../objects/grid.md), [List](../objects/list.md), [ListView](../objects/listview.md), [RichEdit](../objects/richedit.md), [Scroll](../objects/scroll.md), [StatusBar](../objects/statusbar.md), [SubForm](../objects/subform.md), [TabBar](../objects/tabbar.md), [ToolBar](../objects/toolbar.md), [TrackBar](../objects/trackbar.md), [UpDown](../objects/updown.md)


### PR DESCRIPTION
For an UpDown object, VScroll of ¯1 makes the arrows vertical and HScroll of ¯1 makes them horizontal. Cross-link the two property pages.

Fixes #759 