### PR TITLE
Document Align 'Left' for ListView objects (#729)

### DIFF
--- a/object-reference/docs/objects/listview.md
+++ b/object-reference/docs/objects/listview.md
@@ -12,7 +12,7 @@ The Items property is a vector of character vectors that specifies the labels fo
 small icon (16x16 pixel) set. Alternatively, [ImageListObj](../properties/imagelistobj.md) may be empty (no icons displayed) or contain just the name of a single large icon [ImageList](imagelist.md).
 
 The [View](../properties/view.md) property contains a character vector that determines how the items are displayed. It may have one of the
-following values; `'Icon'` (the default), `'SmallIcon'`, `'List'` or `'Report'`. When View is `'Icon'` or `'SmallIcon'`, the items are arranged *row-wise* with large or small icons as appropriate. When View is set to `'List'`, the items are arranged *column-wise* using small icons. Examples of `'Icon'` and `'List'` views are illustrated below.
+following values; `'Icon'` (the default), `'SmallIcon'`, `'List'` or `'Report'`. When View is `'Icon'` or `'SmallIcon'`, the items are arranged *row-wise* with large or small icons as appropriate. In these views, setting the [Align](../properties/align.md) property to `'Left'` left-aligns the items along the left side of the object. When View is set to `'List'`, the items are arranged *column-wise* using small icons. Examples of `'Icon'` and `'List'` views are illustrated below.
 
 ![](../img/listview-icon.png)
 

--- a/object-reference/docs/properties/align.md
+++ b/object-reference/docs/properties/align.md
@@ -12,6 +12,8 @@ For a [DateTimePicker](../objects/datetimepicker.md), the Align property specifi
 
 For a single-line [Edit](../objects/edit.md), Align specifies the vertical alignment of the text. It may be `'None'` (the default), `'Centre'` or `'Center'`.
 
+For a [ListView](../objects/listview.md), Align may be `'Left'`, which left-aligns the items along the left side of the object when the [View](view.md) property is `'Icon'` or `'SmallIcon'`. It has no effect when View is `'List'` or `'Report'`.
+
 For a [Menu](../objects/menu.md), [MenuItem](../objects/menuitem.md), or [StatusField](../objects/statusfield.md), Align `'Right'` is used to position the object at the right end of its parent [MenuBar](../objects/menubar.md) or [StatusBar](../objects/statusbar.md). `'None'` is equivalent to `'Left'` which is the default.
 
 For objects of type [CoolBar](../objects/coolbar.md), [Splitter](../objects/splitter.md), [Scroll](../objects/scroll.md), [StatusBar](../objects/statusbar.md), [TabBar](../objects/tabbar.md), [ToolBar](../objects/toolbar.md) and [ToolControl](../objects/toolcontrol.md), Align may be `'None'`, `'Top'`, `'Bottom'`, `'Left'` or `'Right'`. It specifies to which (if any) of the four sides of the parent the object is anchored and also the default position and size of the object. Specifying Align typically causes the [Attach](attach.md) property to be set to appropriate values as follows :


### PR DESCRIPTION
For a ListView, Align 'Left' left-aligns the items along the left side of the object when View is 'Icon' or 'SmallIcon'. Note it on both the Align property page and the ListView object page.