### PR TITLE
Clarify XRange and YRange as edges rather than corners (#696)

### DIFF
--- a/object-reference/docs/properties/xrange.md
+++ b/object-reference/docs/properties/xrange.md
@@ -4,7 +4,7 @@
 
 XRange and [YRange](yrange.md) together determine a user-defined co-ordinate system. These properties are effective on the object's children which have [Coord](coord.md) set to `'User'`.
 
-XRange is a 2-element numeric vector containing the x-coordinate of the top left and bottom right interior corners of the object respectively. See [Coord](coord.md) for further details.
+XRange is a 2-element numeric vector containing the x-coordinates of the left and right interior edges of the object respectively. See [Coord](coord.md) for further details.
 
 **Application**
 

--- a/object-reference/docs/properties/yrange.md
+++ b/object-reference/docs/properties/yrange.md
@@ -4,7 +4,7 @@
 
 [XRange](xrange.md) and YRange together determine a user-defined co-ordinate system. These properties are effective on the object's children which have [Coord](coord.md) set to `'User'`.
 
-YRange is a 2-element numeric vector containing the y-coordinate of the top left and bottom right interior corners of the object respectively. See [Coord](coord.md) for further details.
+YRange is a 2-element numeric vector containing the y-coordinates of the top and bottom interior edges of the object respectively. See [Coord](coord.md) for further details.
 
 **Application**
 


### PR DESCRIPTION
XRange gives the x-coordinates of the left and right interior edges; YRange gives the y-coordinates of the top and bottom interior edges. This is clearer than the previous top-left/bottom-right corner wording.

Fixes #696 